### PR TITLE
Use current user email for "updated_by" field in service updates

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,12 +1,11 @@
 from flask import render_template, request, redirect, url_for, flash, \
-    current_app, session
+    current_app
 from flask_login import login_required, current_user
 from dmutils.apiclient import HTTPError
 
 from dmutils.validation import Validate
 from dmutils.presenters import Presenters
 from dmutils.s3 import S3
-from dmutils.validation import Validate
 
 from ... import data_api_client
 from ... import service_content
@@ -76,7 +75,8 @@ def update_service_status(service_id):
     try:
         data_api_client.update_service_status(
             service_id, backend_status,
-            "Digital Marketplace admin user", "Status changed to '{0}'".format(
+            current_user.email_address,
+            "Status changed to '{0}'".format(
                 backend_status))
 
     except HTTPError as e:

--- a/config.py
+++ b/config.py
@@ -55,6 +55,8 @@ class Test(Config):
     DOCUMENTS_URL = 'https://assets.test.digitalmarketplace.service.gov.uk'
     SECRET_KEY = "test_secret"
 
+    DM_LOG_LEVEL = 'CRITICAL'
+
 
 class Development(Config):
     DEBUG = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [pep8]
 exclude = ./venv,./bower_components,./node_modules
+max-line-length=120
+
 [pytest]
 norecursedirs = venv bower_components node_modules

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -266,7 +266,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'removed'})
         data_api_client.update_service_status.assert_called_with(
-            '1', 'disabled', 'Digital Marketplace admin user',
+            '1', 'disabled', 'test@example.com',
             "Status changed to 'disabled'")
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
@@ -281,7 +281,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'private'})
         data_api_client.update_service_status.assert_called_with(
-            '1', 'enabled', 'Digital Marketplace admin user',
+            '1', 'enabled', 'test@example.com',
             "Status changed to 'enabled'")
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
@@ -296,7 +296,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'public'})
         data_api_client.update_service_status.assert_called_with(
-            '1', 'published', 'Digital Marketplace admin user',
+            '1', 'published', 'test@example.com',
             "Status changed to 'published'")
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,


### PR DESCRIPTION
Since the admin login is tied to the API now we can use the actual
user email to identify the author of the service update.