### PR TITLE
API service update

### DIFF
--- a/app/main/helpers/s3.py
+++ b/app/main/helpers/s3.py
@@ -38,8 +38,6 @@ class S3(object):
                 existing_path
             )
 
-            self.bucket.delete_key(existing_path)
-
     def _get_mimetype(self, filename):
         mimetype, _ = mimetypes.guess_type(filename)
         return mimetype

--- a/app/main/helpers/s3.py
+++ b/app/main/helpers/s3.py
@@ -14,15 +14,10 @@ class S3(object):
         self.bucket_name = bucket_name
         self.bucket = conn.get_bucket(bucket_name)
 
-    def save(self, path, file, existing_path=None,
-             acl='public-read', move_prefix=None):
+    def save(self, path, file, acl='public-read', move_prefix=None):
         path = path.lstrip('/')
 
-        if existing_path:
-            existing_path = existing_path.lstrip('/')
-            self._move_existing(existing_path, move_prefix)
-        else:
-            self._move_existing(path, move_prefix)
+        self._move_existing(path, move_prefix)
 
         key = self.bucket.new_key(path)
         key.set_contents_from_file(file,

--- a/app/main/helpers/s3.py
+++ b/app/main/helpers/s3.py
@@ -11,23 +11,34 @@ class S3(object):
         self.bucket_name = bucket_name
         self.bucket = conn.get_bucket(bucket_name)
 
-    def save(self, path, name, file, acl='public-read'):
-        timestamp = datetime.datetime.utcnow().isoformat()
+    def save(self, path, file, existing_path=None, acl='public-read'):
+        path = path.lstrip('/')
 
-        full_path = os.path.join(path, name)
+        if existing_path:
+            existing_path = existing_path.lstrip('/')
+            self._move_existing(existing_path)
+        else:
+            self._move_existing(path)
 
-        if self.bucket.get_key(full_path):
-            self.bucket.copy_key(
-                os.path.join(path, '{}-{}'.format(timestamp, name)),
-                self.bucket_name,
-                full_path
-            )
-        key = self.bucket.new_key(full_path)
+        key = self.bucket.new_key(path)
         key.set_contents_from_file(file,
                                    headers={'Content-Type':
                                             self._get_mimetype(key.name)})
         key.set_acl(acl)
         return key
+
+    def _move_existing(self, existing_path):
+        timestamp = datetime.datetime.utcnow().isoformat()
+
+        if self.bucket.get_key(existing_path):
+            path, name = os.path.split(existing_path)
+            self.bucket.copy_key(
+                os.path.join(path, '{}-{}'.format(timestamp, name)),
+                self.bucket_name,
+                existing_path
+            )
+
+            self.bucket.delete_key(existing_path)
 
     def _get_mimetype(self, filename):
         mimetype, _ = mimetypes.guess_type(filename)

--- a/app/main/helpers/s3.py
+++ b/app/main/helpers/s3.py
@@ -1,7 +1,10 @@
 import os
 import boto
+import boto.exception
 import datetime
 import mimetypes
+
+from boto.exception import S3ResponseError  # noqa
 
 
 class S3(object):

--- a/app/main/helpers/service.py
+++ b/app/main/helpers/service.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 
 
@@ -23,9 +25,20 @@ class ServiceLoader(object):
 
         return response.json()["services"]
 
-    def set(self, data, key, value):
-        data[key] = value
-        return data
+    def post(self, service_id, data, user, reason):
+        response = requests.post(
+            "{}/services/{}".format(self.api_url, service_id),
+            headers={
+                "authorization": "Bearer {}".format(self.access_token),
+                "content-type": "application/json",
+            },
+            data=json.dumps({
+                'update_details': {
+                    'updated_by': user,
+                    'update_reason': reason,
+                },
+                'services': data,
+            })
+        )
 
-    def post(self, data):
-        print(data)  # This would be an update call to the API
+        return response

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -1,3 +1,4 @@
+import datetime
 import os.path
 
 try:
@@ -65,19 +66,8 @@ class Validate(object):
             question.filename
         )
 
-        if self.service.get(question_id):
-            existing_path = urlparse.urlsplit(
-                self.service[question_id]
-            ).path.lstrip('/')
-        else:
-            existing_path = None
-
         try:
-            self.uploader.save(
-                file_path,
-                question,
-                existing_path
-            )
+            self.uploader.save(file_path, question)
         except S3ResponseError:
             return False
 
@@ -104,7 +94,11 @@ class Validate(object):
         ]
 
 
-def generate_file_name(supplier_id, service_id, question_id, filename):
+def generate_file_name(supplier_id, service_id, question_id, filename,
+                       suffix=None):
+    if suffix is None:
+        suffix = default_file_suffix()
+
     ID_TO_FILE_NAME_SUFFIX = {
         'serviceDefinitionDocumentURL': 'service-definition-document',
         'termsAndConditionsDocumentURL': 'terms-and-conditions',
@@ -112,12 +106,17 @@ def generate_file_name(supplier_id, service_id, question_id, filename):
         'pricingDocumentURL': 'pricing-document',
     }
 
-    return 'documents/{}/{}-{}{}'.format(
+    return 'documents/{}/{}-{}-{}{}'.format(
         supplier_id,
         service_id,
         ID_TO_FILE_NAME_SUFFIX[question_id],
+        suffix,
         get_extension(filename)
     )
+
+
+def default_file_suffix():
+    return datetime.datetime.utcnow().strftime("%Y-%m-%d-%H%M")
 
 
 def get_extension(filename):

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -41,13 +41,6 @@ class Validate(object):
             if not self.test(question_id, question, rule["name"]):
                 return rule["message"]
 
-        # TODO We can't update file URLs until we have the write API,
-        # so uploaded file must have the same extension as the
-        # current one for now
-        current_extension = get_extension(self.service.get(question_id, ''))
-        if get_extension(question.filename) != current_extension:
-            return u"Uploaded file format should be: %s" % current_extension
-
     def test(self, question_id, question, rule):
         if not hasattr(self, rule):
             raise ValueError("Validation rule " + rule + " not found")

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -65,7 +65,7 @@ class Validate(object):
             question.filename
         )
 
-        if self.service[question_id]:
+        if self.service.get(question_id):
             existing_path = urlparse.urlsplit(
                 self.service[question_id]
             ).path.lstrip('/')

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -52,20 +52,29 @@ class Validate(object):
         return not_empty
 
     def file_can_be_saved(self, question_id, question):
-        file_name = self._generate_file_name(question)
-        file_path = 'documents/{}'.format(
+        file_path = generate_file_name(
             self.service['supplierId'],
+            self.service['id'],
+            question_id,
+            question.filename
         )
+
+        if self.service[question_id]:
+            existing_path = urlparse.urlsplit(
+                self.service[question_id]
+            ).path.lstrip('/')
+        else:
+            existing_path = None
 
         self.uploader.save(
             file_path,
-            file_name,
-            question
+            question,
+            existing_path
         )
 
         full_url = urlparse.urljoin(
             main.config['DOCUMENTS_URL'],
-            "{}/{}".format(file_path, file_name)
+            file_path
         )
 
         self.clean_data[question_id] = full_url
@@ -85,20 +94,21 @@ class Validate(object):
             ".pdf", ".pda", ".odt", ".ods", ".odp"
         ]
 
-    def _generate_file_name(self, question):
-        ID_TO_FILE_NAME_SUFFIX = {
-            'serviceDefinitionDocumentURL': 'service-definition-document',
-            'termsAndConditionsDocumentURL': 'terms-and-conditions',
-            'sfiaRateDocumentURL': 'sfia-rate-card',
-            'pricingDocumentURL': 'pricing-document',
-        }
-        extension = get_extension(question.filename)
 
-        return '{}-{}{}'.format(
-            self.service['id'],
-            ID_TO_FILE_NAME_SUFFIX[question.name],
-            extension
-        )
+def generate_file_name(supplier_id, service_id, question_id, filename):
+    ID_TO_FILE_NAME_SUFFIX = {
+        'serviceDefinitionDocumentURL': 'service-definition-document',
+        'termsAndConditionsDocumentURL': 'terms-and-conditions',
+        'sfiaRateDocumentURL': 'sfia-rate-card',
+        'pricingDocumentURL': 'pricing-document',
+    }
+
+    return 'documents/{}/{}-{}{}'.format(
+        supplier_id,
+        service_id,
+        ID_TO_FILE_NAME_SUFFIX[question_id],
+        get_extension(filename)
+    )
 
 
 def get_extension(filename):

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -1,5 +1,9 @@
 import os.path
-import urlparse
+
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 
 from .. import main
 

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -1,31 +1,36 @@
 import os.path
-import time
-import shutil
+import urlparse
+
+from .. import main
 
 
-class Validate():
-
+class Validate(object):
     def __init__(self, content, service, posted_data, uploader=None):
         self.content = content
         self.service = service
         self.posted_data = posted_data
         self.uploader = uploader
+        self.clean_data = {}
+        self._errors = None
 
     @property
     def errors(self):
+        if self._errors is not None:
+            return self._errors
         errors = {}
         for question_id in self.posted_data:
             question_errors = self.question_errors(question_id)
             if question_errors:
                 errors[question_id] = question_errors
 
+        self._errors = errors
         return errors
 
     def question_errors(self, question_id):
         question = self.posted_data[question_id]
         question_content = self.content.get_question(question_id)
 
-        if not self.test(question, "answer_required"):
+        if not self.test(question_id, question, "answer_required"):
             if "optional" in question_content:
                 return
             # File has previously been uploaded
@@ -33,7 +38,7 @@ class Validate():
                 return
 
         for rule in question_content["validations"]:
-            if not self.test(question, rule["name"]):
+            if not self.test(question_id, question, rule["name"]):
                 return rule["message"]
 
         # TODO We can't update file URLs until we have the write API,
@@ -43,37 +48,45 @@ class Validate():
         if get_extension(question.filename) != current_extension:
             return u"Uploaded file format should be: %s" % current_extension
 
-    def test(self, question, rule):
+    def test(self, question_id, question, rule):
         if not hasattr(self, rule):
             raise ValueError("Validation rule " + rule + " not found")
-        return getattr(self, rule)(question)
+        return getattr(self, rule)(question_id, question)
 
-    def answer_required(self, question):
+    def answer_required(self, question_id, question):
         not_empty = len(question.read(1)) > 0
         question.seek(0)
         return not_empty
 
-    def file_can_be_saved(self, question):
+    def file_can_be_saved(self, question_id, question):
         file_name = self._generate_file_name(question)
+        file_path = 'documents/{}'.format(
+            self.service['supplierId'],
+        )
 
         self.uploader.save(
-            'documents/{}'.format(
-                self.service['supplierId'],
-            ),
+            file_path,
             file_name,
             question
         )
 
+        full_url = urlparse.urljoin(
+            main.config['DOCUMENTS_URL'],
+            "{}/{}".format(file_path, file_name)
+        )
+
+        self.clean_data[question_id] = full_url
+
         return True
 
-    def file_is_less_than_5mb(self, question):
+    def file_is_less_than_5mb(self, question_id, question):
         size_limit = 5400000
         below_size_limit = len(question.read(size_limit)) < size_limit
         question.seek(0)
 
         return below_size_limit
 
-    def file_is_open_document_format(self, question):
+    def file_is_open_document_format(self, question_id, question):
 
         return get_extension(question.filename) in [
             ".pdf", ".pda", ".odt", ".ods", ".odp"
@@ -83,7 +96,7 @@ class Validate():
         ID_TO_FILE_NAME_SUFFIX = {
             'serviceDefinitionDocumentURL': 'service-definition-document',
             'termsAndConditionsDocumentURL': 'terms-and-conditions',
-            'sfiaRateCardURL': 'sfia-rate-card',
+            'sfiaRateDocumentURL': 'sfia-rate-card',
             'pricingDocumentURL': 'pricing-document',
         }
         extension = get_extension(question.filename)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -111,12 +111,13 @@ def update(service_id, section):
         if question_id not in form.errors and question_id in form.clean_data:
             update[question_id] = form.clean_data[question_id]
 
-    service_loader.post(
-        service['id'],
-        update,
-        session['username'],
-        'admin app'
-    )
+    if update:
+        service_loader.post(
+            service['id'],
+            update,
+            session['username'],
+            'admin app'
+        )
 
     if form.errors:
         return render_template("edit_section.html", **get_template_data({

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -104,21 +104,25 @@ def update(service_id, section):
         list(request.form.items()) + list(request.files.items())
     )
 
-    errors = Validate(content, service, posted_data, s3_uploader).errors
+    form = Validate(content, service, posted_data, s3_uploader)
 
     for question_id in posted_data:
-        if question_id not in errors:
-            service_loader.set(service, question_id, "new value")
+        if question_id not in form.errors and question_id in form.clean_data:
+            service_loader.set(
+                service,
+                question_id,
+                form.clean_data[question_id]
+            )
 
     service_loader.post(service)
 
-    if errors:
+    if form.errors:
         return render_template("edit_section.html", **get_template_data({
             "section": content.get_section(section),
             "service_data": service,
             "edits_submitted": posted_data,
             "service_id": service_id,
-            "errors": errors
+            "errors": form.errors
         }))
     else:
         return redirect("/service/" + service_id)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -105,16 +105,18 @@ def update(service_id, section):
     )
 
     form = Validate(content, service, posted_data, s3_uploader)
+    update = {}
 
     for question_id in posted_data:
         if question_id not in form.errors and question_id in form.clean_data:
-            service_loader.set(
-                service,
-                question_id,
-                form.clean_data[question_id]
-            )
+            update[question_id] = form.clean_data[question_id]
 
-    service_loader.post(service)
+    service_loader.post(
+        service['id'],
+        update,
+        session['username'],
+        'admin app'
+    )
 
     if form.errors:
         return render_template("edit_section.html", **get_template_data({

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config(object):
     DEBUG = True
     S3_DOCUMENT_BUCKET = os.getenv('DM_S3_DOCUMENT_BUCKET')
+    DOCUMENTS_URL = 'https://assets.dev.digitalmarketplace.service.gov.uk'
     API_URL = os.getenv('DM_API_URL')
     API_AUTH_TOKEN = os.getenv('DM_ADMIN_FRONTEND_API_AUTH_TOKEN')
     BASE_TEMPLATE_DATA = {}
@@ -28,6 +29,7 @@ class Config(object):
 class Test(Config):
     DEBUG = True
     AUTHENTICATION = True
+    DOCUMENTS_URL = 'https://assets.test.digitalmarketplace.service.gov.uk'
     SECRET_KEY = "test_secret"
     PASSWORD_HASH = "JHA1azIkMjcxMCQwYmZiN2Y5YmJlZmI0YTg4YmNkZjQ1ODY0NWUzOGEwNCRoeDBwbUpHZVhSalREUFBGREFydmJQWnlFYnhWU1g1ag=="  # noqa
     BASE_TEMPLATE_DATA = {
@@ -48,6 +50,7 @@ class Development(Config):
 class Live(Config):
     DEBUG = False
     AUTHENTICATION = True
+    DOCUMENTS_URL = 'https://assets.digitalmarketplace.service.gov.uk'
     BASE_TEMPLATE_DATA = {
         'asset_path': '/static/',
         'header_class': 'with-proposition'

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -7,7 +7,7 @@ export DM_ADMIN_FRONTEND_API_AUTH_TOKEN=${DM_ADMIN_FRONTEND_API_AUTH_TOKEN:=myTo
 # Default hash for user/pass combo: admin/admin
 export DM_ADMIN_FRONTEND_PASSWORD_HASH=${DM_ADMIN_FRONTEND_PASSWORD_HASH:=JHA1azIkMjcxMCQxYjM5Y2JhY2RkYTY0OWMwYjdhMGU1MWU4MjQ5ODZlYSQ2VkNuM1I3dXNXYW8zY3dWZmRzVHFBck10Tzh0cWRBLg==}
 export DM_ADMIN_FRONTEND_COOKIE_SECRET=${DM_ADMIN_FRONTEND_COOKIE_SECRET:=secret}
-export DM_S3_DOCUMENT_BUCKET='admin-frontend-dev-documents'
+export DM_S3_DOCUMENT_BUCKET=${DM_S3_DOCUMENT_BUCKET:=admin-frontend-dev-documents}
 
 echo "Environment variables in use:"
 env | grep DM_

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -14,9 +14,15 @@ class BaseApplicationTest(TestCase):
             return_value=self.service_loader
         ).start()
 
+        self.default_suffix_patch = mock.patch(
+            'app.main.helpers.validation_tools.default_file_suffix',
+            return_value='2015-01-01-1200'
+        ).start()
+
     def tearDown(self):
         self.s3.stop()
         self._service_loader_patch.stop()
+        self.default_suffix_patch.stop()
 
 
 class LoggedInApplicationTest(BaseApplicationTest):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -8,9 +8,15 @@ class BaseApplicationTest(TestCase):
         self.app = create_app('test')
         self.client = self.app.test_client()
         self.s3 = mock.patch('app.main.views.S3').start()
+        self.service_loader = mock.Mock()
+        self._service_loader_patch = mock.patch(
+            'app.main.views.ServiceLoader',
+            return_value=self.service_loader
+        ).start()
 
     def tearDown(self):
         self.s3.stop()
+        self._service_loader_patch.stop()
 
 
 class LoggedInApplicationTest(BaseApplicationTest):

--- a/tests/app/main/helpers/test_s3.py
+++ b/tests/app/main/helpers/test_s3.py
@@ -77,36 +77,6 @@ class TestS3Uploader(unittest.TestCase):
             'folder/OLD-test-file.pdf'
         ]))
 
-    def test_save_with_existing_path(self):
-        mock_bucket = FakeBucket(['folder/test-file.odt'])
-        self.s3_mock.get_bucket.return_value = mock_bucket
-
-        S3('test-bucket').save(
-            'folder/test-file.pdf', mock.Mock(),
-            existing_path='folder/test-file.odt',
-            move_prefix='OLD'
-        )
-
-        self.assertEqual(mock_bucket.keys, set([
-            'folder/test-file.pdf',
-            'folder/OLD-test-file.odt'
-        ]))
-
-    def test_save_strips_existing_path_leading_slash(self):
-        mock_bucket = FakeBucket(['folder/test-file.odt'])
-        self.s3_mock.get_bucket.return_value = mock_bucket
-
-        S3('test-bucket').save(
-            '/folder/test-file.pdf', mock.Mock(),
-            existing_path='/folder/test-file.odt',
-            move_prefix='OLD'
-        )
-
-        self.assertEqual(mock_bucket.keys, set([
-            'folder/test-file.pdf',
-            'folder/OLD-test-file.odt'
-        ]))
-
     def test_move_existing_deletes_file(self):
         mock_bucket = FakeBucket(['folder/test-file.odt'])
         self.s3_mock.get_bucket.return_value = mock_bucket

--- a/tests/app/main/helpers/test_s3.py
+++ b/tests/app/main/helpers/test_s3.py
@@ -77,7 +77,7 @@ class TestS3Uploader(unittest.TestCase):
             'folder/OLD-test-file.pdf'
         ]))
 
-    def test_move_existing_deletes_file(self):
+    def test_move_existing_doesnt_delete_file(self):
         mock_bucket = FakeBucket(['folder/test-file.odt'])
         self.s3_mock.get_bucket.return_value = mock_bucket
 
@@ -87,6 +87,7 @@ class TestS3Uploader(unittest.TestCase):
         )
 
         self.assertEqual(mock_bucket.keys, set([
+            'folder/test-file.odt',
             'folder/OLD-test-file.odt'
         ]))
 

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -94,6 +94,10 @@ class TestValidate(unittest.TestCase):
             self.data['pricingDocumentURL']
         )
 
+        self.assertEquals(self.validate.clean_data, {
+            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document.pdf',  # noqa
+        })
+
     def test_multiple_fields_list_of_validations(self):
         self.data.update({
             'q0': mock_file('a.pdf', 1),

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -121,7 +121,6 @@ class TestValidate(unittest.TestCase):
             {'name': 'file_is_open_document_format', 'message': 'failed'},
             {'name': 'file_is_less_than_5mb', 'message': 'failed'},
             {'name': 'file_can_be_saved', 'message': 'failed'},
-            value=None
         )
         self.assertEquals(self.validate.errors, {})
 

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -90,8 +90,9 @@ class TestValidate(unittest.TestCase):
 
         self.assertEquals(self.validate.errors, {})
         self.uploader.save.assert_called_once_with(
-            'documents/2', '1-pricing-document.pdf',
-            self.data['pricingDocumentURL']
+            'documents/2/1-pricing-document.pdf',
+            self.data['pricingDocumentURL'],
+            'b.pdf'
         )
 
         self.assertEquals(self.validate.clean_data, {

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -23,70 +23,70 @@ class TestValidate(unittest.TestCase):
 
         self.validate.content.get_question = lambda key: self.content[key]
 
+    def set_question(self, question_id, data, *validations, **kwargs):
+        self.data[question_id] = data
+        if 'value' in kwargs:
+            self.service[question_id] = kwargs['value']
+        self.content[question_id] = {'validations': validations}
+
     def test_validate_empty(self):
         self.assertEquals(self.validate.errors, {})
 
     def test_validate_empty_question(self):
-        self.data['q1'] = mock_file('a', 0)
-        self.content['q1'] = {'validations': []}
+        self.set_question('q1', mock_file('a', 0))
         self.assertEquals(self.validate.errors, {})
 
     def test_validate_non_empty_answer_required(self):
-        self.data['q1'] = mock_file('a', 1)
-        self.content['q1'] = {
-            'validations': [
-                {'name': 'answer_required', 'message': 'failed'}
-            ]
-        }
+        self.set_question(
+            'q1', mock_file('a', 1),
+            {'name': 'answer_required', 'message': 'failed'}
+        )
         self.assertEquals(self.validate.errors, {})
 
     def test_validate_empty_answer_required(self):
-        self.data['q1'] = mock_file('a.pdf', 0)
-        self.content['q1'] = {
-            'validations': [
-                {'name': 'answer_required', 'message': 'failed'}
-            ]
-        }
+        self.set_question(
+            'q1', mock_file('a.pdf', 0),
+            {'name': 'answer_required', 'message': 'failed'}
+        )
         self.assertEquals(self.validate.errors, {'q1': 'failed'})
 
+    def test_validate_empty_answer_required_previous_value(self):
+        self.set_question(
+            'q1', mock_file('a.pdf', 0),
+            {'name': 'answer_required', 'message': 'failed'},
+            value='b.pdf',
+        )
+        self.assertEquals(self.validate.errors, {})
+
     def test_incorrect_document_format(self):
-        self.data['q1'] = mock_file('a.txt', 1)
-        self.content['q1'] = {
-            'validations': [
-                {'name': 'file_is_open_document_format', 'message': 'failed'}
-            ]
-        }
+        self.set_question(
+            'q1', mock_file('a.txt', 1),
+            {'name': 'file_is_open_document_format', 'message': 'failed'}
+        )
         self.assertEquals(self.validate.errors, {'q1': 'failed'})
 
     def test_incorrect_file_size(self):
-        self.data['q1'] = mock_file('a.pdf', 5400001)
-        self.content['q1'] = {
-            'validations': [
-                {'name': 'file_is_less_than_5mb', 'message': 'failed'}
-            ]
-        }
+        self.set_question(
+            'q1', mock_file('a.pdf', 5400001),
+            {'name': 'file_is_less_than_5mb', 'message': 'failed'}
+        )
         self.assertEquals(self.validate.errors, {'q1': 'failed'})
 
     def test_list_of_validations(self):
-        self.data['q1'] = mock_file('a.pdf', 1)
-        self.service['q1'] = 'b.pdf'
-        self.content['q1'] = {
-            'validations': [
-                {'name': 'file_is_open_document_format', 'message': 'failed'},
-                {'name': 'file_is_less_than_5mb', 'message': 'failed'},
-            ]
-        }
+        self.set_question(
+            'q1', mock_file('a.pdf', 1),
+            {'name': 'file_is_open_document_format', 'message': 'failed'},
+            {'name': 'file_is_less_than_5mb', 'message': 'failed'},
+            value='b.pdf'
+        )
         self.assertEquals(self.validate.errors, {})
 
     def test_file_save(self):
-        self.data['pricingDocumentURL'] = mock_file('a.pdf', 1,
-                                                    'pricingDocumentURL')
-        self.service['pricingDocumentURL'] = 'b.pdf'
-        self.content['pricingDocumentURL'] = {
-            'validations': [
-                {'name': 'file_can_be_saved', 'message': 'failed'},
-            ]
-        }
+        self.set_question(
+            'pricingDocumentURL', mock_file('a.pdf', 1, 'pricingDocumentURL'),
+            {'name': 'file_can_be_saved', 'message': 'failed'},
+            value='b.pdf'
+        )
 
         self.assertEquals(self.validate.errors, {})
         self.uploader.save.assert_called_once_with(
@@ -99,29 +99,31 @@ class TestValidate(unittest.TestCase):
             'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document.pdf',  # noqa
         })
 
+    def test_field_with_no_previous_value(self):
+        self.set_question(
+            'pricingDocumentURL', mock_file('a.pdf', 1),
+            {'name': 'answer_required', 'message': 'failed'},
+            {'name': 'file_is_open_document_format', 'message': 'failed'},
+            {'name': 'file_is_less_than_5mb', 'message': 'failed'},
+            {'name': 'file_can_be_saved', 'message': 'failed'},
+            value=None
+        )
+        self.assertEquals(self.validate.errors, {})
+
     def test_multiple_fields_list_of_validations(self):
-        self.data.update({
-            'q0': mock_file('a.pdf', 1),
-            'q1': mock_file('a.txt', 1),
-            'q2': mock_file('a.pdf', 5400001),
-            'q3': mock_file('a.txt', 5400001),
-        })
-        self.service.update({
-            'q0': 'b.pdf',
-            'q1': 'b.pdf',
-            'q2': 'b.pdf',
-            'q3': 'b.pdf',
-        })
         validations = [
             {'name': 'file_is_open_document_format', 'message': 'format'},
             {'name': 'file_is_less_than_5mb', 'message': 'size'},
         ]
-        self.content.update({
-            'q0': {'validations': validations},
-            'q1': {'validations': validations},
-            'q2': {'validations': validations},
-            'q3': {'validations': validations},
-        })
+
+        self.set_question('q0', mock_file('a.pdf', 1),
+                          value='b.pdf', *validations)
+        self.set_question('q1', mock_file('a.txt', 1),
+                          value='b.pdf', *validations)
+        self.set_question('q2', mock_file('a.pdf', 5400001),
+                          value='b.pdf', *validations)
+        self.set_question('q3', mock_file('a.txt', 5400001),
+                          value='b.pdf', *validations)
 
         self.assertEquals(self.validate.errors, {
             'q1': 'format',

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -3,7 +3,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from urllib.parse import urlsplit
-    from ioi import StringIO
+    from io import BytesIO as StringIO
 
 from ..helpers import BaseApplicationTest
 from ..helpers import LoggedInApplicationTest
@@ -91,8 +91,8 @@ class TestServiceEdit(LoggedInApplicationTest):
         response = self.client.post(
             '/service/1/edit/documents',
             data={
-                'pricingDocumentURL': (StringIO("doc"), 'test.pdf'),
-                'sfiaRateDocumentURL': (StringIO("doc"), 'test.pdf')
+                'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
+                'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.pdf')
             }
         )
 
@@ -114,8 +114,8 @@ class TestServiceEdit(LoggedInApplicationTest):
         response = self.client.post(
             '/service/1/edit/documents',
             data={
-                'pricingDocumentURL': (StringIO("doc"), 'test.pdf'),
-                'sfiaRateDocumentURL': (StringIO("doc"), 'test.txt'),
+                'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
+                'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.txt'),
                 'termsAndConditionsDocumentURL': (StringIO(), 'test.pdf'),
             }
         )
@@ -125,6 +125,6 @@ class TestServiceEdit(LoggedInApplicationTest):
             'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document.pdf',  # noqa
         }, 'admin', 'admin app')
 
-        self.assertIn('Your document is not in an open format', response.data)
-        self.assertIn('This question requires an answer', response.data)
+        self.assertIn(b'Your document is not in an open format', response.data)
+        self.assertIn(b'This question requires an answer', response.data)
         self.assertEquals(200, response.status_code)

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -98,8 +98,8 @@ class TestServiceEdit(LoggedInApplicationTest):
 
         self.service_loader.get.assert_called_with('1')
         self.service_loader.post.assert_called_with(1, {
-            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document.pdf',  # noqa
-            'sfiaRateDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-sfia-rate-card.pdf',  # noqa
+            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
+            'sfiaRateDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-sfia-rate-card-2015-01-01-1200.pdf',  # noqa
         }, 'admin', 'admin app')
 
         self.assertEquals(302, response.status_code)
@@ -122,7 +122,7 @@ class TestServiceEdit(LoggedInApplicationTest):
 
         self.service_loader.get.assert_called_with('1')
         self.service_loader.post.assert_called_with(1, {
-            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document.pdf',  # noqa
+            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
         }, 'admin', 'admin app')
 
         self.assertIn(b'Your document is not in an open format', response.data)


### PR DESCRIPTION
Adds a call to the API to update service fields. New field values are looked up in the `Validate.clean_data`, so one of the field validators should populate the value for the field. For documents it's done by `file_can_be_saved`.

Update API is called with current username as update author and 'admin app' as reason. Request is only sent if any of the fields have changed.

Only the fields that have passed validation are saved.

`Validate.errors` are now cached, so the validators won't run more than once.

S3 file upload now takes the current file name as an argument and renames the existing file even if it has a different extension.