### PR TITLE
Fix display of booleans to match new presenter

### DIFF
--- a/app/templates/macros/answers.html
+++ b/app/templates/macros/answers.html
@@ -35,7 +35,7 @@
 
 
 {% macro boolean(value='') -%}
-  {{ 'Yes' if value else 'No' }}
+  {{ value }}
 {%- endmacro %}
 
 


### PR DESCRIPTION
Booleans were previously always being displayed as "Yes" no matter what their value.

This should fix the currently failing smoketests on preview.