### PR TITLE
Set secure cookies in admin app.

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,10 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config(object):
     DEBUG = True
     WTF_CSRF_ENABLED = True
+    SESSION_COOKIE_NAME = 'dm_admin_session'
+    SESSION_COOKIE_PATH = '/admin'
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SECURE = True
     S3_DOCUMENT_BUCKET = os.getenv('DM_S3_DOCUMENT_BUCKET')
     DOCUMENTS_URL = 'https://assets.dev.digitalmarketplace.service.gov.uk'
     DM_DATA_API_URL = os.getenv('DM_DATA_API_URL')
@@ -50,6 +54,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    SESSION_COOKIE_SECURE = False
     AUTHENTICATION = True
 
 

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -32,6 +32,7 @@ class TestSession(BaseApplicationTest):
 
         response = self.client.get('/admin')
         self.assertEquals(200, response.status_code)
+        self.assertIn('Secure;', response.headers['Set-Cookie'])
 
     def test_invalid_login(self):
         response = self.client.post('/admin/login', data=dict(


### PR DESCRIPTION
Cookies were being set as 'HttpOnly' but not 'Secure'.
Fixed by updated settings in config file to match supplier app.

Part of the [Pen Test Mitigations Story](https://www.pivotaltracker.com/story/show/96550136)

<sub>This is something of a bandaid, as [this Pivotal story](https://www.pivotaltracker.com/story/show/95620350) is the long-term solution.</sub>