### PR TITLE
Fix S3 upload path and password hash

### DIFF
--- a/.ebextensions/wsgipassauth.config
+++ b/.ebextensions/wsgipassauth.config
@@ -1,0 +1,3 @@
+container_commands:
+  01_wsgipass:
+    command: 'echo "WSGIPassAuthorization On" >> ../wsgi.conf'

--- a/app/main/helpers/auth.py
+++ b/app/main/helpers/auth.py
@@ -1,5 +1,5 @@
 import os
-from functools import wraps
+import base64
 from flask import request, Response
 from pbkdf2 import crypt
 
@@ -8,7 +8,7 @@ def check_auth(username, password):
     """This function is called to check if a username /
     password combination is valid.
     """
-    secret = os.getenv('DM_ADMIN_FRONTEND_PASSWORD_HASH')
+    secret = base64.b64decode(os.getenv('DM_ADMIN_FRONTEND_PASSWORD_HASH'))
     return secret == crypt(username + password, secret, iterations=10000)
 
 

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -57,9 +57,8 @@ class Validate():
         file_name = self._generate_file_name(question)
 
         self.uploader.save(
-            '{}/{}'.format(
+            'documents/{}'.format(
                 self.service['supplierId'],
-                self.service['id'],
             ),
             file_name,
             question

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npm install
+npm run frontend-build:production

--- a/scripts/generate_password.py
+++ b/scripts/generate_password.py
@@ -1,12 +1,17 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
 from pbkdf2 import crypt
-import sys
 import uuid
 import getpass
+import base64
 
-username = input("Username: ")
+username = raw_input("Username: ")
 password = getpass.getpass()
 salt = uuid.uuid4().hex
 
-password_hash = crypt(username + password, salt, iterations=10000)
+password_hash = base64.b64encode(
+    crypt(username + password, salt, iterations=10000)
+)
 
 print(password_hash)

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -5,7 +5,7 @@ source ./venv/bin/activate 2>/dev/null && echo "Virtual environment activated."
 export DM_API_URL=${DM_API_URL:=http://localhost:5000}
 export DM_ADMIN_FRONTEND_API_AUTH_TOKEN=${DM_ADMIN_FRONTEND_API_AUTH_TOKEN:=myToken}
 export DM_ADMIN_FRONTEND_PASSWORD_HASH=${DM_ADMIN_FRONTEND_PASSWORD_HASH:=myHash}
-export DM_DOCUMENT_S3_BUCKET='admin-frontend-dev-documents'
+export DM_S3_DOCUMENT_BUCKET='admin-frontend-dev-documents'
 
 echo "Environment variables in use:"
 env | grep DM_

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -90,7 +90,8 @@ class TestValidate(unittest.TestCase):
 
         self.assertEquals(self.validate.errors, {})
         self.uploader.save.assert_called_once_with(
-            '2/1', '1-pricing-document.pdf', self.data['pricingDocumentURL']
+            'documents/2', '1-pricing-document.pdf',
+            self.data['pricingDocumentURL']
         )
 
     def test_multiple_fields_list_of_validations(self):


### PR DESCRIPTION
Changes S3 file upload path to the one we're using in production.
Encode admin password with base64 to avoid elastic beanstalk env $ substitution.