### PR TITLE
Fix Cloudwatch logs FindInMap call

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -58,7 +58,7 @@ Resources :
                 [apache-access_log]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogFile"]}`
                 log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}`
-                log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
+                log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "AccessLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-combined]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogFile"]}`

--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -42,7 +42,7 @@ Resources:
   AWSEBLoginFailureMetricFilter:
     Type : "AWS::Logs::MetricFilter"
     Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "LoginFailure"]}
       MetricTransformations :
         - MetricValue : 1


### PR DESCRIPTION
The AWSEBLoginFailureMetricFilter metric was failing to created because
it was trying to get the LogGroupName out of the AccessLogs map rather
than ApplicationLogs. There was also a similar bug in the apache logs
config but presumably because of some ordering issue it hadn't caused
any problems.