### PR TITLE
[#100210316] Add an audit event for inviting users

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -6,6 +6,7 @@ from . import get_template_data
 from ... import data_api_client
 from ..forms import EmailAddressForm
 from dmutils.apiclient.errors import HTTPError
+from dmutils.audit import AuditTypes
 from dmutils.email import send_email, \
     generate_token, MandrillException
 
@@ -119,6 +120,13 @@ def invite_user(supplier_id):
                     current_user.supplier_id)
             )
             abort(503, "Failed to send user invite reset")
+
+        data_api_client.create_audit_event(
+            audit_type=AuditTypes.invite_user,
+            user=current_user.email_address,
+            object_type='suppliers',
+            object_id=supplier_id,
+            data={'invitedEmail': form.email_address.data})
 
         flash('user_invited', 'success')
         return redirect(url_for('.find_supplier_users', supplier_id=supplier_id))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@4.1.1#egg=digitalmarketplace-utils==4.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@5.4.0#egg=digitalmarketplace-utils==5.4.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/100210316

Log when users are invited by admin users as well. I have decided to not log anything specific to identify the action as coming from the admin application. This can be determined from the role of the user performing the action. It is very unlikely that roles would change from 'supplier' to 'admin'.