### PR TITLE
/admin/services should 404 with no service ID

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -53,7 +53,7 @@ def logout():
 @main.route('/services', methods=['GET'])
 def find():
     if request.args.get("service_id") is None:
-        abort(404)
+        return render_template("index.html", **get_template_data()), 404
     return redirect(
         url_for(".view", service_id=request.args.get("service_id")))
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,5 +1,5 @@
 from flask import current_app, flash, render_template, request, redirect, \
-    session, url_for
+    session, url_for, abort
 from dmutils.apiclient import HTTPError
 
 from .. import data_api_client
@@ -52,6 +52,8 @@ def logout():
 
 @main.route('/services', methods=['GET'])
 def find():
+    if request.args.get("service_id") is None:
+        abort(404)
     return redirect(
         url_for(".view", service_id=request.args.get("service_id")))
 

--- a/tests/app/main/test_views.py
+++ b/tests/app/main/test_views.py
@@ -399,3 +399,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         response2 = self.client.get(response1.location)
         self.assertIn(b"Not a valid status: 'suspended'",
                       response2.data)
+
+    def test_services_with_missing_id(self):
+        response = self.client.get('/admin/services')
+        self.assertEquals(404, response.status_code)


### PR DESCRIPTION
…rather than return a 500 error.

Fulfils: https://www.pivotaltracker.com/story/show/96881132