### PR TITLE
Update dmutils and replace APIError with HTTPError

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,5 +1,5 @@
 from flask import render_template, request, redirect, session, url_for, abort
-from dmutils.apiclient import APIError
+from dmutils.apiclient import HTTPError
 
 from .. import data_api_client
 from . import main
@@ -60,8 +60,8 @@ def find():
 def view(service_id):
     try:
         service_data = data_api_client.get_service(service_id)['services']
-    except APIError as e:
-        abort(e.response.status_code)
+    except HTTPError as e:
+        abort(e.status_code)
 
     presented_service_data = {}
     for key, value in service_data.items():
@@ -120,8 +120,8 @@ def update(service_id, section):
                 update,
                 session['username'],
                 "admin app")
-        except APIError as e:
-            return e.response_message
+        except HTTPError as e:
+            return e.message
 
     if form.errors:
         service_data.update(form.dirty_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.10.2#egg=digitalmarketplace-utils
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.12.0#egg=digitalmarketplace-utils==0.12.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -6,7 +6,7 @@ except ImportError:
     from io import BytesIO as StringIO
 
 import mock
-from dmutils.apiclient import APIError
+from dmutils.apiclient import HTTPError, REQUEST_ERROR_MESSAGE
 
 from ..helpers import BaseApplicationTest
 from ..helpers import LoggedInApplicationTest
@@ -77,9 +77,9 @@ class TestServiceView(LoggedInApplicationTest):
 
     @mock.patch('app.main.views.data_api_client')
     def test_responds_with_404_for_api_client_404(self, data_api_client):
-        error = mock.Mock()
-        error.response.status_code = 404
-        data_api_client.get_service.side_effect = APIError(error)
+        response = mock.Mock()
+        response.status_code = 404
+        data_api_client.get_service.side_effect = HTTPError(response)
 
         response = self.client.get('/admin/services/1')
 
@@ -220,8 +220,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'sfiaRateDocumentURL': None
         }}
         error = mock.Mock()
-        error.response.content = "API ERROR"
-        data_api_client.update_service.side_effect = APIError(error)
+        data_api_client.update_service.side_effect = HTTPError(error)
 
         response = self.client.post(
             '/admin/services/1/edit/documents',
@@ -231,4 +230,4 @@ class TestServiceEdit(LoggedInApplicationTest):
                 'termsAndConditionsDocumentURL': (StringIO(), 'test.pdf'),
             }
         )
-        self.assertIn(b'API ERROR', response.data)
+        self.assertIn(REQUEST_ERROR_MESSAGE.encode('utf-8'), response.data)


### PR DESCRIPTION
Use the new HTTPError exception instead of the base APIError one.

Requires https://github.com/alphagov/digitalmarketplace-utils/pull/36