### PR TITLE
Fix admin file update

### DIFF
--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -46,6 +46,8 @@ class Validate(object):
 
         if not self.test(question_id, question, "answer_required"):
             if "optional" in question_content:
+                if question_content.get('type') != 'upload':
+                    self.clean_data[question_id] = question
                 return
             # File has previously been uploaded
             if (

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -23,12 +23,9 @@ class Validate(object):
         self.uploader = uploader
         self.clean_data = None
         self.dirty_data = None
-        self._errors = None
+        self.errors = None
 
-    @property
-    def errors(self):
-        if self._errors is not None:
-            return self._errors
+    def validate(self):
         errors = {}
         self.clean_data = {}
         self.dirty_data = {}
@@ -37,8 +34,8 @@ class Validate(object):
             if question_errors:
                 errors[question_id] = question_errors
 
-        self._errors = errors
-        return errors
+        self.errors = errors
+        return self
 
     def question_errors(self, question_id):
         question = self.posted_data[question_id]

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -113,17 +113,11 @@ def update(service_id, section):
     form = Validate(content, service, posted_data, s3_uploader)
     update = {}
 
-    for question_id in posted_data:
-        if question_id not in form.errors:
-            if question_id in form.clean_data:
-                update[question_id] = form.clean_data[question_id]
-            else:
-                update[question_id] = posted_data[question_id]
+    form.errors
 
-    if form.clean_data is not None:
-        for question_id in form.clean_data:
-            if question_id not in form.errors and question_id not in update:
-                update[question_id] = form.clean_data[question_id]
+    for question_id in form.clean_data:
+        if question_id not in form.errors:
+            update[question_id] = form.clean_data[question_id]
 
     if update:
         api_response = service_loader.post(

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -113,7 +113,7 @@ def update(service_id, section):
     form = Validate(content, service, posted_data, s3_uploader)
     update = {}
 
-    form.errors
+    form.validate()
 
     for question_id in form.clean_data:
         if question_id not in form.errors:

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -84,7 +84,49 @@ class TestValidate(unittest.TestCase):
         )
         self.assertEquals(self.validate.errors, {})
 
-    def test_validate_empty_answer_required(self):
+    def test_validate_text_without_validators(self):
+        self.set_question(
+            'q1', 'value',
+            {
+                'optional': True,
+                'validations': []
+            }
+        )
+
+        self.assertEquals(self.validate.errors, {})
+        self.assertEquals(self.validate.clean_data['q1'], 'value')
+
+    def test_validate_empty_upload_optional(self):
+        self.set_question(
+            'q1', mock_file('a.pdf', 0),
+            {
+                'type': 'upload',
+                'optional': True,
+                'validations': [{
+                    'name': 'answer_required', 'message': 'failed'
+                }]
+            }
+        )
+
+        self.assertEquals(self.validate.errors, {})
+        self.assertNotIn('q1', self.validate.clean_data)
+
+    def test_validate_empty_upload_optional_with_previous_value(self):
+        self.set_question(
+            'q2', mock_file('a.pdf', 0),
+            {
+                'type': 'upload',
+                'optional': True,
+                'validations': [{
+                    'name': 'answer_required', 'message': 'failed'
+                }]
+            },
+            value='b.pdf',
+        )
+        self.assertEquals(self.validate.errors, {})
+        self.assertNotIn('q1', self.validate.clean_data)
+
+    def test_validate_empty_upload_not_optional(self):
         self.set_question(
             'q1', mock_file('a.pdf', 0),
             {
@@ -95,8 +137,9 @@ class TestValidate(unittest.TestCase):
             }
         )
         self.assertEquals(self.validate.errors, {'q1': 'failed'})
+        self.assertNotIn('q1', self.validate.clean_data)
 
-    def test_validate_empty_answer_required_previous_value(self):
+    def test_validate_empty_upload_not_optional_with_previous_value(self):
         self.set_question(
             'q2', mock_file('a.pdf', 0),
             {
@@ -108,6 +151,60 @@ class TestValidate(unittest.TestCase):
             value='b.pdf',
         )
         self.assertEquals(self.validate.errors, {})
+        self.assertNotIn('q1', self.validate.clean_data)
+
+    def test_validate_empty_text_optional(self):
+        self.set_question(
+            'q1', '',
+            {
+                'optional': True,
+                'validations': [{
+                    'name': 'answer_required', 'message': 'failed'
+                }]
+            }
+        )
+
+        self.assertEquals(self.validate.errors, {})
+        self.assertEquals(self.validate.clean_data['q1'], '')
+
+    def test_validate_empty_text_optional_with_previous_value(self):
+        self.set_question(
+            'q2', '',
+            {
+                'optional': True,
+                'validations': [{
+                    'name': 'answer_required', 'message': 'failed'
+                }]
+            },
+            value='Previous value',
+        )
+        self.assertEquals(self.validate.errors, {})
+        self.assertEquals(self.validate.clean_data['q2'], '')
+
+    def test_validate_empty_text_not_optional(self):
+        self.set_question(
+            'q1', '',
+            {
+                'validations': [{
+                    'name': 'answer_required', 'message': 'failed'
+                }]
+            }
+        )
+        self.assertEquals(self.validate.errors, {'q1': 'failed'})
+        self.assertNotIn('q1', self.validate.clean_data)
+
+    def test_validate_empty_text_not_optional_with_previous_value(self):
+        self.set_question(
+            'q2', '',
+            {
+                'validations': [{
+                    'name': 'answer_required', 'message': 'failed'
+                }]
+            },
+            value='Previous value',
+        )
+        self.assertEquals(self.validate.errors, {'q2': 'failed'})
+        self.assertNotIn('q1', self.validate.clean_data)
 
     def test_incorrect_document_format(self):
         self.set_question(

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -65,7 +65,10 @@ class TestValidate(unittest.TestCase):
             self.service[question_id] = kwargs['value']
         self.content[question_id] = content
 
+        self.validate.validate()
+
     def test_validate_empty(self):
+        self.validate.validate()
         self.assertEquals(self.validate.errors, {})
 
     def test_validate_empty_question(self):

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -86,13 +86,17 @@ class TestServiceEdit(LoggedInApplicationTest):
             'id': 1,
             'supplierId': 2,
             'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
+            'serviceDefinitionDocumentURL': "http://assets/documents/1/2-service-definition.pdf",  # noqa
+            'termsAndConditionsDocumentURL': "http://assets/documents/1/2-terms-and-conditions.pdf",  # noqa
             'sfiaRateDocumentURL': None
         }
         response = self.client.post(
             '/service/1/edit/documents',
             data={
+                'serviceDefinitionDocumentURL': (StringIO(), ''),
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
-                'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.pdf')
+                'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.pdf'),
+                'termsAndConditionsDocumentURL': (StringIO(b''), ''),
             }
         )
 
@@ -108,12 +112,14 @@ class TestServiceEdit(LoggedInApplicationTest):
         self.service_loader.get.return_value = {
             'id': 1,
             'supplierId': 2,
+            'serviceDefinitionDocumentURL': "http://assets/documents/1/2-service-definition.pdf",  # noqa
             'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
             'sfiaRateDocumentURL': None
         }
         response = self.client.post(
             '/service/1/edit/documents',
             data={
+                'serviceDefinitionDocumentURL': (StringIO(), ''),
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
                 'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.txt'),
                 'termsAndConditionsDocumentURL': (StringIO(), 'test.pdf'),


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/92530470

Trying to add fields to update from `posted_data` adds empty uploaded file streams, which leads to JSON serialization error.

Fixed by only using the fields in `clean_data`, which should contain values for all validated form fields.