### PR TITLE
Add non-PIP dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Front end dependencies
+node_modules
+bower_components
+npm-debug.log

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "digitalmarketplace-admin-frontend",
+  "version": "0.0.1",
+  "dependencies": {
+    "jquery": "1.11.2",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v1.1.0",
+    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "digitalmarketplace-admin-frontend",
+  "description": "Front end application for the Digital Marketplace admin",
+  "version": "0.0.1",
+  "private": true,
+  "engine": "node >= 0.10.0",
+  "dependencies": {
+    "bower": "1.3.12",
+    "govuk_frontend_toolkit": "3.1.0"
+  },
+  "scripts": {
+    "postinstall": "./node_modules/bower/bin/bower install"
+  }
+}


### PR DESCRIPTION
This commit adds dependency management for things which are not available as PIP packages. It uses a combination of:
- npm (GOV.UK front end toolkit)
- Bower (GOV.UK Jinja template, Digital Marketplace front end toolkit, jQuery)

There is a `postinstall` hook in the `package.json` which calls Bower, so **one command (`npm install`) will bring in all the dependencies at their specified versions**.

It does not:
- Wire the template into the app
- Any sort of front end build process or copying of assets (this will probably be Gulp but is something for a separate pull request)