### PR TITLE
Add JS from Digital Marketplace frontend toolkit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,9 @@
-// Load all the things
+/*
+  The following comments are parsed by Gulp include
+  (https://www.npmjs.com/package/gulp-include) which uses
+  Sprockets-style (https://github.com/sstephenson/sprockets)
+  directives to concatenate multiple Javascript files into one.
+*/
 //= include ../../../bower_components/jquery/dist/jquery.js
 //= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,48 @@
+// Load all the things
+//= include ../../../bower_components/jquery/dist/jquery.js
+//= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
+(function(GOVUK, GDM) {
+
+  "use strict";
+
+  var module;
+
+  if (
+    (GDM.debug = !window.location.href.match(/gov.uk/) && !window.jasmine)
+  ) {
+    console.log(
+      "%cDebug mode %cON",
+      "color:#550; background:yellow; font-size: 11pt",
+      "color:yellow; background: #550;font-size:11pt"
+    );
+    console.time("Modules loaded");
+  }
+
+  // Initialise our modules
+  for (module in GDM) {
+
+    if (GDM.debug && module !== "debug") {
+      console.log(
+        "%cLoading module %c" + module,
+        "color:#6a6; background:#dfd; font-size: 11pt",
+        "color:#dfd; background:green; font-size: 11pt"
+      );
+    }
+
+    if ("function" === typeof GDM[module].init) {
+      // If a module has an init() method then we want that to be called here
+      GDM[module].init();
+    } else if ("function" === typeof GDM[module]) {
+      // If a module doesn't have an interface then call it directly
+      GDM[module]();
+    }
+
+  }
+
+  GOVUK.GDM = GDM;
+
+  if (GDM.debug) console.timeEnd("Modules loaded");
+
+}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -13,6 +13,7 @@ $path: "/static/images/";
 @import "forms/questions";
 @import "forms/hint";
 @import "forms/textboxes";
+@import "forms/word-counter";
 @import "forms/list-entry";
 @import "forms/selection-buttons";
 @import "forms/validation";

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -1,5 +1,5 @@
 {% macro question_wrapper_open(question) -%}
-  <div class="question" id="{{ question.id }}">
+  <div class="question">
     <label class="question-heading" for="{{ question.name }}">{{ question.question }}</label>
     {% if "hint" in question %}
       <p class="hint">
@@ -35,7 +35,13 @@
 {%- endmacro %}
 
 {% macro textbox_large(field, value='', service_data) -%}
-  <textarea type="text" class="text-box text-box-large" name="{{ field.id }}" id="{{ field.id }}-text-box">{{ value }}</textarea>
+  {% if field.maxLengthInWords %}
+    <div class="word-count">
+      <textarea class="text-box text-box-large" name="{{ field.id }}" id="{{ field.id }}-text-box" data-max-length-in-words="{{ field.maxLengthInWords }}">{{ value }}</textarea>
+    </div>
+  {% else %}
+    <textarea class="text-box text-box-large" name="{{ field.id }}" id="{{ field.id }}-text-box">{{ value }}</textarea>
+  {% endif %}
 {%- endmacro %}
 
 {% macro upload(question, value='', service_data) -%}
@@ -154,14 +160,14 @@
 
 
 {% macro list(field, value='', service_data) -%}
-  <div class="input-list" data-list-item-name="feature">
+  <div class="input-list" id="{{field.id}}" data-list-item-name="{{field.listItemName}}">
     {% for index in range(10) %}
       {{ list_item(
         field.id,
         index,
         index + 1,
         value,
-        "thing"
+        field.listItemName
       ) }}
     {% endfor %}
   </div>
@@ -172,6 +178,6 @@
     <label for='{{ name }}-item-{{ number }}' class='text-box-number-label'>
       <span class='visuallyhidden'>{{ list_item_name }} number </span>{{ number }}.
     </label>
-    <input type='text' name='{{ name }}' id='{{ name }}-item-{{ number }}' class='text-box' value="{{ values[index] }}" />
+    <input type='text' name='{{ name }}' id='{{ input_name }}-item-{{ number }}' class='text-box' value="{{ values[index] }}" />
   </div>
 {% endmacro %}

--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v1.2.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v2.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#973f540"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#973f540",
+    "hogan": "3.0.2"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var uglify = require('gulp-uglifyjs');
 var deleteFiles = require('del');
 var sass = require('gulp-sass');
+var include = require('gulp-include');
 
 var environment;
 var repoRoot = __dirname + '/';
@@ -77,7 +78,7 @@ gulp.task('sass', function () {
     .pipe(gulp.dest(cssDistributionFolder));
 
   stream.on('end', function () {
-    console.log('Compressed CSS saved as .css files in ' + cssDistributionFolder)
+    console.log('Compressed CSS saved as .css files in ' + cssDistributionFolder);
   });
 
   return stream;
@@ -87,6 +88,7 @@ gulp.task('js', function () {
   // produce full array of JS files from vendor + local scripts
   jsFiles = jsVendorFiles.concat(jsSourceFiles);
   var stream = gulp.src(jsFiles)
+    .pipe(include())
     .pipe(uglify(
       jsDistributionFile,
       uglifyOptions[environment]
@@ -126,7 +128,7 @@ gulp.task('watch', ['build:development'], function () {
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
   var notice = function (event) {
     console.log('File ' + event.path + ' was ' + event.type + ' running tasks...');
-  }
+  };
 
   cssWatcher.on('change', notice);
   jsWatcher.on('change', notice);
@@ -134,7 +136,7 @@ gulp.task('watch', ['build:development'], function () {
 
 gulp.task('copy_toolkit_assets:images', function () {
   return gulp.src(dmToolkitAssetsFolder + '/images/**/*', { base : dmToolkitAssetsFolder + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'))
+    .pipe(gulp.dest(staticFolder + '/images'));
 });
 
 gulp.task('build:development', ['clean'], function () {

--- a/package.json
+++ b/package.json
@@ -6,18 +6,19 @@
   "engine": "node >= 0.10.0",
   "dependencies": {
     "bower": "1.3.12",
+    "del": "1.1.1",
     "govuk_frontend_toolkit": "3.1.0",
     "gulp": "3.8.7",
-    "gulp-uglifyjs": "0.6.0",
-    "del": "1.1.1",
+    "gulp-include": "1.1.1",
     "gulp-sass": "1.3.3",
-    "gulp-shell": "0.2.9"
+    "gulp-shell": "0.2.9",
+    "gulp-uglifyjs": "0.6.0"
   },
   "scripts": {
     "frontend-install": "./node_modules/bower/bin/bower install",
-    "frontend-build:development" : "./node_modules/gulp/bin/gulp.js build:development",
-    "frontend-build:production" : "./node_modules/gulp/bin/gulp.js build:production",
-    "frontend-build:watch" : "./node_modules/gulp/bin/gulp.js watch",
+    "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",
+    "frontend-build:production": "./node_modules/gulp/bin/gulp.js build:production",
+    "frontend-build:watch": "./node_modules/gulp/bin/gulp.js watch",
     "postinstall": "npm run frontend-install"
   }
 }


### PR DESCRIPTION
This pull request brings back:
- Word count on the service summary field
- Add/remove item functionality for features and benefits

The tooling is [Gulp include](https://www.npmjs.com/package/gulp-include) which uses [Sprockets](https://github.com/sstephenson/sprockets)-style directives to concatenate multiple Javascript files into one.

It also makes some minor template changes for compatibility with the toolkit Javascript.

![words](https://cloud.githubusercontent.com/assets/355079/7026282/bba5c2c8-dd40-11e4-95d7-92455b27d1a1.gif)

![fb](https://cloud.githubusercontent.com/assets/355079/7026355/1f37b6de-dd41-11e4-8226-1370c97f2921.gif)