### PR TITLE
Fix minor bugs in CloudWatch logs config

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -63,7 +63,7 @@ Resources :
                 [apache-access_log-combined]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogFile"]}`
                 log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}`
-                log_stream_name = appache-access-combined
+                log_stream_name = apache-access-combined
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
               mode  : "000400"
               owner : root

--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -34,7 +34,10 @@ container_commands:
   # Cannot reference cloud formation variables here
   01-create-directory:
     command: "mkdir -p /var/log/digitalmarketplace/"
-  02-change-permissions:
+  # if we don't create the file ourselves it gets owned by root
+  02-create-file:
+    command: "touch /var/log/digitalmarketplace/application.log"
+  03-change-permissions:
     command: "chmod 777 /var/log/digitalmarketplace/"
-  03-change-ownership:
+  04-change-ownership:
     command: "chown wsgi:wsgi /var/log/digitalmarketplace"


### PR DESCRIPTION
- Fix spelling mistake
- Touch application log file. If we do not it gets created as root and
  then the application cannot write.