### PR TITLE
Admin deactivate a service

### DIFF
--- a/app/main/helpers/presenters.py
+++ b/app/main/helpers/presenters.py
@@ -18,7 +18,7 @@ class Presenters(object):
             return value
 
     def _service_id(self, value):
-        if re.findall("[a-zA-Z]", value):
+        if re.findall("[a-zA-Z]", str(value)):
             return [value]
         else:
             return re.findall("....", str(value))

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,4 +1,5 @@
-from flask import flash, render_template, request, redirect, session, url_for
+from flask import flash, render_template, request, redirect, session, url_for, \
+    current_app
 from dmutils.apiclient import APIError
 
 from .. import data_api_client
@@ -17,7 +18,7 @@ content = ContentLoader(
 presenters = Presenters()
 
 
-@main.route('/')
+@main.route('/', methods=['GET'])
 def index():
     return render_template("index.html", **get_template_data())
 
@@ -44,19 +45,19 @@ def login():
     }))
 
 
-@main.route('/logout')
+@main.route('/logout', methods=['GET'])
 def logout():
     session.pop('username', None)
     return redirect(url_for('.login', logged_out=''))
 
 
-@main.route('/services')
+@main.route('/services', methods=['GET'])
 def find():
     return redirect(
         url_for(".view", service_id=request.args.get("service_id")))
 
 
-@main.route('/services/<service_id>')
+@main.route('/services/<service_id>', methods=['GET'])
 def view(service_id):
     try:
         service = data_api_client.get_service(service_id)
@@ -109,11 +110,14 @@ def update_service_status(service_id):
         flash({'api_error': e.message}, 'error')
         return redirect(url_for('.view', service_id=service_id))
 
+    message = "admin.status.updated: " \
+              "Service ID %s updated to '%s'"
+    current_app.logger.info(message, service_id, frontend_status)
     flash({'status_updated': frontend_status})
     return redirect(url_for('.view', service_id=service_id))
 
 
-@main.route('/services/<service_id>/edit/<section>')
+@main.route('/services/<service_id>/edit/<section>', methods=['GET'])
 def edit(service_id, section):
     template_data = get_template_data({
         "section": content.get_section(section),

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,7 +1,6 @@
-from dmutils.apiclient import APIError, HTTPError
-
 from flask import current_app, flash, render_template, request, redirect, \
     session, url_for
+from dmutils.apiclient import HTTPError
 
 from .. import data_api_client
 from . import main
@@ -107,7 +106,7 @@ def update_service_status(service_id):
             "Digital Marketplace admin user", "Status changed to '{0}'".format(
                 backend_status))
 
-    except APIError as e:
+    except HTTPError as e:
         flash({'api_error': e.message}, 'error')
         return redirect(url_for('.view', service_id=service_id))
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, redirect, session, url_for, abort
+from flask import flash, render_template, request, redirect, session, url_for
 from dmutils.apiclient import APIError
 
 from .. import data_api_client
@@ -59,9 +59,14 @@ def find():
 @main.route('/services/<service_id>')
 def view(service_id):
     try:
-        service_data = data_api_client.get_service(service_id)['services']
-    except APIError as e:
-        abort(e.response.status_code)
+        service = data_api_client.get_service(service_id)
+        if service is None:
+            flash({'no_service': service_id}, 'error')
+            return redirect(url_for('.index'))
+        service_data = service['services']
+    except APIError:
+        flash({'api_error': service_id}, 'error')
+        return redirect(url_for('.index'))
 
     presented_service_data = {}
     for key, value in service_data.items():

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,6 +7,27 @@
 
 {% block content %}
 <div class="page-container">
+    
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+{% for category, message in messages %}
+{% if category == 'error' %}
+    <div class="banner-destructive-without-action">
+    {% else %}
+    <div class="banner-success-without-action">
+        {% endif %}
+        <p class="banner-message">
+            {% if message['no_service'] %}
+            Could not find a service with ID: {{ message['no_service'] }}
+            {% elif message['api_error'] %}
+            Error trying to retrieve service with ID: {{ message['api_error'] }}
+            {% endif %}
+        </p>
+        {% endfor %}
+    </div>
+{% endif %}
+{% endwith %}
+    
   {{ page_heading("Find a service") }}
   <form action="{{ url_for('.find') }}" method="get" class="question">
       <label class="question-heading" for="service_id">Service ID</label>

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -10,6 +10,29 @@
 {% block content %}
   {{ breadcrumb() }}
   <div class="page-container">
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+{% for category, message in messages %}
+    {% if category == 'error' %}
+        <div class="banner-destructive-without-action">
+    {% else %}
+        <div class="banner-success-without-action">
+    {% endif %}
+      <p class="banner-message">
+          {% if message['bad_status'] %}
+          Not a valid status: '{{ message['bad_status'] }}'
+          {% elif message['api_error'] %}
+          Error trying to update status of service: {{ message['api_error'] }}
+          {% elif message['status_updated'] %}
+          Service status has been updated to: {{ message['status_updated']|title }}
+          {% endif %}
+      </p>
+      {% endfor %}
+  </div>
+  {% endif %}
+  {% endwith %}
+          
     {% if service_data %}
       <div class="grid-row">
         <div class="service-title">
@@ -51,6 +74,29 @@
           </table>
         {% endif %}
       {% endfor %}
+
+      <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="POST">
+          <fieldset class="question">
+              <legend class="question-heading">
+                  Service status
+              </legend>
+              <label class="selection-button">
+                  <input type="radio" name="service_status" id="service_status_disabled" value="removed" {{'checked="checked"' if service_data['status'] == 'disabled' }} />
+                  Removed
+              </label>
+              <label class="selection-button">
+                  <input type="radio" name="service_status" id="service_status_private" value="private" {{'checked="checked"' if service_data['status'] == 'enabled' }} />
+                  Private
+              </label>
+              {% if service_data.status != 'disabled' %}
+              <label class="selection-button">
+                  <input type="radio" name="service_status" id="service_status_published" value="public" {{'checked="checked"' if service_data['status'] == 'published' }} />
+                  Public
+              </label>
+              {% endif %}
+          </fieldset>
+          <button type="submit" class="button-save">Update status</button>
+      </form>
 
     {% else %}
     <h1>Error</h1>

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -81,16 +81,16 @@
                   Service status
               </legend>
               <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_disabled" value="removed" {{'checked="checked"' if service_data['status'] == 'disabled' }} />
+                  <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service_data['status'] == 'disabled' %}checked="checked"{% endif %} />
                   Removed
               </label>
               <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_private" value="private" {{'checked="checked"' if service_data['status'] == 'enabled' }} />
+                  <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
                   Private
               </label>
               {% if service_data.status != 'disabled' %}
               <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_published" value="public" {{'checked="checked"' if service_data['status'] == 'published' }} />
+                  <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
                   Public
               </label>
               {% endif %}

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -85,7 +85,7 @@ class TestServiceView(LoggedInApplicationTest):
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location, 'http://localhost/admin/')
         response2 = self.client.get(response1.location)
-        self.assertIn("Error trying to retrieve service with ID: 1",
+        self.assertIn(b'Error trying to retrieve service with ID: 1',
                       response2.data)
 
 
@@ -246,9 +246,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'status': 'disabled'
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed" checked="checked" />', response.data)  # noqa
-        self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
-        self.assertNotIn('<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_disabled" value="removed" checked="checked" />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
+        self.assertNotIn(b'<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
 
     @mock.patch('app.main.views.data_api_client')
     def test_can_make_private_service_public_or_removed(self, data_api_client):
@@ -258,9 +258,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'status': 'enabled'
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
-        self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked" />', response.data)  # noqa
-        self.assertIn('<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked" />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
 
     @mock.patch('app.main.views.data_api_client')
     def test_can_make_public_service_private_or_removed(self, data_api_client):
@@ -270,9 +270,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'status': 'published'
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
-        self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
-        self.assertIn('<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
+        self.assertIn(b'<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />', response.data)  # noqa
 
     @mock.patch('app.main.views.data_api_client')
     def test_status_update_to_removed(self, data_api_client):
@@ -286,7 +286,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         self.assertEquals(response1.location,
                           'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
-        self.assertIn("Service status has been updated to: Removed",
+        self.assertIn(b'Service status has been updated to: Removed',
                       response2.data)
 
     @mock.patch('app.main.views.data_api_client')
@@ -301,7 +301,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         self.assertEquals(response1.location,
                           'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
-        self.assertIn("Service status has been updated to: Private",
+        self.assertIn(b'Service status has been updated to: Private',
                       response2.data)
 
     @mock.patch('app.main.views.data_api_client')
@@ -316,7 +316,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         self.assertEquals(response1.location,
                           'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
-        self.assertIn("Service status has been updated to: Public",
+        self.assertIn(b'Service status has been updated to: Public',
                       response2.data)
 
     @mock.patch('app.main.views.data_api_client')
@@ -327,5 +327,5 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         self.assertEquals(response1.location,
                           'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
-        self.assertIn("Not a valid status: 'suspended'",
+        self.assertIn(b"Not a valid status: 'suspended'",
                       response2.data)

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -76,11 +76,7 @@ class TestServiceView(LoggedInApplicationTest):
         self.assertEquals(200, response.status_code)
 
     @mock.patch('app.main.views.data_api_client')
-    # def test_redirect_with_flash_for_api_client_404(self, data_api_client):
-    # error = mock.Mock()
-    # error.response.status_code = 404
-    # data_api_client.get_service.side_effect = APIError(error)
-    def test_responds_with_404_for_api_client_404(self, data_api_client):
+    def test_redirect_with_flash_for_api_client_404(self, data_api_client):
         response = mock.Mock()
         response.status_code = 404
         data_api_client.get_service.side_effect = HTTPError(response)

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -76,14 +76,17 @@ class TestServiceView(LoggedInApplicationTest):
         self.assertEquals(200, response.status_code)
 
     @mock.patch('app.main.views.data_api_client')
-    def test_responds_with_404_for_api_client_404(self, data_api_client):
+    def test_redirect_with_flash_for_api_client_404(self, data_api_client):
         error = mock.Mock()
         error.response.status_code = 404
         data_api_client.get_service.side_effect = APIError(error)
 
-        response = self.client.get('/admin/services/1')
-
-        self.assertEquals(404, response.status_code)
+        response1 = self.client.get('/admin/service/1')
+        self.assertEquals(302, response1.status_code)
+        self.assertEquals(response1.location, 'http://localhost/admin/')
+        response2 = self.client.get(response1.location)
+        self.assertIn("Error trying to retrieve service with ID: 1",
+                      response2.data)
 
 
 class TestServiceEdit(LoggedInApplicationTest):
@@ -232,3 +235,97 @@ class TestServiceEdit(LoggedInApplicationTest):
             }
         )
         self.assertIn(b'API ERROR', response.data)
+
+
+class TestServiceStatusUpdate(LoggedInApplicationTest):
+    @mock.patch('app.main.views.data_api_client')
+    def test_cannot_make_removed_service_public(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'id': 1,
+            'supplierId': 2,
+            'status': 'disabled'
+        }}
+        response = self.client.get('/admin/service/1')
+        self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed" checked="checked" />', response.data)  # noqa
+        self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
+        self.assertNotIn('<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_can_make_private_service_public_or_removed(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'id': 1,
+            'supplierId': 2,
+            'status': 'enabled'
+        }}
+        response = self.client.get('/admin/service/1')
+        self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
+        self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked" />', response.data)  # noqa
+        self.assertIn('<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_can_make_public_service_private_or_removed(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'id': 1,
+            'supplierId': 2,
+            'status': 'published'
+        }}
+        response = self.client.get('/admin/service/1')
+        self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
+        self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
+        self.assertIn('<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />', response.data)  # noqa
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_status_update_to_removed(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {}}
+        response1 = self.client.post('/admin/service/status/1',
+                                     data={'service_status': 'removed'})
+        data_api_client.update_service_status.assert_called_with(
+            '1', 'disabled', 'Digital Marketplace admin user',
+            "Status changed to 'disabled'")
+        self.assertEquals(302, response1.status_code)
+        self.assertEquals(response1.location,
+                          'http://localhost/admin/service/1')
+        response2 = self.client.get(response1.location)
+        self.assertIn("Service status has been updated to: Removed",
+                      response2.data)
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_status_update_to_private(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {}}
+        response1 = self.client.post('/admin/service/status/1',
+                                     data={'service_status': 'private'})
+        data_api_client.update_service_status.assert_called_with(
+            '1', 'enabled', 'Digital Marketplace admin user',
+            "Status changed to 'enabled'")
+        self.assertEquals(302, response1.status_code)
+        self.assertEquals(response1.location,
+                          'http://localhost/admin/service/1')
+        response2 = self.client.get(response1.location)
+        self.assertIn("Service status has been updated to: Private",
+                      response2.data)
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_status_update_to_published(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {}}
+        response1 = self.client.post('/admin/service/status/1',
+                                     data={'service_status': 'public'})
+        data_api_client.update_service_status.assert_called_with(
+            '1', 'published', 'Digital Marketplace admin user',
+            "Status changed to 'published'")
+        self.assertEquals(302, response1.status_code)
+        self.assertEquals(response1.location,
+                          'http://localhost/admin/service/1')
+        response2 = self.client.get(response1.location)
+        self.assertIn("Service status has been updated to: Public",
+                      response2.data)
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_bad_status_gives_error_message(self, data_api_client):
+        response1 = self.client.post('/admin/service/status/1',
+                                     data={'service_status': 'suspended'})
+        self.assertEquals(302, response1.status_code)
+        self.assertEquals(response1.location,
+                          'http://localhost/admin/service/1')
+        response2 = self.client.get(response1.location)
+        self.assertIn("Not a valid status: 'suspended'",
+                      response2.data)

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -81,7 +81,7 @@ class TestServiceView(LoggedInApplicationTest):
         error.response.status_code = 404
         data_api_client.get_service.side_effect = APIError(error)
 
-        response1 = self.client.get('/admin/service/1')
+        response1 = self.client.get('/admin/services/1')
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location, 'http://localhost/admin/')
         response2 = self.client.get(response1.location)
@@ -245,7 +245,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'supplierId': 2,
             'status': 'disabled'
         }}
-        response = self.client.get('/admin/service/1')
+        response = self.client.get('/admin/services/1')
         self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed" checked="checked" />', response.data)  # noqa
         self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
         self.assertNotIn('<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
@@ -257,7 +257,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'supplierId': 2,
             'status': 'enabled'
         }}
-        response = self.client.get('/admin/service/1')
+        response = self.client.get('/admin/services/1')
         self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
         self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked" />', response.data)  # noqa
         self.assertIn('<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
@@ -269,7 +269,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'supplierId': 2,
             'status': 'published'
         }}
-        response = self.client.get('/admin/service/1')
+        response = self.client.get('/admin/services/1')
         self.assertIn('<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
         self.assertIn('<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
         self.assertIn('<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />', response.data)  # noqa
@@ -277,14 +277,14 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     @mock.patch('app.main.views.data_api_client')
     def test_status_update_to_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {}}
-        response1 = self.client.post('/admin/service/status/1',
+        response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'removed'})
         data_api_client.update_service_status.assert_called_with(
             '1', 'disabled', 'Digital Marketplace admin user',
             "Status changed to 'disabled'")
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
-                          'http://localhost/admin/service/1')
+                          'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
         self.assertIn("Service status has been updated to: Removed",
                       response2.data)
@@ -292,14 +292,14 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     @mock.patch('app.main.views.data_api_client')
     def test_status_update_to_private(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {}}
-        response1 = self.client.post('/admin/service/status/1',
+        response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'private'})
         data_api_client.update_service_status.assert_called_with(
             '1', 'enabled', 'Digital Marketplace admin user',
             "Status changed to 'enabled'")
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
-                          'http://localhost/admin/service/1')
+                          'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
         self.assertIn("Service status has been updated to: Private",
                       response2.data)
@@ -307,25 +307,25 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     @mock.patch('app.main.views.data_api_client')
     def test_status_update_to_published(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {}}
-        response1 = self.client.post('/admin/service/status/1',
+        response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'public'})
         data_api_client.update_service_status.assert_called_with(
             '1', 'published', 'Digital Marketplace admin user',
             "Status changed to 'published'")
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
-                          'http://localhost/admin/service/1')
+                          'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
         self.assertIn("Service status has been updated to: Public",
                       response2.data)
 
     @mock.patch('app.main.views.data_api_client')
     def test_bad_status_gives_error_message(self, data_api_client):
-        response1 = self.client.post('/admin/service/status/1',
+        response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'suspended'})
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
-                          'http://localhost/admin/service/1')
+                          'http://localhost/admin/services/1')
         response2 = self.client.get(response1.location)
         self.assertIn("Not a valid status: 'suspended'",
                       response2.data)


### PR DESCRIPTION
See this story: https://www.pivotaltracker.com/story/show/92216650
And also: https://www.pivotaltracker.com/story/show/94082572

Adds radio buttons at the bottom of the admin service page to change the status of a service.
To go from deactivated to published takes two clicks.

I have checked the API code and services are removed from the search index when their status changes from 'published', so there is no extra work to be done for the second story above. (See relevant API code for updating a status here: https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/services.py#L338)