### PR TITLE
Fix bug with pricing list

### DIFF
--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -182,7 +182,14 @@ class Validate(object):
         return not has_long_item
 
     def under_10_items(self, question_id, question):
-        return len(question) <= 10
+        items_with_empty_removed = [
+            list_item for list_item in question if list_item.strip()
+        ]
+        if len(items_with_empty_removed) <= 10:
+            self.clean_data[question_id] = items_with_empty_removed
+            return True
+        else:
+            return False
 
 
 def generate_file_name(supplier_id, service_id, question_id, filename,

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -108,9 +108,7 @@ def update(service_id, section):
     for key in request.form:
         item_as_list = request.form.getlist(key)
         if len(item_as_list) > 1:
-            posted_data[key] = [
-                list_item for list_item in item_as_list if list_item.strip()
-            ]
+            posted_data[key] = item_as_list
 
     form = Validate(content, service, posted_data, s3_uploader)
     update = {}

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -483,6 +483,31 @@ class TestValidate(unittest.TestCase):
         )
         self.assertEquals(self.validate.errors, {'q1': 'failed'})
 
+    def test_list_with_empty_items(self):
+        self.set_question(
+            'q1', [
+                "something",
+                "",
+                "something",
+                "",
+                "something"
+            ],
+            {
+                'type': 'list',
+                'validations': [
+                    {
+                        'name': 'under_10_items',
+                        'message': 'failed'
+                    }
+                ]
+            }
+        )
+        errors = self.validate.errors
+        self.assertEquals(
+            self.validate.clean_data['q1'],
+            ["something", "something", "something"]
+        )
+
     def test_list_with_short_items(self):
         self.set_question(
             'q1', [


### PR DESCRIPTION
There was a bug when max price was left empty. It meant that max price got replaced with the value of the next item in the pricing list (unit). This is because any list submitted to the app was having its empty items removed.

This commit changes the app to only strip empty items from lists that get validated for their length.