### PR TITLE
Surface API errors

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -128,12 +128,14 @@ def update(service_id, section):
                 update[question_id] = form.clean_data[question_id]
 
     if update:
-        service_loader.post(
+        api_response = service_loader.post(
             service['id'],
             update,
             session['username'],
             'admin app'
         )
+        if not api_response.ok:
+            return "Error: " + str(api_response.content)
 
     if form.errors:
         service.update(form.dirty_data)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -135,7 +135,10 @@ def update(service_id, section):
             'admin app'
         )
         if not api_response.ok:
-            return "Error: " + str(api_response.content)
+            try:
+                return api_response.json()['error']
+            except TypeError:
+                return str(api_response.content)
 
     if form.errors:
         service.update(form.dirty_data)

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -128,3 +128,22 @@ class TestServiceEdit(LoggedInApplicationTest):
         self.assertIn(b'Your document is not in an open format', response.data)
         self.assertIn(b'This question requires an answer', response.data)
         self.assertEquals(200, response.status_code)
+
+    def test_service_edit_when_API_returns_error(self):
+        self.service_loader.get.return_value = {
+            'id': 1,
+            'supplierId': 2,
+            'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
+            'sfiaRateDocumentURL': None
+        }
+        self.service_loader.post.return_value.ok = False
+        self.service_loader.post.return_value.content = 'API ERROR'
+        response = self.client.post(
+            '/service/1/edit/documents',
+            data={
+                'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
+                'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.txt'),
+                'termsAndConditionsDocumentURL': (StringIO(), 'test.pdf'),
+            }
+        )
+        self.assertIn(b'API ERROR', response.data)


### PR DESCRIPTION
If the validations pass but the `post` to the API fails for whatever reason it will appear to the user that their changes have been persisted, when they have, infact, not.

This pull request does the minimum required to indicate to the user that something has gone wrong.