### PR TITLE
Make home page use GOV.UK template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 node_modules
 bower_components
 npm-debug.log
+
+# Front end generated assets
+app/static

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
+from config import config
 
 
 bootstrap = Bootstrap()
@@ -9,10 +10,15 @@ def create_app(config_name):
 
     application = Flask(__name__)
     application.config['DEBUG'] = True
+    application.config.from_object(config[config_name])
+    config[config_name].init_app(application)
 
     bootstrap.init_app(application)
 
     from .main import main as main_blueprint
     application.register_blueprint(main_blueprint)
+    main_blueprint.config = {
+        'BASE_TEMPLATE_DATA' : application.config['BASE_TEMPLATE_DATA']
+    }
 
     return application

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -6,7 +6,8 @@ from flask import json, render_template, Response, request
 
 @main.route('/')
 def index():
-    return render_template("index.html"), 200
+    template_data = main.config['BASE_TEMPLATE_DATA']
+    return render_template("index.html", **template_data), 200
 
 
 @main.route('/editservice')

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,0 +1,23 @@
+{% extends "govuk_template.html" %}
+
+{% block head %}
+  {% include "_stylesheets.html" %}
+{% endblock %}
+
+{% block cookie_message %}
+  {% include "_cookie_message.html" %}
+{% endblock %}
+
+{% block header_class %}with-proposition{% endblock %}
+
+{% block proposition_header %}
+  {% include "_proposition_header.html" %}
+{% endblock %}
+
+{% block footer_top %}
+  {% include "_footer_categories.html" %}
+{% endblock %}
+
+{% block body_end %}
+  {% include "_javascripts.html" %}
+{% endblock %}

--- a/app/templates/_cookie_message.html
+++ b/app/templates/_cookie_message.html
@@ -1,0 +1,2 @@
+<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+

--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -1,0 +1,31 @@
+<div class="footer-categories">
+  <div class="footer-about">
+    <h2>About the Digital Marketplace</h2>
+    <ul>
+      <li><a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a></li>
+      <li><a href="/terms-and-conditions">Terms and conditions</a></li>
+      <li><a href="https://ccs.cabinetoffice.gov.uk">Crown Commercial Service website </a></li>
+    </ul>
+  </div>
+  <div class="footer-buyers">
+    <h2>
+      Buyers
+    </h2>
+    <ul>
+      <li>
+        <a href="/buyers-guide/">Preparing to buy</a>
+      </li>
+    </ul>
+  </div>
+  <div class="footer-suppliers">
+    <h2>
+      Suppliers
+    </h2>
+    <ul>
+      <li>
+        <a href="/suppliers-guide/">Supplying a service</a>
+      </li>
+    </ul>
+  </div>
+  <hr />
+</div>

--- a/app/templates/_javascripts.html
+++ b/app/templates/_javascripts.html
@@ -1,0 +1,2 @@
+<script type="text/javascript" src="{{ asset_path }}javascripts/application.js"></script>
+

--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -1,0 +1,13 @@
+<div class="header-proposition">
+  <div class="content">
+    <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+    <nav id="proposition-menu">
+      <a href="/" id="proposition-name">Digital Marketplace</a>
+      <ul id="proposition-links">
+        <li><a class="home" href="/">Home</a></li>
+        <li><a class="home" href="/login">Login</a></li>
+        <li><a class="home" href="/register">Create account</a></li>
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/app/templates/_stylesheets.html
+++ b/app/templates/_stylesheets.html
@@ -1,0 +1,2 @@
+<link type="text/css" rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/application.css" />
+

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,13 +1,10 @@
-<html>
-<head>
+{% extends "_base_page.html" %}
 
-</head>
-<body>
+{% block content %}
 <h1>Digital Marketplace Admin</h1>
 <form action="/editservice" method="get">
     Service ID to edit: <input type="text" name="service_id">
     <br><br>
     <input type="submit" value="Edit this service">
 </form>
-</body>
-</html>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -9,19 +9,21 @@ class Config:
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
         template_folders = [
+            os.path.join(repo_root, 'bower_components/govuk_template/views/layouts'),
             os.path.join(repo_root, 'app/templates')
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader
 
-
 class Test(Config):
     DEBUG = True
 
-
 class Development(Config):
-    DEBUG = True
-
+    DEBUG = True,
+    BASE_TEMPLATE_DATA = {
+        'asset_path': '/static/',
+        'header_class' : 'with-proposition'
+    }
 
 class Live(Config):
     DEBUG = False

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,145 @@
+var gulp = require('gulp');
+var uglify = require('gulp-uglifyjs');
+var deleteFiles = require('del');
+var sass = require('gulp-sass');
+
+var environment;
+var repoRoot = __dirname + '/';
+var govukToolkitSCSS = repoRoot + 'node_modules/govuk_frontend_toolkit/stylesheets';
+var dmToolkitSCSS = repoRoot + 'bower_components/digitalmarketplace-frontend-toolkit/toolkit/scss';
+var assetsFolder = repoRoot + 'app/assets';
+var staticFolder = repoRoot + 'app/static';
+var govukTemplateAssetsFolder = repoRoot + 'bower_components/govuk_template/assets';
+
+// JavaScript paths
+var jsVendorFiles = [
+  assetsFolder + '/javascripts/vendor/jquery-1.11.0.js',
+  assetsFolder + '/javascripts/vendor/hogan-3.0.2.min.js'
+];
+var jsSourceFiles = [
+  assetsFolder + '/javascripts/test1.js',
+  assetsFolder + '/javascripts/test2.js'
+];
+var jsDistributionFolder = staticFolder + '/javascripts';
+var jsDistributionFile = 'application.js';
+
+// CSS paths
+var cssSourceGlob = assetsFolder + '/scss/**/*.scss';
+var cssDistributionFolder = staticFolder + '/stylesheets';
+
+// Configuration
+var sassOptions = {
+  development: {
+    outputStyle: 'expanded',
+    lineNumbers: true,
+    includePaths: [govukToolkitSCSS, dmToolkitSCSS],
+    sourceComments: true
+  },
+  production: {
+    outputStyle: 'compressed',
+    lineNumbers: true,
+    includePaths: [govukToolkitSCSS, dmToolkitSCSS]
+  },
+};
+
+var uglifyOptions = {
+  development: {
+    mangle: false,
+    output: {
+      beautify: true,
+      semicolons: true,
+      comments: true,
+      indent_level: 2
+    }
+  },
+  production: {
+    mangle: true
+  }
+};
+
+gulp.task('clean', function () {
+  var logOutputFor = function (fileType) {
+    return function (err, paths) {
+      console.log('Deleted the following ' + fileType + ' files:\n', paths.join('\n'));
+    };
+  };
+
+  deleteFiles(jsDistributionFolder + '/*.js', logOutputFor('JavaScript'));
+  deleteFiles(cssDistributionFolder + '/*.css', logOutputFor('CSS'));
+});
+
+gulp.task('sass', function () {
+  var stream = gulp.src(cssSourceGlob)
+    .pipe(sass(sassOptions[environment]))
+    .on('error', function (err) {
+      console.log(err.message);
+    })
+    .pipe(gulp.dest(cssDistributionFolder));
+
+  stream.on('end', function () {
+    console.log('Compressed CSS saved as .css files in ' + cssDistributionFolder)
+  });
+
+  return stream;
+});
+
+gulp.task('js', function () {
+  // produce full array of JS files from vendor + local scripts
+  jsFiles = jsVendorFiles.concat(jsSourceFiles);
+  var stream = gulp.src(jsFiles)
+    .pipe(uglify(
+      jsDistributionFile,
+      uglifyOptions[environment]
+    ))
+    .pipe(gulp.dest(jsDistributionFolder));
+
+  stream.on('end', function () {
+    console.log('Compressed JavaScript saved as ' + jsDistributionFolder + '/' + jsDistributionFile)
+  });
+
+  return stream;
+});
+
+gulp.task('copy_template_assets:stylesheets', function () {
+  return gulp.src(govukTemplateAssetsFolder + '/stylesheets/**/*', { base : govukTemplateAssetsFolder + '/stylesheets' })
+    .pipe(gulp.dest(staticFolder + '/stylesheets'))
+});
+
+gulp.task('copy_template_assets:images', function () {
+  return gulp.src(govukTemplateAssetsFolder + '/images/**/*', { base : govukTemplateAssetsFolder + '/images' })
+    .pipe(gulp.dest(staticFolder + '/images'))
+});
+
+gulp.task('copy_template_assets:javascripts', function () {
+  return gulp.src(govukTemplateAssetsFolder + '/javascripts/**/*', { base : govukTemplateAssetsFolder + '/javascripts' })
+    .pipe(gulp.dest(staticFolder + '/javascripts'))
+});
+
+gulp.task('copy_template_assets', function () {
+   gulp.start('copy_template_assets:stylesheets');
+   gulp.start('copy_template_assets:images');
+   gulp.start('copy_template_assets:javascripts');
+});
+
+gulp.task('watch', ['build'], function () {
+  var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
+  var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
+  var notice = function (event) {
+    console.log('File ' + event.path + ' was ' + event.type + ' running tasks...');
+  }
+
+  cssWatcher.on('change', notice);
+  jsWatcher.on('change', notice);
+});
+
+gulp.task('build:development', ['clean'], function () {
+  environment = 'development';
+  gulp.start('sass', 'js');
+  gulp.start('copy_template_assets');
+});
+
+gulp.task('build:production', ['clean'], function () {
+  environment = 'production';
+  gulp.start('sass', 'js');
+  gulp.start('copy_template_assets');
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "engine": "node >= 0.10.0",
   "dependencies": {
     "bower": "1.3.12",
-    "govuk_frontend_toolkit": "3.1.0"
+    "govuk_frontend_toolkit": "3.1.0",
+    "gulp": "3.8.7",
+    "gulp-uglifyjs": "0.6.0",
+    "del": "1.1.1",
+    "gulp-sass": "1.3.2",
+    "gulp-shell": "0.2.9"
   },
   "scripts": {
     "postinstall": "./node_modules/bower/bin/bower install"


### PR DESCRIPTION
This commit makes the template for the home page extend a new template called `_base_layout` which itself extends the GOV.UK Template brought in by https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/2

For now it doesn't
- add any CSS or Javascript to the page beyond what is provided by the template (but there is a Gulp pipeline in place to do this)
- add the template to any of the other pages (probably need to copy the work Tom is doing on the Thermos to do this in an extensible way)

![image](https://cloud.githubusercontent.com/assets/355079/6368595/0f615fd4-bcd6-11e4-87d5-a14e7f40641d.png)
