### PR TITLE
Disable autocomplete on login form.

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -15,7 +15,7 @@
     </div>
   {% endif %}
   {{ page_heading("Administrator login") }}
-  <form action="{{ url_for('.login') }}" method="post" class="question">
+  <form autocomplete="off" action="{{ url_for('.login') }}" method="post" class="question">
     <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
     {% if error %}
       <div class="validation-masthead">
@@ -25,10 +25,10 @@
       </div>
     {% endif %}
     <label class="question-heading" for="username">Username</label>
-    <input type="text" name="username" id="username" class="text-box" value="{{previous_responses.username}}">
+    <input autocomplete="off" type="text" name="username" id="username" class="text-box" value="{{previous_responses.username}}">
     <label class="question-heading" for="password">Password</label>
-    <input type="password" name="password" id="password" class="text-box">
-    <input type="submit" value="Log in" class="button-save">
+    <input autocomplete="off" type="password" name="password" id="password" class="text-box">
+    <button class="button-save">Log in</button>
   </form>
 </div>
 {% endblock %}

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,3 +4,4 @@ pep8==1.5.7
 nose==1.3.4
 mock==1.0.1
 requests-mock==0.6.0
+lxml==3.4.4


### PR DESCRIPTION
Added `autocomplete="off"` to form and input  elements on login page + added a test.
Also changed our submit button to a `<button>` because that's what we've done [in the supplier app](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/templates/auth/login.html#L89).