### PR TITLE
[#94078878] Not able to save features and benefits with only one feature or one benefit.

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -100,7 +100,7 @@ def update(service_id, section):
     # Turn responses which have multiple parts into lists
     for key in request.form:
         item_as_list = request.form.getlist(key)
-        if len(item_as_list) > 1:
+        if content.get_question(key)['type'] == 'list':
             posted_data[key] = item_as_list
 
     form = Validate(content, service_data, posted_data, s3_uploader)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -59,7 +59,7 @@ def find():
 @main.route('/service/<service_id>')
 def view(service_id):
     try:
-        service_data = data_api_client.get_service(service_id)
+        service_data = data_api_client.get_service(service_id)['services']
     except APIError as e:
         abort(e.response.status_code)
 
@@ -81,7 +81,7 @@ def view(service_id):
 def edit(service_id, section):
     template_data = get_template_data({
         "section": content.get_section(section),
-        "service_data": data_api_client.get_service(service_id),
+        "service_data": data_api_client.get_service(service_id)['services'],
     })
     return render_template("edit_section.html", **template_data)
 
@@ -92,7 +92,7 @@ def update(service_id, section):
         bucket_name=main.config['S3_DOCUMENT_BUCKET'],
     )
 
-    service_data = data_api_client.get_service(service_id)
+    service_data = data_api_client.get_service(service_id)['services']
     posted_data = dict(
         list(request.form.items()) + list(request.files.items())
     )

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -100,7 +100,8 @@ def update(service_id, section):
     # Turn responses which have multiple parts into lists
     for key in request.form:
         item_as_list = request.form.getlist(key)
-        if content.get_question(key)['type'] == 'list':
+        list_types = ['list', 'checkboxes', 'pricing']
+        if content.get_question(key)['type'] in list_types:
             posted_data[key] = item_as_list
 
     form = Validate(content, service_data, posted_data, s3_uploader)

--- a/app/templates/macros/answers.html
+++ b/app/templates/macros/answers.html
@@ -59,6 +59,6 @@
       {% endfor %}
     </ul>
   {% else %}
-    {{ value }}
+    {{ value.0 }}
   {% endif %}
 {%- endmacro %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.6.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.9.0#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -161,6 +161,32 @@ class TestServiceEdit(LoggedInApplicationTest):
         self.assertEquals(200, response.status_code)
 
     @mock.patch('app.main.views.data_api_client')
+    def test_service_edit_with_one_service_feature(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'id': 1,
+            'supplierId': 2,
+            'lot': 'SCS',
+            'serviceFeatures': [
+                "foo",
+            ],
+            'serviceBenefits': [
+                "foo",
+            ],
+        }}
+        response = self.client.post(
+            '/admin/service/1/edit/features_and_benefits',
+            data={
+                'serviceFeatures': 'foo',
+                'serviceBenefits': 'foo',
+            }
+        )
+        data_api_client.update_service.assert_called_with(1, {
+            'serviceFeatures': ['foo'],
+            'serviceBenefits': ['foo'],
+        }, 'admin', 'admin app')
+        self.assertEquals(response.status_code, 302)
+
+    @mock.patch('app.main.views.data_api_client')
     def test_service_edit_when_API_returns_error(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -57,7 +57,7 @@ class TestApplication(LoggedInApplicationTest):
 class TestServiceView(LoggedInApplicationTest):
     @mock.patch('app.main.views.data_api_client')
     def test_service_response(self, data_api_client):
-        data_api_client.get_service.return_value = {}
+        data_api_client.get_service.return_value = {'services': {}}
         response = self.client.get('/admin/service/1')
 
         data_api_client.get_service.assert_called_with('1')
@@ -78,6 +78,7 @@ class TestServiceView(LoggedInApplicationTest):
 class TestServiceEdit(LoggedInApplicationTest):
     @mock.patch('app.main.views.data_api_client')
     def test_service_edit_documents_get_response(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {}}
         response = self.client.get('/admin/service/1/edit/documents')
 
         data_api_client.get_service.assert_called_with('1')
@@ -86,10 +87,10 @@ class TestServiceEdit(LoggedInApplicationTest):
 
     @mock.patch('app.main.views.data_api_client')
     def test_service_edit_documents_empty_post(self, data_api_client):
-        data_api_client.get_service.return_value = {
+        data_api_client.get_service.return_value = {'services': {
             'id': 1,
             'supplierId': 2,
-        }
+        }}
         response = self.client.post(
             '/admin/service/1/edit/documents',
             data={}
@@ -103,14 +104,14 @@ class TestServiceEdit(LoggedInApplicationTest):
 
     @mock.patch('app.main.views.data_api_client')
     def test_service_edit_documents_post(self, data_api_client):
-        data_api_client.get_service.return_value = {
+        data_api_client.get_service.return_value = {'services': {
             'id': 1,
             'supplierId': 2,
             'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
             'serviceDefinitionDocumentURL': "http://assets/documents/1/2-service-definition.pdf",  # noqa
             'termsAndConditionsDocumentURL': "http://assets/documents/1/2-terms-and-conditions.pdf",  # noqa
             'sfiaRateDocumentURL': None
-        }
+        }}
         response = self.client.post(
             '/admin/service/1/edit/documents',
             data={
@@ -132,14 +133,14 @@ class TestServiceEdit(LoggedInApplicationTest):
     @mock.patch("app.main.views.data_api_client")
     def test_service_edit_documents_post_with_validation_errors(
             self, data_api_client):
-        data_api_client.get_service.return_value = {
+        data_api_client.get_service.return_value = {'services': {
             'id': 1,
             'supplierId': 2,
             'lot': 'SCS',
             'serviceDefinitionDocumentURL': "http://assets/documents/1/2-service-definition.pdf",  # noqa
             'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
             'sfiaRateDocumentURL': None
-        }
+        }}
         response = self.client.post(
             '/admin/service/1/edit/documents',
             data={
@@ -161,12 +162,12 @@ class TestServiceEdit(LoggedInApplicationTest):
 
     @mock.patch('app.main.views.data_api_client')
     def test_service_edit_when_API_returns_error(self, data_api_client):
-        data_api_client.get_service.return_value = {
+        data_api_client.get_service.return_value = {'services': {
             'id': 1,
             'supplierId': 2,
             'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
             'sfiaRateDocumentURL': None
-        }
+        }}
         error = mock.Mock()
         error.response.content = "API ERROR"
         data_api_client.update_service.side_effect = APIError(error)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/94078878

This also fixes how the API client response is being used. The client now returns the entire response object. This feels a bit clunky but it is how the API is currently returning. I'm going to look at returning a response object that gives access to the metadata and links while giving access to the data in a more natural way.