### PR TITLE
Deny third-party sites from embedding in an iframe

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,4 +45,9 @@ def create_app(config_name):
         if request.path != '/' and request.path.endswith('/'):
             return redirect(request.path[:-1], code=301)
 
+    @application.after_request
+    def add_header(response):
+        response.headers['X-Frame-Options'] = 'DENY'
+        return response
+
     return application

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -33,6 +33,7 @@ class TestSession(BaseApplicationTest):
         response = self.client.get('/admin')
         self.assertEquals(200, response.status_code)
         self.assertIn('Secure;', response.headers['Set-Cookie'])
+        self.assertIn('DENY', response.headers['X-Frame-Options'])
 
     def test_invalid_login(self):
         response = self.client.post('/admin/login', data=dict(


### PR DESCRIPTION
Added an `X-Frame-Options` line in our header which denies embedding our site in an iframe by other sites.
All very well and good for this app, but we'll also have to duplicate the code in other apps we want to share this behaviour.
Things to consider:
- We *could* set this at the server level if we wanted to make
this change more uniform.
- [The alphagov/whitehall team have set their public-facing headers
for their content to `ALLOWALL`](https://github.com/alphagov/whitehall/commit/9f8c7ccd1fdf7695e66b1340cb6b89ca0e134f9a), but @minglis says we're not going to allow this at present.