### PR TITLE
Update GOV.UK template

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.1",
-    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
+    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.0/jinja_govuk_template-0.14.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#dc09e191ccffc7e914db41ced1fabfbb2818669d",
     "hogan": "3.0.2"
   }


### PR DESCRIPTION
Doing a check of footer links discovered an unnecessary redirect, which was fixed here: https://github.com/alphagov/govuk_template/commit/091f855551923733c9e7df11f0eb66660653fa79

This commit updates the version of GOV.UK template we use to bring in this fix.

Full change list: https://github.com/alphagov/govuk_template/compare/v0.12.0%E2%80%A6v0.14.0