### PR TITLE
[#98947448] Fix diff tool bug.

### DIFF
--- a/app/main/helpers/diff_tools.py
+++ b/app/main/helpers/diff_tools.py
@@ -27,8 +27,8 @@ def get_diffs_from_service_data(
     for section in sections:
         for question in section['questions']:
             revisions_are_valid = True
-            question_revision_1 = revision_1.get(question['id'], None)
-            question_revision_2 = revision_2.get(question['id'], None)
+            question_revision_1 = revision_1.get(question['id'], [])
+            question_revision_2 = revision_2.get(question['id'], [])
 
             if all_are_lists(question_revision_1, question_revision_2):
                 pass
@@ -47,16 +47,16 @@ def get_diffs_from_service_data(
                     include_unchanged_lines_in_output
                 )
 
-                # if arrays are empty, there are no changes for this question
-                if question_diff['revision_1'] or question_diff['revision_2']:
-                    diffs.append({
-                        'section_name': section['name'],
-                        'label': question['question'],
-                        'revisions':
-                            [val + question_diff['revision_2'][i]
-                             for i, val
-                             in enumerate(question_diff['revision_1'])]
-                    })
+            # if arrays are empty, there are no changes for this question
+            if question_diff['revision_1'] or question_diff['revision_2']:
+                diffs.append({
+                    'section_name': section['name'],
+                    'label': question['question'],
+                    'revisions':
+                        [val + question_diff['revision_2'][i]
+                         for i, val
+                         in enumerate(question_diff['revision_1'])]
+                })
 
     return diffs
 
@@ -115,7 +115,6 @@ def render_lines(
         lines['revision_2'].append(
             Markup(render_words_html(revision_2_words, index+1))
         )
-
     return lines
 
 

--- a/app/main/helpers/diff_tools.py
+++ b/app/main/helpers/diff_tools.py
@@ -27,8 +27,8 @@ def get_diffs_from_service_data(
     for section in sections:
         for question in section['questions']:
             revisions_are_valid = True
-            question_revision_1 = revision_1[question['id']]
-            question_revision_2 = revision_2[question['id']]
+            question_revision_1 = revision_1.get(question['id'], None)
+            question_revision_2 = revision_2.get(question['id'], None)
 
             if all_are_lists(question_revision_1, question_revision_2):
                 pass

--- a/app/main/helpers/diff_tools.py
+++ b/app/main/helpers/diff_tools.py
@@ -26,37 +26,39 @@ def get_diffs_from_service_data(
 
     for section in sections:
         for question in section['questions']:
-            revisions_are_valid = True
-            question_revision_1 = revision_1.get(question['id'], [])
-            question_revision_2 = revision_2.get(question['id'], [])
+            question_revision_1, question_revision_2 = None, None
 
-            if all_are_lists(question_revision_1, question_revision_2):
-                pass
+            if all_are_lists(
+                    revision_1.get(question['id'], []),
+                    revision_2.get(question['id'], [])
+            ):
+                question_revision_1 = revision_1.get(question['id'], [])
+                question_revision_2 = revision_2.get(question['id'], [])
 
-            elif all_are_strings(question_revision_1, question_revision_2):
-                question_revision_1 = question_revision_1.splitlines()
-                question_revision_2 = question_revision_2.splitlines()
+            elif all_are_strings(
+                    revision_1.get(question['id'], ''),
+                    revision_2.get(question['id'], '')
+            ):
+                question_revision_1 = revision_1.get(question['id'], '').splitlines()
+                question_revision_2 = revision_2.get(question['id'], '').splitlines()
 
-            else:
-                revisions_are_valid = False
-
-            if revisions_are_valid:
+            if question_revision_1 is not None and question_revision_2 is not None:
                 question_diff = render_lines(
                     question_revision_1,
                     question_revision_2,
                     include_unchanged_lines_in_output
                 )
 
-            # if arrays are empty, there are no changes for this question
-            if question_diff['revision_1'] or question_diff['revision_2']:
-                diffs.append({
-                    'section_name': section['name'],
-                    'label': question['question'],
-                    'revisions':
-                        [val + question_diff['revision_2'][i]
-                         for i, val
-                         in enumerate(question_diff['revision_1'])]
-                })
+                # if arrays are empty, there are no changes for this question
+                if question_diff['revision_1'] or question_diff['revision_2']:
+                    diffs.append({
+                        'section_name': section['name'],
+                        'label': question['question'],
+                        'revisions':
+                            [val + question_diff['revision_2'][i]
+                             for i, val
+                             in enumerate(question_diff['revision_1'])]
+                    })
 
     return diffs
 
@@ -115,6 +117,7 @@ def render_lines(
         lines['revision_2'].append(
             Markup(render_words_html(revision_2_words, index+1))
         )
+
     return lines
 
 

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -358,10 +358,11 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
                 'supplierId': 2,
                 'updatedAt': '2014-12-04T10:55:25.00000Z'
             }},
+            # missing the serviceSummary
             50: {'services': {
                 'id': 1,
                 'supplierId': 2,
-                'updatedAt': '2014-12-02T10:55:25.00000Z',
+                'updatedAt': '2014-12-03T10:55:25.00000Z',
                 'serviceName': '<h1>Cloudy</h1> Cloud Service'
             }},
         }

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -364,7 +364,7 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
                 'supplierId': 2,
                 'updatedAt': '2014-12-03T10:55:25.00000Z',
                 'serviceName': '<h1>Cloudy</h1> Cloud Service'
-            }},
+            }}
         }
 
         self._service_not_found = {
@@ -372,6 +372,24 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
                      'entered the URL manually please check your spelling and '
                      'try again.'
             }
+
+    class TestContent(object):
+        def __init__(self):
+            self.sections = [{
+                'editable': True,
+                'name': 'Description',
+                'questions': [
+                    {
+                        'question': 'Service name',
+                        'id': 'serviceName'
+                    },
+                    {
+                        'question': 'Service summary',
+                        'id': 'serviceSummary',
+                    }
+                ],
+                'id': 'description'
+            }]
 
     def _get_archived_service(self, *args):
         try:
@@ -432,28 +450,10 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.service_content')
     def test_can_get_archived_services_with_dates_and_diffs(self, service_content):
 
-        class TestContent(object):
-            def __init__(self):
-                self.sections = [{
-                    'editable': True,
-                    'name': 'Description',
-                    'questions': [
-                        {
-                            'question': 'Service name',
-                            'id': 'serviceName'
-                        },
-                        {
-                            'question': 'Service summary',
-                            'id': 'serviceSummary',
-                        }
-                    ],
-                    'id': 'description'
-                }]
-
         class TestBuilder(object):
             @staticmethod
             def filter(*args):
-                return TestContent()
+                return self.TestContent()
 
         service_content.get_builder.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '20')
@@ -493,28 +493,10 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.service_content')
     def test_can_get_archived_services_with_differing_keys(self, service_content):
 
-        class TestContent(object):
-            def __init__(self):
-                self.sections = [{
-                    'editable': True,
-                    'name': 'Description',
-                    'questions': [
-                        {
-                            'question': 'Service name',
-                            'id': 'serviceName'
-                        },
-                        {
-                            'question': 'Service summary',
-                            'id': 'serviceSummary',
-                        }
-                    ],
-                    'id': 'description'
-                }]
-
         class TestBuilder(object):
             @staticmethod
             def filter(*args):
-                return TestContent()
+                return self.TestContent()
 
         service_content.get_builder.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '50')

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -357,7 +357,13 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
                 'id': 2,
                 'supplierId': 2,
                 'updatedAt': '2014-12-04T10:55:25.00000Z'
-            }}
+            }},
+            50: {'services': {
+                'id': 1,
+                'supplierId': 2,
+                'updatedAt': '2014-12-02T10:55:25.00000Z',
+                'serviceName': '<h1>Cloudy</h1> Cloud Service'
+            }},
         }
 
         self._service_not_found = {
@@ -482,3 +488,33 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
             '<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />')  # noqa
             in self.strip_all_whitespace(response.get_data(as_text=True))
         )
+
+    @mock.patch('app.main.views.services.service_content')
+    def test_can_get_archived_services_with_differing_keys(self, service_content):
+
+        class TestContent(object):
+            def __init__(self):
+                self.sections = [{
+                    'editable': True,
+                    'name': 'Description',
+                    'questions': [
+                        {
+                            'question': 'Service name',
+                            'id': 'serviceName'
+                        },
+                        {
+                            'question': 'Service summary',
+                            'id': 'serviceSummary',
+                        }
+                    ],
+                    'id': 'description'
+                }]
+
+        class TestBuilder(object):
+            @staticmethod
+            def filter(*args):
+                return TestContent()
+
+        service_content.get_builder.return_value = TestBuilder()
+        response = self._get_archived_services_response('10', '50')
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
If one of the keys was non-existent, the diff page would break.

```python
# Would both throw a KeyErrors
revision_1 = { 'serviceName': "Paul's Service" }
revision_2 = {}

...

revision_1 = {}
revision_2 = { 'serviceFeatures': [ "Fixes your computer", "Makes you tea"] }
```
New update makes sure that the diff page handles the case where a key exists in one revision and not the other.

There's nothing in the interface differentiating between a new key being added and a new value being added, but I don't think that's actually a meaningful difference.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/98947448)

***

#### Key (containing a list) exists in revision 2, not revision 1
![screen shot 2015-07-23 at 09 45 43](https://cloud.githubusercontent.com/assets/2454380/8847001/f4046a44-3122-11e5-99ab-495e655e9e00.png)

####  Key (containing a string) exists in revision 1, not revision 2
![screen shot 2015-07-23 at 09 46 18](https://cloud.githubusercontent.com/assets/2454380/8846992/e7ba63e2-3122-11e5-8100-d2bb742ca4a0.png)

***

##### Note: 
If a searched-for key doesn't exist in *either* revision, two empty values are assigned but they won't show up in the diff page because they're not different from each other.