### PR TITLE
Change URLs from /service to /services

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -50,13 +50,13 @@ def logout():
     return redirect(url_for('.login', logged_out=''))
 
 
-@main.route('/service')
+@main.route('/services')
 def find():
     return redirect(
         url_for(".view", service_id=request.args.get("service_id")))
 
 
-@main.route('/service/<service_id>')
+@main.route('/services/<service_id>')
 def view(service_id):
     try:
         service_data = data_api_client.get_service(service_id)['services']
@@ -77,7 +77,7 @@ def view(service_id):
     return render_template("view_service.html", **template_data)
 
 
-@main.route('/service/<service_id>/edit/<section>')
+@main.route('/services/<service_id>/edit/<section>')
 def edit(service_id, section):
     template_data = get_template_data({
         "section": content.get_section(section),
@@ -86,7 +86,7 @@ def edit(service_id, section):
     return render_template("edit_section.html", **template_data)
 
 
-@main.route('/service/<service_id>/edit/<section>', methods=['POST'])
+@main.route('/services/<service_id>/edit/<section>', methods=['POST'])
 def update(service_id, section):
     s3_uploader = S3(
         bucket_name=main.config['S3_DOCUMENT_BUCKET'],

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -58,7 +58,7 @@ class TestServiceView(LoggedInApplicationTest):
     @mock.patch('app.main.views.data_api_client')
     def test_service_response(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {}}
-        response = self.client.get('/admin/service/1')
+        response = self.client.get('/admin/services/1')
 
         data_api_client.get_service.assert_called_with('1')
 
@@ -69,7 +69,7 @@ class TestServiceView(LoggedInApplicationTest):
         data_api_client.get_service.return_value = {'services': {
             'lot': 'IaaS',
         }}
-        response = self.client.get('/admin/service/1')
+        response = self.client.get('/admin/services/1')
 
         data_api_client.get_service.assert_called_with('1')
 
@@ -81,7 +81,7 @@ class TestServiceView(LoggedInApplicationTest):
         error.response.status_code = 404
         data_api_client.get_service.side_effect = APIError(error)
 
-        response = self.client.get('/admin/service/1')
+        response = self.client.get('/admin/services/1')
 
         self.assertEquals(404, response.status_code)
 
@@ -90,7 +90,7 @@ class TestServiceEdit(LoggedInApplicationTest):
     @mock.patch('app.main.views.data_api_client')
     def test_service_edit_documents_get_response(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {}}
-        response = self.client.get('/admin/service/1/edit/documents')
+        response = self.client.get('/admin/services/1/edit/documents')
 
         data_api_client.get_service.assert_called_with('1')
 
@@ -103,7 +103,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'supplierId': 2,
         }}
         response = self.client.post(
-            '/admin/service/1/edit/documents',
+            '/admin/services/1/edit/documents',
             data={}
         )
 
@@ -111,7 +111,9 @@ class TestServiceEdit(LoggedInApplicationTest):
         self.assertFalse(data_api_client.update_service.called)
 
         self.assertEquals(302, response.status_code)
-        self.assertEquals("/admin/service/1", urlsplit(response.location).path)
+        self.assertEquals(
+            "/admin/services/1", urlsplit(response.location).path
+        )
 
     @mock.patch('app.main.views.data_api_client')
     def test_service_edit_documents_post(self, data_api_client):
@@ -124,7 +126,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'sfiaRateDocumentURL': None
         }}
         response = self.client.post(
-            '/admin/service/1/edit/documents',
+            '/admin/services/1/edit/documents',
             data={
                 'serviceDefinitionDocumentURL': (StringIO(), ''),
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
@@ -153,7 +155,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'sfiaRateDocumentURL': None
         }}
         response = self.client.post(
-            '/admin/service/1/edit/documents',
+            '/admin/services/1/edit/documents',
             data={
                 'serviceDefinitionDocumentURL': (StringIO(), ''),
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
@@ -185,7 +187,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             ],
         }}
         response = self.client.post(
-            '/admin/service/1/edit/features_and_benefits',
+            '/admin/services/1/edit/features_and_benefits',
             data={
                 'serviceFeatures': 'foo',
                 'serviceBenefits': 'foo',
@@ -203,7 +205,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'lot': 'IaaS',
         }}
         response = self.client.get(
-            '/admin/service/1/edit/features_and_benefits')
+            '/admin/services/1/edit/features_and_benefits')
 
         data_api_client.get_service.assert_called_with('1')
 
@@ -222,7 +224,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         data_api_client.update_service.side_effect = APIError(error)
 
         response = self.client.post(
-            '/admin/service/1/edit/documents',
+            '/admin/services/1/edit/documents',
             data={
                 'pricingDocumentURL': (StringIO(b"doc"), 'test.pdf'),
                 'sfiaRateDocumentURL': (StringIO(b"doc"), 'test.txt'),


### PR DESCRIPTION
This changes the admin app's URLs to match those of the buyer app, supplier app and the data API.

Old                                 | New
------------------------------------|------------------------------------
`/admin/service/123`                  | `/admin/services/123`
`/admin/service/123/edit/documents`   | `/admin/services/123/edit/documents`

No redirects should be required because:
- the app is not public-facing or indexed by Google
- it only has one user, currently 