### PR TITLE
Bump DM utils to 0.10.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.9.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.10.2#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
https://github.com/alphagov/digitalmarketplace-utils/compare/0.9.0...0.10.2

Changes are mostly bug fixes or for the buyers app.