### PR TITLE
Make "view service" link relative to environment

### DIFF
--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -55,7 +55,7 @@
           {% endwith %}
         </div>
         <div class="service-view">
-          <a href="https://www.digitalmarketplace.service.gov.uk/service/{{ service_id }}">View service</a>
+          <a href="/g-cloud/services/{{ service_id }}">View service</a>
         </div>
       </div>
 


### PR DESCRIPTION
Currently the "view service" link in the admin app always points at live. It should be relative to the environment that the app is being used it (so that it can be tested).

**This PR is blocked until the admin app is being used on the production domain.**

Actual: https://www.digitalmarketplace.service.gov.uk/service/5126395806089216

Expected: https://preview.development.digitalmarketplace.service.gov.uk/service/5126395806089216

Fixes: https://www.pivotaltracker.com/story/show/94162812