### PR TITLE
Make Gulpfile generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ npm-debug.log
 app/assets/scss/toolkit
 app/templates/govuk
 app/templates/toolkit
+app/content
 
 # Front end generated assets
 app/static

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ target/
 node_modules
 bower_components
 npm-debug.log
+app/assets/scss/toolkit
+app/templates/govuk
+app/templates/toolkit
 
 # Front end generated assets
 app/static

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -7,18 +7,18 @@
 
 // Digital Marketplace front end toolkit components
 $path: "/static/images/";
-@import "breadcrumb";
-@import "page-headings";
-@import "forms/summary";
-@import "forms/questions";
-@import "forms/hint";
-@import "forms/textboxes";
-@import "forms/word-counter";
-@import "forms/list-entry";
-@import "forms/selection-buttons";
-@import "forms/validation";
-@import "buttons";
-@import "notification-banners";
+@import "toolkit/breadcrumb";
+@import "toolkit/page-headings";
+@import "toolkit/forms/summary";
+@import "toolkit/forms/questions";
+@import "toolkit/forms/hint";
+@import "toolkit/forms/textboxes";
+@import "toolkit/forms/word-counter";
+@import "toolkit/forms/list-entry";
+@import "toolkit/forms/selection-buttons";
+@import "toolkit/forms/validation";
+@import "toolkit/buttons";
+@import "toolkit/notification-banners";
 
 // Patterns specific to this app
 @import "patterns/service-id";

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -13,7 +13,7 @@ from .helpers.auth import check_auth, is_authenticated
 
 content = ContentLoader(
     "app/section_order.yml",
-    "bower_components/digital-marketplace-ssp-content/g6/"
+    "app/content/g6/"
 )
 presenters = Presenters()
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,4 +1,4 @@
-{% extends "govuk_template.html" %}
+{% extends "govuk/govuk_template.html" %}
 
 {% block head %}
   {% include "_stylesheets.html" %}

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v2.0.4",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#973f540",
     "hogan": "3.0.2"

--- a/config.py
+++ b/config.py
@@ -30,8 +30,6 @@ class Config(object):
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
         template_folders = [
-            os.path.join(repo_root,
-                         'bower_components/govuk_template/views/layouts'),
             os.path.join(repo_root, 'app/templates')
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,15 +122,15 @@ gulp.task('js', function () {
   return stream;
 });
 
-function copyFactory(what, base, destination) {
+function copyFactory(resourceName, sourceFolder, targetFolder) {
 
   return function() {
 
     return gulp
-      .src(base + "/**/*", { base: base })
-      .pipe(gulp.dest(destination))
+      .src(sourceFolder + "/**/*", { base: sourceFolder })
+      .pipe(gulp.dest(targetFolder))
       .on('end', function () {
-        console.log('📂  Copied ' + what);
+        console.log('📂  Copied ' + resourceName);
       });
 
   };
@@ -141,7 +141,8 @@ gulp.task(
   'copy:template_assets:stylesheets',
   copyFactory(
     "GOV.UK template stylesheets",
-    govukTemplateAssetsFolder + '/stylesheets', staticFolder + '/stylesheets'
+    govukTemplateAssetsFolder + '/stylesheets',
+    staticFolder + '/stylesheets'
   )
 );
 
@@ -149,7 +150,8 @@ gulp.task(
   'copy:template_assets:images',
   copyFactory(
     "GOV.UK template images",
-    govukTemplateAssetsFolder + '/images', staticFolder + '/images'
+    govukTemplateAssetsFolder + '/images',
+    staticFolder + '/images'
   )
 );
 
@@ -157,7 +159,8 @@ gulp.task(
   'copy:template_assets:javascripts',
   copyFactory(
     'GOV.UK template Javascript files',
-    govukTemplateAssetsFolder + '/javascripts', staticFolder + '/javascripts'
+    govukTemplateAssetsFolder + '/javascripts',
+    staticFolder + '/javascripts'
   )
 );
 
@@ -165,7 +168,8 @@ gulp.task(
   'copy:dm_toolkit_assets:stylesheets',
   copyFactory(
     "stylesheets from the Digital Marketplace frontend toolkit",
-    dmToolkitRoot + '/scss', 'app/assets/scss/toolkit'
+    dmToolkitRoot + '/scss',
+    'app/assets/scss/toolkit'
   )
 );
 
@@ -173,7 +177,8 @@ gulp.task(
   'copy:dm_toolkit_assets:images',
   copyFactory(
     "images from the Digital Marketplace frontend toolkit",
-    dmToolkitRoot + '/images', staticFolder + '/images'
+    dmToolkitRoot + '/images',
+    staticFolder + '/images'
   )
 );
 
@@ -181,7 +186,8 @@ gulp.task(
   'copy:dm_toolkit_assets:templates',
   copyFactory(
     "templates from the Digital Marketplace frontend toolkit",
-    dmToolkitRoot + '/templates', 'app/templates/toolkit'
+    dmToolkitRoot + '/templates',
+    'app/templates/toolkit'
   )
 );
 
@@ -189,7 +195,8 @@ gulp.task(
   'copy:images',
   copyFactory(
     "image assets from app to static folder",
-    assetsFolder + '/images', staticFolder + '/images'
+    assetsFolder + '/images',
+    staticFolder + '/images'
   )
 );
 
@@ -197,7 +204,8 @@ gulp.task(
   'copy:govuk_template',
   copyFactory(
     "GOV.UK template into app folder",
-    govukTemplateLayoutsFolder, 'app/templates/govuk'
+    govukTemplateLayoutsFolder,
+    'app/templates/govuk'
   )
 );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,30 +2,29 @@ var gulp = require('gulp');
 var uglify = require('gulp-uglifyjs');
 var deleteFiles = require('del');
 var sass = require('gulp-sass');
+var filelog = require('gulp-filelog');
 var include = require('gulp-include');
 
+// Paths
 var environment;
 var repoRoot = __dirname + '/';
-var govukToolkitSCSS = repoRoot + 'node_modules/govuk_frontend_toolkit/stylesheets';
-var dmToolkitSCSS = repoRoot + 'bower_components/digitalmarketplace-frontend-toolkit/toolkit/scss';
+var bowerRoot = repoRoot + 'bower_components';
+var npmRoot = repoRoot + 'node_modules';
+var govukToolkitRoot = npmRoot + '/govuk_frontend_toolkit';
+var dmToolkitRoot = bowerRoot + '/digitalmarketplace-frontend-toolkit/toolkit';
 var assetsFolder = repoRoot + 'app/assets';
 var staticFolder = repoRoot + 'app/static';
-var govukTemplateAssetsFolder = repoRoot + 'bower_components/govuk_template/assets';
-var dmToolkitAssetsFolder = repoRoot + 'bower_components/digitalmarketplace-frontend-toolkit/toolkit/';
+var govukTemplateFolder = repoRoot + 'bower_components/govuk_template';
+var govukTemplateAssetsFolder = govukTemplateFolder + '/assets';
+var govukTemplateLayoutsFolder = govukTemplateFolder + '/views/layouts';
 
 // JavaScript paths
-var jsVendorFiles = [
-  assetsFolder + '/javascripts/vendor/jquery-1.11.0.js',
-  assetsFolder + '/javascripts/vendor/hogan-3.0.2.min.js'
-];
-var jsSourceFiles = [
-  assetsFolder + '/javascripts/application.js'
-];
+var jsSourceFile = assetsFolder + '/javascripts/application.js';
 var jsDistributionFolder = staticFolder + '/javascripts';
 var jsDistributionFile = 'application.js';
 
 // CSS paths
-var cssSourceGlob = assetsFolder + '/scss/**/*.scss';
+var cssSourceGlob = assetsFolder + '/scss/application*.scss';
 var cssDistributionFolder = staticFolder + '/stylesheets';
 
 // Configuration
@@ -33,13 +32,22 @@ var sassOptions = {
   development: {
     outputStyle: 'expanded',
     lineNumbers: true,
-    includePaths: [govukToolkitSCSS, dmToolkitSCSS],
-    sourceComments: true
+    includePaths: [
+      assetsFolder + '/scss',
+      dmToolkitRoot + '/scss',
+      govukToolkitRoot + '/stylesheets',
+    ],
+    sourceComments: true,
+    errLogToConsole: true
   },
   production: {
     outputStyle: 'compressed',
     lineNumbers: true,
-    includePaths: [govukToolkitSCSS, dmToolkitSCSS]
+    includePaths: [
+      assetsFolder + '/scss',
+      dmToolkitRoot + '/scss',
+      govukToolkitRoot + '/stylesheets',
+    ],
   },
 };
 
@@ -51,26 +59,38 @@ var uglifyOptions = {
       semicolons: true,
       comments: true,
       indent_level: 2
-    }
+    },
+    compress: false
   },
   production: {
     mangle: true
   }
 };
 
-gulp.task('clean', function () {
+gulp.task('clean', function (cb) {
+  var fileTypes = [];
+  var complete = function (fileType) {
+    fileTypes.push(fileType);
+    if (fileTypes.length == 2) {
+      cb();
+    }
+  };
   var logOutputFor = function (fileType) {
     return function (err, paths) {
-      console.log('Deleted the following ' + fileType + ' files:\n', paths.join('\n'));
+      if (paths !== undefined) {
+        console.log('💥  Deleted the following ' + fileType + ' files:\n', paths.join('\n'));
+      }
+      complete(fileType);
     };
   };
 
-  deleteFiles(jsDistributionFolder + '/*.js', logOutputFor('JavaScript'));
-  deleteFiles(cssDistributionFolder + '/*.css', logOutputFor('CSS'));
+  deleteFiles(jsDistributionFolder + '/**/*', logOutputFor('JavaScript'));
+  deleteFiles(cssDistributionFolder + '/**/*', logOutputFor('CSS'));
 });
 
 gulp.task('sass', function () {
   var stream = gulp.src(cssSourceGlob)
+    .pipe(filelog('Compressing SCSS files'))
     .pipe(sass(sassOptions[environment]))
     .on('error', function (err) {
       console.log(err.message);
@@ -78,16 +98,15 @@ gulp.task('sass', function () {
     .pipe(gulp.dest(cssDistributionFolder));
 
   stream.on('end', function () {
-    console.log('Compressed CSS saved as .css files in ' + cssDistributionFolder);
+    console.log('💾  Compressed CSS saved as .css files in ' + cssDistributionFolder);
   });
 
   return stream;
 });
 
 gulp.task('js', function () {
-  // produce full array of JS files from vendor + local scripts
-  jsFiles = jsVendorFiles.concat(jsSourceFiles);
-  var stream = gulp.src(jsFiles)
+  var stream = gulp.src(jsSourceFile)
+    .pipe(filelog('Compressing JavaScript files'))
     .pipe(include())
     .pipe(uglify(
       jsDistributionFile,
@@ -96,32 +115,90 @@ gulp.task('js', function () {
     .pipe(gulp.dest(jsDistributionFolder));
 
   stream.on('end', function () {
-    console.log('Compressed JavaScript saved as ' + jsDistributionFolder + '/' + jsDistributionFile)
+    console.log('💾 Compressed JavaScript saved as ' + jsDistributionFolder + '/' + jsDistributionFile);
   });
 
   return stream;
 });
 
-gulp.task('copy_template_assets:stylesheets', function () {
-  return gulp.src(govukTemplateAssetsFolder + '/stylesheets/**/*', { base : govukTemplateAssetsFolder + '/stylesheets' })
-    .pipe(gulp.dest(staticFolder + '/stylesheets'))
-});
+function copyFactory(what, base, destination) {
 
-gulp.task('copy_template_assets:images', function () {
-  return gulp.src(govukTemplateAssetsFolder + '/images/**/*', { base : govukTemplateAssetsFolder + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'))
-});
+  return function() {
 
-gulp.task('copy_template_assets:javascripts', function () {
-  return gulp.src(govukTemplateAssetsFolder + '/javascripts/**/*', { base : govukTemplateAssetsFolder + '/javascripts' })
-    .pipe(gulp.dest(staticFolder + '/javascripts'))
-});
+    return gulp
+      .src(base + "/**/*", { base: base })
+      .pipe(gulp.dest(destination))
+      .on('end', function () {
+        console.log('📂  Copied ' + what);
+      });
 
-gulp.task('copy_template_assets', function () {
-   gulp.start('copy_template_assets:stylesheets');
-   gulp.start('copy_template_assets:images');
-   gulp.start('copy_template_assets:javascripts');
-});
+  };
+
+}
+
+gulp.task(
+  'copy:template_assets:stylesheets',
+  copyFactory(
+    "GOV.UK template stylesheets",
+    govukTemplateAssetsFolder + '/stylesheets', staticFolder + '/stylesheets'
+  )
+);
+
+gulp.task(
+  'copy:template_assets:images',
+  copyFactory(
+    "GOV.UK template images",
+    govukTemplateAssetsFolder + '/images', staticFolder + '/images'
+  )
+);
+
+gulp.task(
+  'copy:template_assets:javascripts',
+  copyFactory(
+    'GOV.UK template Javascript files',
+    govukTemplateAssetsFolder + '/javascripts', staticFolder + '/javascripts'
+  )
+);
+
+gulp.task(
+  'copy:dm_toolkit_assets:stylesheets',
+  copyFactory(
+    "stylesheets from the Digital Marketplace frontend toolkit",
+    dmToolkitRoot + '/scss', 'app/assets/scss/toolkit'
+  )
+);
+
+gulp.task(
+  'copy:dm_toolkit_assets:images',
+  copyFactory(
+    "images from the Digital Marketplace frontend toolkit",
+    dmToolkitRoot + '/images', staticFolder + '/images'
+  )
+);
+
+gulp.task(
+  'copy:dm_toolkit_assets:templates',
+  copyFactory(
+    "templates from the Digital Marketplace frontend toolkit",
+    dmToolkitRoot + '/templates', 'app/templates/toolkit'
+  )
+);
+
+gulp.task(
+  'copy:images',
+  copyFactory(
+    "image assets from app to static folder",
+    assetsFolder + '/images', staticFolder + '/images'
+  )
+);
+
+gulp.task(
+  'copy:govuk_template',
+  copyFactory(
+    "GOV.UK template into app folder",
+    govukTemplateLayoutsFolder, 'app/templates/govuk'
+  )
+);
 
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
@@ -134,21 +211,45 @@ gulp.task('watch', ['build:development'], function () {
   jsWatcher.on('change', notice);
 });
 
-gulp.task('copy_toolkit_assets:images', function () {
-  return gulp.src(dmToolkitAssetsFolder + '/images/**/*', { base : dmToolkitAssetsFolder + '/images' })
-    .pipe(gulp.dest(staticFolder + '/images'));
-});
-
-gulp.task('build:development', ['clean'], function () {
+gulp.task('set_environment_to_development', function (cb) {
   environment = 'development';
-  gulp.start('sass', 'js');
-  gulp.start('copy_template_assets');
-  gulp.start('copy_toolkit_assets:images');
+  cb();
 });
 
-gulp.task('build:production', ['clean'], function () {
+gulp.task('set_environment_to_production', function (cb) {
   environment = 'production';
-  gulp.start('sass', 'js');
-  gulp.start('copy_template_assets');
-  gulp.start('copy_toolkit_assets:images');
+  cb();
+});
+
+gulp.task(
+  'copy',
+  [
+    'copy:template_assets:images',
+    'copy:template_assets:stylesheets',
+    'copy:template_assets:javascripts',
+    'copy:dm_toolkit_assets:stylesheets',
+    'copy:dm_toolkit_assets:images',
+    'copy:dm_toolkit_assets:templates',
+    'copy:images',
+    'copy:govuk_template'
+  ]
+);
+
+gulp.task(
+  'compile',
+  [
+    'copy'
+  ],
+  function() {
+    gulp.start('sass');
+    gulp.start('js');
+  }
+);
+
+gulp.task('build:development', ['set_environment_to_development', 'clean'], function () {
+  gulp.start('compile');
+});
+
+gulp.task('build:production', ['set_environment_to_production', 'clean'], function () {
+  gulp.start('compile');
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var bowerRoot = repoRoot + 'bower_components';
 var npmRoot = repoRoot + 'node_modules';
 var govukToolkitRoot = npmRoot + '/govuk_frontend_toolkit';
 var dmToolkitRoot = bowerRoot + '/digitalmarketplace-frontend-toolkit/toolkit';
+var sspContentRoot = bowerRoot + '/digital-marketplace-ssp-content';
 var assetsFolder = repoRoot + 'app/assets';
 var staticFolder = repoRoot + 'app/static';
 var govukTemplateFolder = repoRoot + 'bower_components/govuk_template';
@@ -200,6 +201,14 @@ gulp.task(
   )
 );
 
+gulp.task(
+  'copy:ssp_content',
+  copyFactory(
+    "content YAML into app folder",
+    sspContentRoot, 'app/content'
+  )
+);
+
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
@@ -224,6 +233,7 @@ gulp.task('set_environment_to_production', function (cb) {
 gulp.task(
   'copy',
   [
+    'copy:ssp_content',
     'copy:template_assets:images',
     'copy:template_assets:stylesheets',
     'copy:template_assets:javascripts',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "del": "1.1.1",
     "govuk_frontend_toolkit": "3.1.0",
     "gulp": "3.8.7",
+    "gulp-filelog" : "0.4.1",
     "gulp-include": "1.1.1",
     "gulp-sass": "1.3.3",
     "gulp-shell": "0.2.9",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 
-npm install
-npm run frontend-build:production
+npm install 1>&2
+npm run frontend-build:production 1>&2
+
+# Non-Git paths that should be included when deploying
+echo "app/static"
+echo "app/templates/toolkit"
+echo "app/templates/govuk"
+echo "app/content"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,6 +28,9 @@ function display_result {
   fi
 }
 
+# Build front-end static assets
+npm run frontend-build:production
+
 pep8 .
 display_result $? 1 "Code style check"
 


### PR DESCRIPTION
This copies the Gulpfile from the suppliers app, which is now generic, and makes the necessary changes to the setup of this app so that it works.