### PR TITLE
Fix login failure cloudwatch logs metric filter

### DIFF
--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -8,7 +8,7 @@ Mappings:
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
-      LoginFailure: "[timestamp, app=admin-frontend, type=app, status, request_id, message=login.fail:*, ...]"
+      LoginFailure: "[timestamp, app=admin-frontend, type=app, status, request_id, message=login.fail*, ...]"
 
 Resources:
   AWSEBAutoScalingGroup:
@@ -36,50 +36,50 @@ Resources:
               owner : root
               group : root
   
-  ##################################
-  ### Cloudwatch Logs Metric Filters
-  #
-  #AWSEBLoginFailureMetricFilter:
-  #  Type : "AWS::Logs::MetricFilter"
-  #  Properties :
-  #    LogGroupName: {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogGroupName"]}
-  #    FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "LoginFailure"]}
-  #    MetricTransformations :
-  #      - MetricValue : 1
-  #        MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
-  #        MetricName : LoginFailure
+  #################################
+  ## Cloudwatch Logs Metric Filters
+  
+  AWSEBLoginFailureMetricFilter:
+    Type : "AWS::Logs::MetricFilter"
+    Properties :
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogGroupName"]}
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "LoginFailure"]}
+      MetricTransformations :
+        - MetricValue : 1
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : LoginFailure
 
-  ################################
-  ### Alarms
+  ###############################
+  ## Alarms
 
-  #AWSEBLoginFailureCountAlarm:
-  #  Type: "AWS::CloudWatch::Alarm"
-  #  DependsOn: AWSEBLoginFailureMetricFilter
-  #  Properties:
-  #    AlarmDescription:
-  #      "Fn::Join":
-  #        - ""
-  #        -
-  #          - "There have been too many failed logins on the admin app.\n"
-  #          - "Application: admin-frontend\n"
-  #          - "Stage and environment: "
-  #          - {"Fn::FindInMap": ["CWLogs", "ApplicationLogs", "LogGroupName"]}
-  #          - "\nManual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#login-failures"
-  #    MetricName: LoginFailure
-  #    Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
-  #    Statistic: Sum
-  #    Period: 60
-  #    EvaluationPeriods: 5
-  #    Threshold: 10
-  #    ComparisonOperator: GreaterThanThreshold
-  #    AlarmActions:
-  #      - "Fn::If":
-  #          - SNSTopicExists
-  #          - "Fn::FindInMap":
-  #              - AWSEBOptions
-  #              - options
-  #              - EBSNSTopicArn
-  #          - { "Ref" : "AWS::NoValue" }
+  AWSEBLoginFailureCountAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    DependsOn: AWSEBLoginFailureMetricFilter
+    Properties:
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "There have been too many failed logins on the admin app.\n"
+            - "Application: admin-frontend\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "ApplicationLogs", "LogGroupName"]}
+            - "\nManual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#login-failures"
+      MetricName: LoginFailure
+      Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 10
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - "Fn::If":
+            - SNSTopicExists
+            - "Fn::FindInMap":
+                - AWSEBOptions
+                - options
+                - EBSNSTopicArn
+            - { "Ref" : "AWS::NoValue" }
 
 container_commands:
   # Cannot reference cloud formation variables here


### PR DESCRIPTION
The problem was that : (colon) is not allowed in the filter pattern.

Props to @minglis for suggesting to try and create it manually.