### PR TITLE
Pass AuditType objects to data API client

### DIFF
--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -18,7 +18,7 @@ def service_update_audits():
 
     if form.validate():
         audit_events = data_api_client.find_audit_events(
-            audit_type=AuditTypes.update_service.value,
+            audit_type=AuditTypes.update_service,
             acknowledged=form.default_acknowledged(),
             audit_date=form.format_date()
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@5.4.0#egg=digitalmarketplace-utils==5.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.1.0#egg=digitalmarketplace-utils==6.1.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -2,6 +2,7 @@ import mock
 
 from datetime import datetime
 from app import DISPLAY_DATE_FORMAT
+from dmutils.audit import AuditTypes
 
 from ...helpers import LoggedInApplicationTest
 
@@ -126,7 +127,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         )
         data_api_client.find_audit_events.assert_called_with(
             audit_date='2006-01-01',
-            audit_type='update_service',
+            audit_type=AuditTypes.update_service,
             acknowledged='false')
 
     @mock.patch('app.main.views.service_updates.data_api_client')
@@ -147,7 +148,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         )
         data_api_client.find_audit_events.assert_called_with(
             audit_date=None,
-            audit_type='update_service',
+            audit_type=AuditTypes.update_service,
             acknowledged='false')
 
     @mock.patch('app.main.views.service_updates.data_api_client')
@@ -158,7 +159,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         self.assertEquals(200, response.status_code)
 
         data_api_client.find_audit_events.assert_called_with(
-            audit_type='update_service',
+            audit_type=AuditTypes.update_service,
             audit_date='2006-01-01',
             acknowledged='all')
 
@@ -170,7 +171,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         self.assertEquals(200, response.status_code)
 
         data_api_client.find_audit_events.assert_called_with(
-            audit_type='update_service',
+            audit_type=AuditTypes.update_service,
             audit_date=None,
             acknowledged='all')
 
@@ -259,7 +260,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         )
         data_api_client.find_audit_events.assert_called_with(
             audit_date='2006-01-01',
-            audit_type='update_service',
+            audit_type=AuditTypes.update_service,
             acknowledged='false')
 
     @mock.patch('app.main.views.service_updates.data_api_client')
@@ -326,7 +327,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             self._replace_whitespace(response.get_data(as_text=True))
         )
         data_api_client.find_audit_events.assert_called_with(
-            audit_type='update_service',
+            audit_type=AuditTypes.update_service,
             acknowledged='false',
             audit_date='2010-01-01')
 


### PR DESCRIPTION
Since 6.0.0 [1] the data API client expects AuditTypes instances.

[1]
https://github.com/alphagov/digitalmarketplace-utils/compare/5.3.1...6.0.0