### PR TITLE
Fail the build if SASS doesn't compile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,6 +68,14 @@ var uglifyOptions = {
   }
 };
 
+var logErrorAndExit = function logErrorAndExit(err) {
+
+  // coloured text: https://coderwall.com/p/yphywg/printing-colorful-text-in-terminal-when-run-node-js-script
+  console.log('\x1b[41m\x1b[37m  Error: ' + err.message + '\x1b[0m');
+  process.exit(1);
+
+};
+
 gulp.task('clean', function (cb) {
   var fileTypes = [];
   var complete = function (fileType) {
@@ -92,10 +100,9 @@ gulp.task('clean', function (cb) {
 gulp.task('sass', function () {
   var stream = gulp.src(cssSourceGlob)
     .pipe(filelog('Compressing SCSS files'))
-    .pipe(sass(sassOptions[environment]))
-    .on('error', function (err) {
-      console.log(err.message);
-    })
+    .pipe(
+      sass(sassOptions[environment]))
+        .on('error', logErrorAndExit)
     .pipe(gulp.dest(cssDistributionFolder));
 
   stream.on('end', function () {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,11 +28,11 @@ function display_result {
   fi
 }
 
-# Build front-end static assets
-npm run frontend-build:production
+npm run --silent frontend-build:production
+display_result $? 1 "Build of front end static assets"
 
 pep8 .
-display_result $? 1 "Code style check"
+display_result $? 2 "Code style check"
 
 nosetests -v -s --with-doctest
-display_result $? 2 "Unit tests"
+display_result $? 3 "Unit tests"


### PR DESCRIPTION
Duplicates: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/65/

--

We have had problems with build going through and getting deployed without any stylesheets.

This commit addresses that issue by causing `./scripts/run_tests.sh` to fail if the SASS compilation doesn't complete.

This means that problems will be picked up locally or on Travis before they reach deployment.