### PR TITLE
Prohibit empty username or password.

### DIFF
--- a/app/main/helpers/auth.py
+++ b/app/main/helpers/auth.py
@@ -7,6 +7,9 @@ def check_auth(username, password, password_hash):
     """This function is called to check if a username /
     password combination is valid.
     """
+    if not username or not password:
+        return False
+
     secret = base64.b64decode(
         password_hash
     ).decode('utf-8')

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -13,6 +13,26 @@ from ..helpers import LoggedInApplicationTest
 
 
 class TestSession(BaseApplicationTest):
+
+    def _login(self, username, password, is_authenticated=True):
+        post_response = self.client.post('/admin/login', data=dict(
+            username=username,
+            password=password
+        ))
+
+        get_response = self.client.get('/admin')
+
+        if is_authenticated:
+            self.assertEquals(302, post_response.status_code)
+            self.assertEquals(
+                "/admin", urlsplit(post_response.location).path)
+            self.assertEquals(200, get_response.status_code)
+        else:
+            self.assertEquals(200, post_response.status_code)
+            self.assertEquals(302, get_response.status_code)
+            self.assertEquals(
+                "/admin/login", urlsplit(get_response.location).path)
+
     def test_index(self):
         response = self.client.get('/admin')
         self.assertEquals(302, response.status_code)
@@ -22,29 +42,25 @@ class TestSession(BaseApplicationTest):
         self.assertEquals(301, response.status_code)
         self.assertEquals("http://localhost/admin", response.location)
 
-    def test_login(self):
-        response = self.client.post('/admin/login', data=dict(
+    def test_valid_login(self):
+        self._login(
             username="admin",
             password="admin"
-        ))
-        self.assertEquals(302, response.status_code)
-        self.assertEquals("/admin", urlsplit(response.location).path)
+        )
 
-        response = self.client.get('/admin')
-        self.assertEquals(200, response.status_code)
-        self.assertIn('Secure;', response.headers['Set-Cookie'])
-        self.assertIn('DENY', response.headers['X-Frame-Options'])
+    def test_invalid_logins(self):
+        invalid_logins = [
+            ("admin", "wrong"),
+            ("adminadmin", ""),
+            ("", "adminadmin")
+        ]
 
-    def test_invalid_login(self):
-        response = self.client.post('/admin/login', data=dict(
-            username="admin",
-            password="wrong"
-        ))
-        self.assertEquals(200, response.status_code)
-
-        response = self.client.get('/admin')
-        self.assertEquals(302, response.status_code)
-        self.assertEquals("/admin/login", urlsplit(response.location).path)
+        for invalid_login in invalid_logins:
+            self._login(
+                username=invalid_login[0],
+                password=invalid_login[1],
+                is_authenticated=False
+            )
 
 
 class TestApplication(LoggedInApplicationTest):
@@ -59,6 +75,12 @@ class TestApplication(LoggedInApplicationTest):
     def test_index_is_404(self):
         response = self.client.get('/')
         self.assertEquals(404, response.status_code)
+
+    def test_headers(self):
+        res = self.client.get('/admin')
+        assert 200 == res.status_code
+        self.assertIn('Secure;', res.headers['Set-Cookie'])
+        self.assertIn('DENY', res.headers['X-Frame-Options'])
 
 
 class TestServiceView(LoggedInApplicationTest):


### PR DESCRIPTION
App will reject empty usernames or passwords, tests have been extended to reflect this.
Also isolated the header verification test to bring it more in line with what's happening in the [buyer app](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/tests/test_application.py#L26) and the [supplier app](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/tests/app/test_application.py#L53).