### PR TITLE
Admin '/admin' prefix to views, static file paths, links and redirect destinations

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,11 +19,11 @@ def create_app(config_name):
 
     bootstrap.init_app(application)
 
-    application.register_blueprint(main_blueprint)
-    main_blueprint.config = application.config.copy()
-
     if application.config['AUTHENTICATION']:
         application.permanent_session_lifetime = timedelta(minutes=60)
-        application.before_request(requires_auth)
+        main_blueprint.before_request(requires_auth)
+
+    application.register_blueprint(main_blueprint, url_prefix='/admin')
+    main_blueprint.config = application.config.copy()
 
     return application

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,3 @@
-import os
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from config import config
@@ -11,7 +10,10 @@ bootstrap = Bootstrap()
 
 def create_app(config_name):
 
-    application = Flask(__name__)
+    application = Flask(__name__,
+                        static_folder='static/',
+                        static_url_path=config[config_name].STATIC_URL_PATH)
+
     application.config.from_object(config[config_name])
     config[config_name].init_app(application)
 

--- a/app/main/helpers/auth.py
+++ b/app/main/helpers/auth.py
@@ -1,6 +1,5 @@
-import os
 import base64
-from flask import redirect, request, session
+from flask import redirect, request, session, url_for
 from pbkdf2 import crypt
 
 
@@ -20,7 +19,7 @@ def requires_auth():
         request.endpoint != 'main.login' and
         request.endpoint != 'static'
     ):
-        return redirect("/login")
+        return redirect(url_for(".login"))
 
 
 def is_authenticated():

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, redirect, session
+from flask import render_template, request, redirect, session, url_for
 from . import main
 from .helpers.validation_tools import Validate
 from .helpers.content import ContentLoader
@@ -34,7 +34,7 @@ def login():
         main.config['PASSWORD_HASH']
     ):
         session['username'] = request.form['username']
-        return redirect('/')
+        return redirect(url_for('.index'))
 
     return render_template("login.html", **get_template_data({
         "error": "Could not log in",
@@ -45,12 +45,13 @@ def login():
 @main.route('/logout')
 def logout():
     session.pop('username', None)
-    return redirect('/login?logged_out')
+    return redirect(url_for('.login', logged_out=''))
 
 
 @main.route('/service')
 def find():
-    return redirect("/service/" + request.args.get("service_id"))
+    return redirect(
+        url_for(".view", service_id=request.args.get("service_id")))
 
 
 @main.route('/service/<service_id>')
@@ -147,7 +148,7 @@ def update(service_id, section):
             "errors": form.errors
         }))
     else:
-        return redirect("/service/" + service_id)
+        return redirect(url_for(".view", service_id=service_id))
 
 
 def get_template_data(merged_with={}):

--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -9,7 +9,7 @@
     {% if authenticated %}
       <ul id="proposition-links">
         <li>
-          <a href="/logout">Log out</a>
+          <a href="{{ url_for('.logout') }}">Log out</a>
         </li>
       </ul>
     {% endif %}

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -10,7 +10,7 @@
 {% block content %}
   {{ breadcrumb([
     {
-      "link": "/service/" + service_data['id']|string,
+      "link": url_for(".view", service_id=service_data.id),
       "text": service_data['serviceName']
     }
   ]) }}
@@ -32,7 +32,7 @@
         </ul>
       </div>
     {% endif %}
-    <form action="/service/{{ service_data['id'] }}/edit/{{ section.id }}" method="post" enctype="multipart/form-data">
+    <form action="{{ url_for('.update', service_id=service_data.id, section=section.id) }}" method="post" enctype="multipart/form-data">
       {% for question in section.questions %}
         {% if question.id in errors %}
           {{ forms.validation_wrapper_open() }}
@@ -49,7 +49,7 @@
       {% endfor %}
       <button class="button-save" type="submit">Save and return to summary</button>
       <p>
-        <a href="/service/{{ service_data['id'] }}">Return without saving</a>
+        <a href="{{ url_for('.view', service_id=service_data.id) }}">Return without saving</a>
       </p>
     </form>
   </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div class="page-container">
   {{ page_heading("Find a service") }}
-  <form action="/service" method="get" class="question">
+  <form action="{{ url_for('.find') }}" method="get" class="question">
       <label class="question-heading" for="service_id">Service ID</label>
       <input type="text" name="service_id" id="service_id" class="text-box">
       <input type="submit" value="Find service" class="button-save">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -15,7 +15,7 @@
     </div>
   {% endif %}
   {{ page_heading("Administrator login") }}
-  <form action="/login" method="post" class="question">
+  <form action="{{ url_for('.login') }}" method="post" class="question">
     {% if error %}
       <div class="validation-masthead">
         <h2 class="validation-masthead-heading">

--- a/app/templates/macros/breadcrumb.html
+++ b/app/templates/macros/breadcrumb.html
@@ -3,7 +3,7 @@
     <nav>
       <ol>
         <li>
-          <a href="/" alt="Back to home">Admin home</a>
+          <a href="{{ url_for('.index') }}" alt="Back to home">Admin home</a>
         </li>
         {% for crumb in crumbs %}
           {% if crumb.link is defined %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -27,7 +27,7 @@
           </h2>
           {% if section.editable %}
             <p class="summary-item-top-level-action">
-              <a href="/service/{{ service_id }}/edit/{{section.id}}">Edit</a>
+              <a href="{{ url_for('.edit', service_id=service_id, section=section.id) }}">Edit</a>
             </p>
           {% endif %}
           <table class="summary-item-body">

--- a/config.py
+++ b/config.py
@@ -10,9 +10,15 @@ class Config(object):
     DOCUMENTS_URL = 'https://assets.dev.digitalmarketplace.service.gov.uk'
     API_URL = os.getenv('DM_API_URL')
     API_AUTH_TOKEN = os.getenv('DM_ADMIN_FRONTEND_API_AUTH_TOKEN')
-    BASE_TEMPLATE_DATA = {}
     SECRET_KEY = os.getenv('DM_ADMIN_FRONTEND_COOKIE_SECRET')
     PASSWORD_HASH = os.getenv('DM_ADMIN_FRONTEND_PASSWORD_HASH')
+
+    STATIC_URL_PATH = '/admin/static'
+    ASSET_PATH = STATIC_URL_PATH + '/'
+    BASE_TEMPLATE_DATA = {
+        'asset_path': ASSET_PATH,
+        'header_class': 'with-proposition'
+    }
 
     @staticmethod
     def init_app(app):
@@ -32,29 +38,17 @@ class Test(Config):
     DOCUMENTS_URL = 'https://assets.test.digitalmarketplace.service.gov.uk'
     SECRET_KEY = "test_secret"
     PASSWORD_HASH = "JHA1azIkMjcxMCQwYmZiN2Y5YmJlZmI0YTg4YmNkZjQ1ODY0NWUzOGEwNCRoeDBwbUpHZVhSalREUFBGREFydmJQWnlFYnhWU1g1ag=="  # noqa
-    BASE_TEMPLATE_DATA = {
-        'asset_path': '/static/',
-        'header_class': 'with-proposition'
-    }
 
 
 class Development(Config):
     DEBUG = True
     AUTHENTICATION = True
-    BASE_TEMPLATE_DATA = {
-        'asset_path': '/static/',
-        'header_class': 'with-proposition'
-    }
 
 
 class Live(Config):
     DEBUG = False
     AUTHENTICATION = True
     DOCUMENTS_URL = 'https://assets.digitalmarketplace.service.gov.uk'
-    BASE_TEMPLATE_DATA = {
-        'asset_path': '/static/',
-        'header_class': 'with-proposition'
-    }
 
 
 config = {

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -11,46 +11,50 @@ from ..helpers import LoggedInApplicationTest
 
 class TestSession(BaseApplicationTest):
     def test_index(self):
-        response = self.client.get('/')
+        response = self.client.get('/admin/')
         self.assertEquals(302, response.status_code)
 
     def test_login(self):
-        response = self.client.post('/login', data=dict(
+        response = self.client.post('/admin/login', data=dict(
             username="admin",
             password="admin"
         ))
         self.assertEquals(302, response.status_code)
-        self.assertEquals("/", urlsplit(response.location).path)
+        self.assertEquals("/admin/", urlsplit(response.location).path)
 
-        response = self.client.get('/')
+        response = self.client.get('/admin/')
         self.assertEquals(200, response.status_code)
 
     def test_invalid_login(self):
-        response = self.client.post('/login', data=dict(
+        response = self.client.post('/admin/login', data=dict(
             username="admin",
             password="wrong"
         ))
         self.assertEquals(200, response.status_code)
 
-        response = self.client.get('/')
+        response = self.client.get('/admin/')
         self.assertEquals(302, response.status_code)
-        self.assertEquals("/login", urlsplit(response.location).path)
+        self.assertEquals("/admin/login", urlsplit(response.location).path)
 
 
 class TestApplication(LoggedInApplicationTest):
-    def test_index(self):
-        response = self.client.get('/')
+    def test_main_index(self):
+        response = self.client.get('/admin/')
         self.assertEquals(200, response.status_code)
 
     def test_404(self):
-        response = self.client.get('/not-found')
+        response = self.client.get('/admin/not-found')
+        self.assertEquals(404, response.status_code)
+
+    def test_index_is_404(self):
+        response = self.client.get('/')
         self.assertEquals(404, response.status_code)
 
 
 class TestServiceView(LoggedInApplicationTest):
     def test_service_response(self):
         self.service_loader.get.return_value = {}
-        response = self.client.get('/service/1')
+        response = self.client.get('/admin/service/1')
 
         self.service_loader.get.assert_called_with('1')
 
@@ -59,7 +63,7 @@ class TestServiceView(LoggedInApplicationTest):
 
 class TestServiceEdit(LoggedInApplicationTest):
     def test_service_edit_documents_get_response(self):
-        response = self.client.get('/service/1/edit/documents')
+        response = self.client.get('/admin/service/1/edit/documents')
 
         self.service_loader.get.assert_called_with('1')
 
@@ -71,7 +75,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'supplierId': 2,
         }
         response = self.client.post(
-            '/service/1/edit/documents',
+            '/admin/service/1/edit/documents',
             data={}
         )
 
@@ -79,7 +83,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         self.assertFalse(self.service_loader.post.called)
 
         self.assertEquals(302, response.status_code)
-        self.assertEquals("/service/1", urlsplit(response.location).path)
+        self.assertEquals("/admin/service/1", urlsplit(response.location).path)
 
     def test_service_edit_documents_post(self):
         self.service_loader.get.return_value = {
@@ -89,7 +93,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'sfiaRateDocumentURL': None
         }
         response = self.client.post(
-            '/service/1/edit/documents',
+            '/admin/service/1/edit/documents',
             data={
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
                 'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.pdf')
@@ -112,7 +116,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'sfiaRateDocumentURL': None
         }
         response = self.client.post(
-            '/service/1/edit/documents',
+            '/admin/service/1/edit/documents',
             data={
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
                 'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.txt'),
@@ -139,7 +143,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         self.service_loader.post.return_value.ok = False
         self.service_loader.post.return_value.content = 'API ERROR'
         response = self.client.post(
-            '/service/1/edit/documents',
+            '/admin/service/1/edit/documents',
             data={
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
                 'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.txt'),


### PR DESCRIPTION
Adds url_prefix to the main blueprint and the static path, so that `main` is not the only blueprint that requires authentication and will be accessible through the CloudFront/reverse proxy.

This requires changes to the CloudFormation templates to set the static URL path to `/admin/static` in the ElasticBeanstalk environments.