### PR TITLE
[Fixes #94162812] Make view service link relative

### DIFF
--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -39,7 +39,7 @@
           {{ page_heading(service_data['serviceName'], service_data['supplierName'], "page-heading-smaller") }}
         </div>
         <div class="service-view">
-          <a href="https://www.digitalmarketplace.service.gov.uk/service/{{ service_id }}">View service</a>
+          <a href="/services/{{ service_id }}">View service</a>
         </div>
       </div>
 


### PR DESCRIPTION
The link was always pointing to production and was pointing to `/service/<id>` rather than `/services/<id>`.