### PR TITLE
[Fixes 94480244] 500 error on G5 service

### DIFF
--- a/app/templates/macros/answers.html
+++ b/app/templates/macros/answers.html
@@ -58,7 +58,7 @@
         </li>
       {% endfor %}
     </ul>
-  {% else %}
+  {% elif value|length == 1 %}
     {{ value.0 }}
   {% endif %}
 {%- endmacro %}

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -180,6 +180,6 @@
     <label for='{{ name }}-item-{{ number }}' class='text-box-number-label'>
       <span class='visuallyhidden'>{{ list_item_name }} number </span>{{ number }}.
     </label>
-    <input type='text' name='{{ name }}' id='{{ input_name }}-item-{{ number }}' class='text-box' value="{{ values[index] }}" />
+    <input type='text' name='{{ name }}' id='{{ input_name }}-item-{{ number }}' class='text-box' value="{% if index in values %}{{ values[index] }}{% endif %}" />
   </div>
 {% endmacro %}

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -65,6 +65,17 @@ class TestServiceView(LoggedInApplicationTest):
         self.assertEquals(200, response.status_code)
 
     @mock.patch('app.main.views.data_api_client')
+    def test_service_view_with_no_features_or_benefits(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'lot': 'IaaS',
+        }}
+        response = self.client.get('/admin/service/1')
+
+        data_api_client.get_service.assert_called_with('1')
+
+        self.assertEquals(200, response.status_code)
+
+    @mock.patch('app.main.views.data_api_client')
     def test_responds_with_404_for_api_client_404(self, data_api_client):
         error = mock.Mock()
         error.response.status_code = 404
@@ -185,6 +196,18 @@ class TestServiceEdit(LoggedInApplicationTest):
             'serviceBenefits': ['foo'],
         }, 'admin', 'admin app')
         self.assertEquals(response.status_code, 302)
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_service_edit_with_no_features_or_benefits(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'lot': 'IaaS',
+        }}
+        response = self.client.get(
+            '/admin/service/1/edit/features_and_benefits')
+
+        data_api_client.get_service.assert_called_with('1')
+
+        self.assertEquals(200, response.status_code)
 
     @mock.patch('app.main.views.data_api_client')
     def test_service_edit_when_API_returns_error(self, data_api_client):


### PR DESCRIPTION
Only try to display answers if there are any. We were getting index out
of range errors because there were no features or benefits.