### PR TITLE
Upgrade dmutils, remove redundant code.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,9 +47,4 @@ def create_app(config_name):
         if request.path != '/' and request.path.endswith('/'):
             return redirect(request.path[:-1], code=301)
 
-    @application.after_request
-    def add_header(response):
-        response.headers['X-Frame-Options'] = 'DENY'
-        return response
-
     return application

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.21.0#egg=digitalmarketplace-utils==0.21.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.23.0#egg=digitalmarketplace-utils==0.23.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
Since moving the `add_header` method to dmutils, we can remove it from individual apps and just require the new version of dmutils.
Tests remain as they were.