### PR TITLE
Update document mime type

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export DM_API_URL=http://localhost:5000
 export DM_ADMIN_FRONTEND_API_AUTH_TOKEN=<bearer_token>
 export DM_ADMIN_FRONTEND_PASSWORD_HASH=<generated password hash>
 ```
-You can generate a password hash by running `python ./scripts/generate_password.sh`.
+You can generate a password hash by running `python ./scripts/generate_password.py`.
 
 
 ### Upgrade dependencies

--- a/app/main/helpers/s3.py
+++ b/app/main/helpers/s3.py
@@ -1,6 +1,7 @@
 import os
 import boto
 import datetime
+import mimetypes
 
 
 class S3(object):
@@ -23,5 +24,6 @@ class S3(object):
             )
 
         key = self.bucket.new_key(full_path)
-        key.set_contents_from_file(file)
+        mimetype, _ = mimetypes.guess_type(key.name)
+        key.set_contents_from_file(file, headers={'Content-Type': mimetype})
         key.set_acl(acl)

--- a/app/main/helpers/s3.py
+++ b/app/main/helpers/s3.py
@@ -25,10 +25,10 @@ class S3(object):
         key = self.bucket.new_key(full_path)
         key.set_contents_from_file(file,
                                    headers={'Content-Type':
-                                            self.__get_mimetype(key.name)})
+                                            self._get_mimetype(key.name)})
         key.set_acl(acl)
         return key
 
-    def __get_mimetype(self, filename):
+    def _get_mimetype(self, filename):
         mimetype, _ = mimetypes.guess_type(filename)
         return mimetype

--- a/app/main/helpers/s3.py
+++ b/app/main/helpers/s3.py
@@ -22,8 +22,13 @@ class S3(object):
                 self.bucket_name,
                 full_path
             )
-
         key = self.bucket.new_key(full_path)
-        mimetype, _ = mimetypes.guess_type(key.name)
-        key.set_contents_from_file(file, headers={'Content-Type': mimetype})
+        key.set_contents_from_file(file,
+                                   headers={'Content-Type':
+                                            self.__get_mimetype(key.name)})
         key.set_acl(acl)
+        return key
+
+    def __get_mimetype(self, filename):
+        mimetype, _ = mimetypes.guess_type(filename)
+        return mimetype

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,9 +1,4 @@
-<<<<<<< HEAD
-import re
 from flask import render_template, request, redirect, session
-=======
-from flask import render_template, request, redirect
->>>>>>> 8af0f3b... Remove unused import of 're'
 from . import main
 from .helpers.validation_tools import Validate
 from .helpers.content import ContentLoader

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,5 +1,9 @@
+<<<<<<< HEAD
 import re
 from flask import render_template, request, redirect, session
+=======
+from flask import render_template, request, redirect
+>>>>>>> 8af0f3b... Remove unused import of 're'
 from . import main
 from .helpers.validation_tools import Validate
 from .helpers.content import ContentLoader

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -4,7 +4,8 @@ source ./venv/bin/activate 2>/dev/null && echo "Virtual environment activated."
 # Use default environment vars for localhost if not already set
 export DM_API_URL=${DM_API_URL:=http://localhost:5000}
 export DM_ADMIN_FRONTEND_API_AUTH_TOKEN=${DM_ADMIN_FRONTEND_API_AUTH_TOKEN:=myToken}
-export DM_ADMIN_FRONTEND_PASSWORD_HASH=${DM_ADMIN_FRONTEND_PASSWORD_HASH:=myHash}
+# Default hash for user/pass combo: admin/admin
+export DM_ADMIN_FRONTEND_PASSWORD_HASH=${DM_ADMIN_FRONTEND_PASSWORD_HASH:=JHA1azIkMjcxMCQxYjM5Y2JhY2RkYTY0OWMwYjdhMGU1MWU4MjQ5ODZlYSQ2VkNuM1I3dXNXYW8zY3dWZmRzVHFBck10Tzh0cWRBLg==}
 export DM_ADMIN_FRONTEND_COOKIE_SECRET=${DM_ADMIN_FRONTEND_COOKIE_SECRET:=secret}
 export DM_S3_DOCUMENT_BUCKET='admin-frontend-dev-documents'
 

--- a/tests/app/main/helpers/test_s3.py
+++ b/tests/app/main/helpers/test_s3.py
@@ -49,11 +49,22 @@ class FakeBucket(object):
 
     def get_key(self, key):
         if key in self.keys:
-            return mock.Mock()
+            return FakeKey(key)
 
     def new_key(self, key):
         self.keys.add(key)
-        return mock.Mock()
+        return FakeKey(key)
 
     def copy_key(self, new_key, *args, **kwargs):
         self.keys.add(new_key)
+
+
+class FakeKey(object):
+    def __init__(self, key):
+        self.name = key.split('/')[-1]
+
+    def set_contents_from_file(self, file, headers):
+        return mock.Mock()
+
+    def set_acl(self, acl):
+        return mock.Mock()


### PR DESCRIPTION
Current document updates in the admin app do not preserve the content type - it is reset to "application/octet-stream".
This sets the correct content type so that browsers know what to do when users access the documents.

I've tested it locally for uploads into the admin-frontend-dev-documents S3 bucket - look in folder '93292' for a document uploaded by this code. (The Properties/Metadata/Content-Type is set to application/pdf)