### PR TITLE
Make one command to initialise the frontend code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install new Python dependencies with pip
 Install frontend dependencies with npm and gulp
 
 ```
-npm install
+npm run init
 ```
 
 ### Run the tests
@@ -77,5 +77,8 @@ The admin frontend runs on port 5004. Use the app at [http://127.0.0.1:5004/](ht
 - `npm run frontend-build:production` (compile the frontend files for production)
 - `npm run frontend-build:watch` (watch all frontend files & rebuild when anything changes)
 - `npm run frontend-install` (install all non-NPM dependancies)
+- `npm init:development` (install all non-NPM dependancies and compile the frontend files for development)
+- `npm init:production` (install all non-NPM dependancies and compile the frontend files for production)
+- `npm init` (alias for `npm run init:development)
 
 Note: `npm run frontend-install` is run as a post-install task after you run `npm install`.

--- a/package.json
+++ b/package.json
@@ -13,11 +13,17 @@
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9"
   },
+  "config": {
+    "environment": "development"
+  },
   "scripts": {
     "frontend-install": "./node_modules/bower/bin/bower install",
-    "frontend-build:development" : "./node_modules/gulp/bin/gulp.js build:development",
-    "frontend-build:production" : "./node_modules/gulp/bin/gulp.js build:production",
-    "frontend-build:watch" : "./node_modules/gulp/bin/gulp.js watch",
-    "postinstall": "npm run frontend-install"
+    "frontend-build:development": "./node_modules/gulp/bin/gulp.js build:development",
+    "frontend-build:production": "./node_modules/gulp/bin/gulp.js build:production",
+    "frontend-build:watch": "./node_modules/gulp/bin/gulp.js watch",
+    "init:development": "npm install",
+    "init:production": "npm config set digitalmartketplace-admin-frontend:environment production && npm install",
+    "init": "npm run init:development",
+    "postinstall": "npm run frontend-install && npm run frontend-build:$npm_package_config_environment"
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-npm install
-npm run frontend-build:production
+npm run init:production


### PR DESCRIPTION
The current README seems to indicate you just need to run `npm install` to get started with the app. We do list the NPM build commands at the bottom but it's not clear which you need to do before the front-end will be ready.

This creates a command which does just that: `npm run init`.