### PR TITLE
Add extra pricing fields

### DIFF
--- a/app/assets/javascripts/_selection-buttons.js
+++ b/app/assets/javascripts/_selection-buttons.js
@@ -1,0 +1,14 @@
+(function(GOVUK, GDM) {
+
+  GOVUK.GDM.selectionButtons = function() {
+
+    if (!GOVUK.SelectionButtons) return;
+
+    new GOVUK.SelectionButtons('.selection-button input', {
+      'focusedClass' : 'selection-button-focused',
+      'selectedClass' : 'selection-button-selected'
+    });
+
+  };
+
+}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,8 @@
 //= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
+//= include _selection-buttons.js
 (function(GOVUK, GDM) {
 
   "use strict";

--- a/app/main/helpers/validation_tools.py
+++ b/app/main/helpers/validation_tools.py
@@ -73,6 +73,10 @@ class Validate(object):
         elif 'upload' == content.get('type'):
             return self.file_has_been_uploaded(question_id, question)
         elif isinstance(question, six.string_types):
+            if question == "True":
+                self.clean_data[question_id] = True
+            if question == "False":
+                self.clean_data[question_id] = False
             return not empty(question)
 
     def file_has_been_uploaded(self, question_id, question):

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -53,7 +53,7 @@ def logout():
 @main.route('/service')
 def find():
     return redirect(
-        url_for(".view", service_id=request.args.get_service("service_id")))
+        url_for(".view", service_id=request.args.get("service_id")))
 
 
 @main.route('/service/<service_id>')

--- a/app/section_order.yml
+++ b/app/section_order.yml
@@ -21,6 +21,12 @@
   editable: true
   questions:
     - priceString
+    - vatIncluded
+    - educationPricing
+    - terminationCost
+    - trialOption
+    - freeOption
+    - minimumContractPeriod
 -
   name: Documents
   editable: true

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -34,17 +34,19 @@
     {% endif %}
     <form action="{{ url_for('.update', service_id=service_data.id, section=section.id) }}" method="post" enctype="multipart/form-data">
       {% for question in section.questions %}
-        {% if question.id in errors %}
-          {{ forms.validation_wrapper_open() }}
-        {% endif %}
-        {{ forms.question_wrapper_open(question) }}
+        {% if service_data['lot']|lower in question['depends_on_lots'] %}
           {% if question.id in errors %}
-            {{ forms.validation_message(errors[question.id ], question.id) }}
+            {{ forms.validation_wrapper_open() }}
           {% endif %}
-          {{ forms[question.type](question, service_data[question.id], service_data) }}
-        {{ forms.question_wrapper_close(question) }}
-        {% if question.id in errors %}
-          {{ forms.validation_wrapper_close() }}
+          {{ forms.question_wrapper_open(question) }}
+            {% if question.id in errors %}
+              {{ forms.validation_message(errors[question.id ], question.id) }}
+            {% endif %}
+            {{ forms[question.type](question, service_data[question.id], service_data) }}
+          {{ forms.question_wrapper_close(question) }}
+          {% if question.id in errors %}
+            {{ forms.validation_wrapper_close() }}
+          {% endif %}
         {% endif %}
       {% endfor %}
       <button class="button-save" type="submit">Save and return to summary</button>

--- a/app/templates/macros/answers.html
+++ b/app/templates/macros/answers.html
@@ -29,8 +29,13 @@
 {%- endmacro %}
 
 
-{% macro boolean(value='') -%}
+{% macro radios(value='') -%}
   {{ value }}
+{%- endmacro %}
+
+
+{% macro boolean(value='') -%}
+  {{ 'Yes' if value else 'No' }}
 {%- endmacro %}
 
 

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -51,29 +51,31 @@
   <input type="file" name="{{ question.id }}" id="{{ question.id }}-file-upload" />
 {%- endmacro %}
 
-{% macro radio(field, value='', service_data) -%}
-  {{ selection_button("radio", field, value) }}
-{%- endmacro %}
+{% macro radios(question, value='', service_data) -%}
+  {% for option in question.options %}
+    {{ _selection_button("radio", question.id, option.label, service_data) }}
+  {% endfor %}
+{%- endmacro%}
 
-{% macro checkbox(field, value='', service_data) -%}
-  {{ selection_button("radio", field, value) }}
-{%- endmacro %}
-
-{% macro selection_button(type, field, value='', service_data) -%}
+{% macro _selection_button(type, name, label, service_data) -%}
   <label class="selection-button">
-    {{ field.label }}
-    <input type="{{ type }}" name="{{ field.name }}" id="{{ field.name }}" value="{{ value }}">
+    {{ label }}
+    <input
+      type="{{ type }}" name="{{ name }}"
+      value="{{ label }}"
+      {{ 'checked="checked"' if service_data[name] == label }}
+    />
   </label>
 {%- endmacro %}
 
-{% macro boolean(field, value='', service_data) -%}
-  <label class="selection-button selection-button-boolean">
+{% macro boolean(question, value='', service_data) -%}
+  <label class="selection-button selection-button-boolean" for="{{question.id}}-yes">
     Yes
-    <input type="radio" name="boolean-1" id="boolean-1" value="val-1">
+    <input type="radio" name="{{question.id}}" id="{{question.id}}-yes" value="True" {{ 'checked="checked"' if value }}>
   </label>
-  <label class="selection-button selection-button-boolean">
+  <label class="selection-button selection-button-boolean" for="{{question.id}}-no">
     No
-    <input type="radio" name="boolean-1" id="boolean-1" value="val-1">
+    <input type="radio" name="{{question.id}}" id="{{question.id}}-no" value="False" {{ 'checked="checked"' if not value }}>
   </label>
 {%- endmacro %}
 

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v2.0.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v2.0.4",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#973f540",
     "hogan": "3.0.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.4.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.4.1#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/helpers/test_validation_tools.py
+++ b/tests/app/main/helpers/test_validation_tools.py
@@ -87,6 +87,27 @@ class TestValidate(unittest.TestCase):
         )
         self.assertEquals(self.validate.errors, {})
 
+    def test_validate_required_boolean_gets_type(self):
+        self.set_question(
+            'q1', 'False',
+            {
+                'type': 'boolean',
+                'validations': [{
+                    'name': 'answer_required', 'message': ''
+                }]
+            }
+        )
+        self.set_question(
+            'q2', 'True',
+            {
+                'type': 'boolean',
+                'validations': [{
+                    'name': 'answer_required', 'message': ''
+                }]
+            }
+        )
+        self.assertEquals(self.validate.clean_data, {'q1': False, 'q2': True})
+
     def test_validate_text_without_validators(self):
         self.set_question(
             'q1', 'value',

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -125,6 +125,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         data_api_client.get_service.return_value = {
             'id': 1,
             'supplierId': 2,
+            'lot': 'SCS',
             'serviceDefinitionDocumentURL': "http://assets/documents/1/2-service-definition.pdf",  # noqa
             'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
             'sfiaRateDocumentURL': None


### PR DESCRIPTION
This pull request allows an admin user to edit the following fields:
- price includes VAT
- education pricing
- termination cost
- trial option
- free option
- minimum contract period

In doing so it fulfils https://www.pivotaltracker.com/story/show/92217036

![image](https://cloud.githubusercontent.com/assets/355079/7428655/38f650e0-efec-11e4-8236-6b96e73ab04d.png)

![image](https://cloud.githubusercontent.com/assets/355079/7428653/335ac53a-efec-11e4-8aec-f926bf75be4e.png)