### PR TITLE
Add CSRF tokens to all forms that are POSTed to.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from flask import Flask, request, redirect
 from flask.ext.bootstrap import Bootstrap
+from flask_wtf.csrf import CsrfProtect
 from dmutils import apiclient, config, logging
 
 from config import configs
@@ -9,6 +10,7 @@ from config import configs
 
 bootstrap = Bootstrap()
 data_api_client = apiclient.DataAPIClient()
+csrf = CsrfProtect()
 
 
 def create_app(config_name):
@@ -24,6 +26,7 @@ def create_app(config_name):
     bootstrap.init_app(application)
     logging.init_app(application)
     data_api_client.init_app(application)
+    csrf.init_app(application)
 
     from .main import main as main_blueprint
     from .status import status as status_blueprint

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -157,9 +157,11 @@ def update(service_id, section):
     for key in request.form:
         item_as_list = request.form.getlist(key)
         list_types = ['list', 'checkboxes', 'pricing']
-        if content.get_question(key)['type'] in list_types:
+        if key != 'csrf_token' \
+                and content.get_question(key)['type'] in list_types:
             posted_data[key] = item_as_list
 
+    posted_data.pop('csrf_token', None)
     form = Validate(content, service_data, posted_data,
                     main.config['DOCUMENTS_URL'], s3_uploader)
     update = {}

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,6 +1,5 @@
 from flask import current_app, flash, render_template, request, redirect, \
     session, url_for
-from flask.ext.wtf import Form
 from dmutils.apiclient import HTTPError
 
 from .. import data_api_client
@@ -27,12 +26,11 @@ def index():
 @main.route('/login', methods=['POST', 'GET'])
 def login():
     if request.method == 'GET':
-        return render_template("login.html", form=Form(), **get_template_data({
+        return render_template("login.html", **get_template_data({
             "previous_responses": None,
             "logged_out": "logged_out" in request.args
         }))
-    form = Form()
-    if form.validate_on_submit() and check_auth(
+    if check_auth(
         request.form['username'],
         request.form['password'],
         main.config['PASSWORD_HASH']
@@ -40,7 +38,7 @@ def login():
         session['username'] = request.form['username']
         return redirect(url_for('.index'))
 
-    return render_template("login.html", form=Form(), **get_template_data({
+    return render_template("login.html", **get_template_data({
         "error": "Could not log in",
         "previous_responses": request.form
     }))
@@ -81,15 +79,11 @@ def view(service_id):
         "service_data": presented_service_data,
         "service_id": service_id
     })
-    return render_template("view_service.html", form=Form(), **template_data)
+    return render_template("view_service.html", **template_data)
 
 
 @main.route('/services/status/<string:service_id>', methods=['POST'])
 def update_service_status(service_id):
-    form = Form()
-    if not form.validate_on_submit():
-        flash({'status_error': 'Invalid CSRF token supplied'}, 'error')
-        return redirect(url_for('.view', service_id=service_id))
 
     frontend_status = request.form['service_status']
 
@@ -128,21 +122,11 @@ def edit(service_id, section):
         "section": content.get_section(section),
         "service_data": data_api_client.get_service(service_id)['services'],
     })
-    return render_template("edit_section.html", form=Form(), **template_data)
+    return render_template("edit_section.html", **template_data)
 
 
 @main.route('/services/<service_id>/edit/<section>', methods=['POST'])
 def update(service_id, section):
-    form = Form()
-    if not form.validate_on_submit():
-        flash({'update_fail': 'Invalid CSRF token supplied'}, 'error')
-        template_data = get_template_data({
-            "section": content.get_section(section),
-            "service_data": data_api_client.get_service(service_id)
-            ['services'],
-        })
-        return render_template("edit_section.html", form=Form(),
-                               **template_data)
 
     s3_uploader = S3(
         bucket_name=main.config['S3_DOCUMENT_BUCKET'],
@@ -157,26 +141,27 @@ def update(service_id, section):
     for key in request.form:
         item_as_list = request.form.getlist(key)
         list_types = ['list', 'checkboxes', 'pricing']
-        if key != 'csrf_token' \
-                and content.get_question(key)['type'] in list_types:
+        if (
+            key != 'csrf_token'
+            and content.get_question(key)['type'] in list_types
+        ):
             posted_data[key] = item_as_list
 
     posted_data.pop('csrf_token', None)
     form = Validate(content, service_data, posted_data,
                     main.config['DOCUMENTS_URL'], s3_uploader)
-    update = {}
-
     form.validate()
 
+    update_data = {}
     for question_id in form.clean_data:
         if question_id not in form.errors:
-            update[question_id] = form.clean_data[question_id]
+            update_data[question_id] = form.clean_data[question_id]
 
-    if update:
+    if update_data:
         try:
             data_api_client.update_service(
                 service_data['id'],
-                update,
+                update_data,
                 session['username'],
                 "admin app")
         except HTTPError as e:
@@ -184,15 +169,12 @@ def update(service_id, section):
 
     if form.errors:
         service_data.update(form.dirty_data)
-        return render_template("edit_section.html", form=Form(),
-                               **get_template_data(
-                                   {
-                                       "section": content.get_section(section),
-                                       "service_data": service_data,
-                                       "service_id": service_id,
-                                       "errors": form.errors
-                                       }
-                                   ))
+        return render_template("edit_section.html", **get_template_data({
+            "section": content.get_section(section),
+            "service_data": service_data,
+            "service_id": service_id,
+            "errors": form.errors
+            }))
     else:
         return redirect(url_for(".view", service_id=service_id))
 

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -15,7 +15,25 @@
     }
   ]) }}
   <div class="page-container edit-section">
-    {{ page_heading(section.name, null, "page-heading-smaller") }}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    {% for category, message in messages %}
+    {% if category == 'error' %}
+      <div class="banner-destructive-without-action">
+    {% else %}
+      <div class="banner-success-without-action">
+    {% endif %}
+        <p class="banner-message">
+          {% if message['update_fail'] %}
+          Could not update service: {{ message['update_fail'] }}
+          {% endif %}
+        </p>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+
+      {{ page_heading(section.name, null, "page-heading-smaller") }}
     {% if errors %}
       <div class="validation-masthead">
         <h2 class="validation-masthead-heading">
@@ -33,6 +51,7 @@
       </div>
     {% endif %}
     <form action="{{ url_for('.update', service_id=service_data.id, section=section.id) }}" method="post" enctype="multipart/form-data">
+      {{ form.hidden_tag() }}
       {% for question in section.questions %}
         {% if service_data['lot']|lower in question['depends_on_lots'] %}
           {% if question.id in errors %}

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -15,25 +15,7 @@
     }
   ]) }}
   <div class="page-container edit-section">
-    {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-    {% for category, message in messages %}
-    {% if category == 'error' %}
-      <div class="banner-destructive-without-action">
-    {% else %}
-      <div class="banner-success-without-action">
-    {% endif %}
-        <p class="banner-message">
-          {% if message['update_fail'] %}
-          Could not update service: {{ message['update_fail'] }}
-          {% endif %}
-        </p>
-        {% endfor %}
-    </div>
-    {% endif %}
-    {% endwith %}
-
-      {{ page_heading(section.name, null, "page-heading-smaller") }}
+    {{ page_heading(section.name, null, "page-heading-smaller") }}
     {% if errors %}
       <div class="validation-masthead">
         <h2 class="validation-masthead-heading">

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -51,7 +51,7 @@
       </div>
     {% endif %}
     <form action="{{ url_for('.update', service_id=service_data.id, section=section.id) }}" method="post" enctype="multipart/form-data">
-      {{ form.hidden_tag() }}
+      <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
       {% for question in section.questions %}
         {% if service_data['lot']|lower in question['depends_on_lots'] %}
           {% if question.id in errors %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -16,7 +16,7 @@
   {% endif %}
   {{ page_heading("Administrator login") }}
   <form action="{{ url_for('.login') }}" method="post" class="question">
-    {{ form.hidden_tag() }}
+    <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
     {% if error %}
       <div class="validation-masthead">
         <h2 class="validation-masthead-heading">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -16,6 +16,7 @@
   {% endif %}
   {{ page_heading("Administrator login") }}
   <form action="{{ url_for('.login') }}" method="post" class="question">
+    {{ form.hidden_tag() }}
     {% if error %}
       <div class="validation-masthead">
         <h2 class="validation-masthead-heading">

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -22,8 +22,8 @@
       <p class="banner-message">
           {% if message['bad_status'] %}
           Not a valid status: '{{ message['bad_status'] }}'
-          {% elif message['api_error'] %}
-          Error trying to update status of service: {{ message['api_error'] }}
+          {% elif message['status_error'] %}
+          Error trying to update status of service: {{ message['status_error'] }}
           {% elif message['status_updated'] %}
           Service status has been updated to: {{ message['status_updated']|title }}
           {% endif %}
@@ -75,7 +75,8 @@
         {% endif %}
       {% endfor %}
 
-      <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="POST">
+      <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
+          {{ form.hidden_tag() }}
           <fieldset class="question">
               <legend class="question-heading">
                   Service status

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -76,7 +76,7 @@
       {% endfor %}
 
       <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
-          {{ form.hidden_tag() }}
+          <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
           <fieldset class="question">
               <legend class="question-heading">
                   Service status

--- a/config.py
+++ b/config.py
@@ -6,6 +6,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config(object):
     DEBUG = True
+    WTF_CSRF_ENABLED = True
     S3_DOCUMENT_BUCKET = os.getenv('DM_S3_DOCUMENT_BUCKET')
     DOCUMENTS_URL = 'https://assets.dev.digitalmarketplace.service.gov.uk'
     DM_DATA_API_URL = os.getenv('DM_DATA_API_URL')
@@ -41,6 +42,7 @@ class Config(object):
 class Test(Config):
     DEBUG = True
     AUTHENTICATION = True
+    WTF_CSRF_ENABLED = False
     DOCUMENTS_URL = 'https://assets.test.digitalmarketplace.service.gov.uk'
     SECRET_KEY = "test_secret"
     PASSWORD_HASH = "JHA1azIkMjcxMCQwYmZiN2Y5YmJlZmI0YTg4YmNkZjQ1ODY0NWUzOGEwNCRoeDBwbUpHZVhSalREUFBGREFydmJQWnlFYnhWU1g1ag=="  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==0.10.1
 Flask-Bootstrap==3.3.0.1
 Flask-Script==2.0.5
+Flask-WTF==0.11
 requests==2.5.1
 pbkdf2==1.3
 six==1.9.0


### PR DESCRIPTION
Addresses this bug: https://www.pivotaltracker.com/story/show/96434676

This uses the WTForms CSRF protection to check that all forms that are POSTed have a valid CSRF token. This is the same method as used in the Supplier app. It just uses the basic Form() object as we aren't using WTForms for the rest of the validation.