### PR TITLE
Pull `_status` route error handling into dmutils.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Create a virtual environment
 Set the required environment variables (for dev use local API instance if you
 have it running):
 ```
-export DM_API_URL=http://localhost:5000
-export DM_ADMIN_FRONTEND_API_AUTH_TOKEN=<bearer_token>
+export DM_DATA_API_URL=http://localhost:5000
+export DM_DATA_API_AUTH_TOKEN=<bearer_token>
 export DM_ADMIN_FRONTEND_PASSWORD_HASH=<generated password hash>
 ```
 You can generate a password hash by running `python ./scripts/generate_password.py`.

--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,5 +1,4 @@
 import os
-from dmutils.apiclient import ConnectionError
 
 
 def get_version_label():
@@ -10,18 +9,3 @@ def get_version_label():
             return f.read().strip()
     except IOError:
         return None
-
-
-def return_response_from_api_status_call(api_status_call):
-
-    try:
-        return api_status_call()
-
-    except ConnectionError:
-        pass
-
-    return None
-
-
-def return_json_or_none(response):
-    return None if response is None else response.json()

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,4 +1,4 @@
-from flask import jsonify, current_app
+from flask import jsonify
 
 from .. import data_api_client
 from . import status
@@ -8,32 +8,18 @@ from . import utils
 @status.route('/_status')
 def status():
 
-    api_response = utils.return_response_from_api_status_call(
-        data_api_client.get_status
-    )
+    status = data_api_client.get_status()
 
-    apis_with_errors = []
-
-    if api_response is None or api_response.status_code != 200:
-        apis_with_errors.append("(Data) API")
-
-    # if no errors found, return everything
-    if not apis_with_errors:
+    if status['status'] == "ok":
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
-            api_status=api_response.json(),
+            api_status=status,
         )
-
-    message = "Error connecting to the {}.".format(
-        " and the ".join(apis_with_errors)
-    )
-
-    current_app.logger.error(message)
 
     return jsonify(
         status="error",
         version=utils.get_version_label(),
-        api_status=utils.return_json_or_none(api_response),
-        message=message,
+        api_status=status,
+        message="Error connecting to the (Data) API.",
     ), 500

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.5.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.6.0#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -6,8 +6,8 @@ else
 fi
 
 # Use default environment vars for localhost if not already set
-export DM_API_URL=${DM_API_URL:=http://localhost:5000}
-export DM_ADMIN_FRONTEND_API_AUTH_TOKEN=${DM_ADMIN_FRONTEND_API_AUTH_TOKEN:=myToken}
+export DM_DATA_API_URL=${DM_DATA_API_URL:=http://localhost:5000}
+export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
 # Default hash for user/pass combo: admin/admin
 export DM_ADMIN_FRONTEND_PASSWORD_HASH=${DM_ADMIN_FRONTEND_PASSWORD_HASH:=JHA1azIkMjcxMCQxYjM5Y2JhY2RkYTY0OWMwYjdhMGU1MWU4MjQ5ODZlYSQ2VkNuM1I3dXNXYW8zY3dWZmRzVHFBck10Tzh0cWRBLg==}
 export DM_ADMIN_FRONTEND_COOKIE_SECRET=${DM_ADMIN_FRONTEND_COOKIE_SECRET:=secret}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,8 +6,8 @@
 # ./scripts/run_tests.sh
 
 # Use default environment vars for localhost if not already set
-export DM_API_URL=${DM_API_URL:=http://localhost:5000}
-export DM_ADMIN_FRONTEND_API_AUTH_TOKEN=${DM_ADMIN_FRONTEND_API_AUTH_TOKEN:=myToken}
+export DM_DATA_API_URL=${DM_DATA_API_URL:=http://localhost:5000}
+export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
 export DM_ENVIRONMENT="test"
 
 echo "Environment variables in use:"

--- a/tests/app/status/test_views.py
+++ b/tests/app/status/test_views.py
@@ -1,5 +1,4 @@
 from flask import json
-from requests import Response
 import mock
 
 from ..helpers import BaseApplicationTest
@@ -9,15 +8,8 @@ class TestStatus(BaseApplicationTest):
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_ok(self, data_api_client):
-        response = Response()
-        response.status_code = 200
-        response._content = json.dumps({
-            'status': 'ok',
-            'app_version': None,
-            'api_status': 'ok'
-        }).encode('utf-8')
 
-        data_api_client.get_status.return_value = response
+        data_api_client.get_status.return_value = {"status": "ok"}
 
         response = self.client.get('/_status')
         self.assertEquals(200, response.status_code)
@@ -30,16 +22,12 @@ class TestStatus(BaseApplicationTest):
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_error(self, data_api_client):
-        response = Response()
-        response.status_code = 500
-        response._content = json.dumps({
+
+        data_api_client.get_status.return_value = {
             'status': 'error',
             'app_version': None,
             'message': 'Cannot connect to (Data) API'
-        }).encode('utf-8')
-
-        # set up the service_loader to return a 500 status-code response
-        data_api_client.get_status.return_value = response
+        }
 
         response = self.client.get('/_status')
         self.assertEquals(500, response.status_code)


### PR DESCRIPTION
API Client now handles exceptions and errors, meaning that _status routes for our frontend apps don't need as much logic.

Also, removed references to `DM_API_URL` which are no longer needed and updated dmutils tag.