### PR TITLE
Add all front-end build tasks as NPM scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
   - pip install -r requirements.txt
   - npm install
+  - npm run frontend-build:production
 script:
   - ./scripts/run_tests.sh
 notifications:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Install frontend dependencies with npm and gulp
 
 ```
 npm install
-node_modules/gulp/bin/gulp.js build:development
 ```
 
 ### Run the tests
@@ -58,3 +57,14 @@ python application.py runserver
 ```
 
 Use the app at [http://127.0.0.1:5000/](http://127.0.0.1:5000/)
+
+## Frontend tasks
+
+[NPM](https://www.npmjs.org/) is used for all frontend build tasks. The commands available are:
+
+- `npm run frontend-build:development` (compile the frontend files for development)
+- `npm run frontend-build:production` (compile the frontend files for production)
+- `npm run frontend-build:watch` (watch all frontend files & rebuild when anything changes)
+- `npm run frontend-install` (install all non-NPM dependancies)
+
+Note: `npm run frontend-install` is run as a post-install task after you run `npm install`.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "gulp-shell": "0.2.9"
   },
   "scripts": {
-    "postinstall": "./node_modules/bower/bin/bower install"
+    "frontend-install": "./node_modules/bower/bin/bower install",
+    "frontend-build:development" : "./node_modules/gulp/bin/gulp.js build:development",
+    "frontend-build:production" : "./node_modules/gulp/bin/gulp.js build:production",
+    "frontend-build:watch" : "./node_modules/gulp/bin/gulp.js watch",
+    "postinstall": "npm run frontend-install"
   }
 }


### PR DESCRIPTION
Moving all of them to be handled by NPM should mean you only have to think about one build tool.

Adding `npm run build:development` to the `npm install` process also means setup only concerns one task.