### PR TITLE
Admin-ccs role

### DIFF
--- a/app/main/auth.py
+++ b/app/main/auth.py
@@ -1,0 +1,30 @@
+from functools import wraps
+
+from flask import abort
+from flask_login import current_user
+
+
+def role_required(*roles):
+    """Ensure that logged in user has one of the required roles.
+
+    Return 403 if the user doesn't have a required role.
+
+    Should be applied before the `@login_required` decorator:
+
+        @login_required
+        @role_required('admin', 'admin-ccs')
+        def view():
+            ...
+
+    """
+
+    def role_decorator(func):
+        @wraps(func)
+        def decorated_view(*args, **kwargs):
+            if not any(current_user.has_role(role) for role in roles):
+                return abort(403, "One of {} roles required".format(", ".join(roles)))
+            return func(*args, **kwargs)
+
+        return decorated_view
+
+    return role_decorator

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -14,6 +14,12 @@ def page_not_found(e):
                            **main.config['BASE_TEMPLATE_DATA']), 404
 
 
+@main.app_errorhandler(403)
+def page_not_found(e):
+    return render_template("errors/403.html",
+                           **main.config['BASE_TEMPLATE_DATA']), 403
+
+
 @main.app_errorhandler(500)
 def exception(e):
     return render_template("errors/500.html",

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -25,7 +25,7 @@ def process_login():
             form.password.data,
             supplier=False)
 
-        if not user_has_role(user_json, 'admin'):
+        if not any(user_has_role(user_json, role) for role in ['admin', 'admin-ccs']):
             message = "login.fail: Failed to log in: %s"
             current_app.logger.info(message, form.email_address.data)
             flash('no_account', 'error')

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -7,6 +7,7 @@ from dmutils.audit import AuditTypes
 
 from ... import data_api_client
 from .. import main
+from ..auth import role_required
 from ..forms import ServiceUpdateAuditEventsForm
 from . import get_template_data
 
@@ -42,6 +43,7 @@ def service_update_audits():
 
 @main.route('/service-updates/<audit_id>/acknowledge', methods=['POST'])
 @login_required
+@role_required('admin')
 def submit_service_update_acknowledgment(audit_id):
     form = ServiceUpdateAuditEventsForm(request.form)
     if form.validate():

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -14,6 +14,7 @@ from ... import service_content
 from .. import main
 from . import get_template_data
 
+from ..auth import role_required
 from ..helpers.diff_tools import get_diffs_from_service_data, get_revision_dates
 
 presenters = Presenters()
@@ -59,6 +60,7 @@ def view(service_id):
 
 @main.route('/services/status/<string:service_id>', methods=['POST'])
 @login_required
+@role_required('admin')
 def update_service_status(service_id):
     frontend_status = request.form['service_status']
 
@@ -94,6 +96,7 @@ def update_service_status(service_id):
 
 @main.route('/services/<service_id>/edit/<section>', methods=['GET'])
 @login_required
+@role_required('admin')
 def edit(service_id, section):
     service_data = data_api_client.get_service(service_id)['services']
 
@@ -175,6 +178,7 @@ def compare(old_archived_service_id, new_archived_service_id):
 
 @main.route('/services/<service_id>/edit/<section>', methods=['POST'])
 @login_required
+@role_required('admin')
 def update(service_id, section):
     s3_uploader = S3(
         bucket_name=main.config['S3_DOCUMENT_BUCKET'],

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -5,6 +5,7 @@ from .. import main
 from . import get_template_data
 from ... import data_api_client
 from ..forms import EmailAddressForm
+from ..auth import role_required
 from dmutils.apiclient.errors import HTTPError
 from dmutils.audit import AuditTypes
 from dmutils.email import send_email, \
@@ -30,6 +31,7 @@ def find_supplier_users():
 
 @main.route('/suppliers/users/<int:user_id>/unlock', methods=['POST'])
 @login_required
+@role_required('admin')
 def unlock_user(user_id):
     user = data_api_client.update_user(user_id, locked=False)
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
@@ -37,6 +39,7 @@ def unlock_user(user_id):
 
 @main.route('/suppliers/users/<int:user_id>/activate', methods=['POST'])
 @login_required
+@role_required('admin')
 def activate_user(user_id):
     user = data_api_client.update_user(user_id, active=True)
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
@@ -44,6 +47,7 @@ def activate_user(user_id):
 
 @main.route('/suppliers/users/<int:user_id>/deactivate', methods=['POST'])
 @login_required
+@role_required('admin')
 def deactivate_user(user_id):
     user = data_api_client.update_user(user_id, active=False)
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
@@ -66,6 +70,7 @@ def find_supplier_services():
 
 @main.route('/suppliers/<int:supplier_id>/invite-user', methods=['POST'])
 @login_required
+@role_required('admin')
 def invite_user(supplier_id):
     form = EmailAddressForm()
 

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -77,6 +77,7 @@
       {% endfor %}
       </div><!-- end of .diff -->
 
+      {% if current_user.has_role('admin') %}
       <form action="{{ url_for('.update_service_status', service_id=service_data.id ) }}" method="post">
           <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
           <fieldset class="question">
@@ -100,6 +101,7 @@
           </fieldset>
           <button type="submit" class="button-save">Update status</button>
       </form>
+      {% endif %}
 
     {% else %}
     <h1>Error</h1>

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -1,0 +1,14 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Access denied - 403 – Digital Marketplace{% endblock %}
+
+{% block content %}
+  <div class="page-container">
+    {% with heading = "You don’t have permission to perform this action" %}
+      {% include 'toolkit/page-heading.html' %}
+    {% endwith %}
+    <p>
+      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need to access this content.
+    </p>
+  </div>
+{% endblock %}

--- a/app/templates/service_update_audits.html
+++ b/app/templates/service_update_audits.html
@@ -119,7 +119,13 @@ Digital Marketplace admin
                 ) }}
                 {% call summary.field(action=True) %}
 
-                  {% if not item.acknowledged %}
+                  {% if item.acknowledged %}
+                    {{ item.acknowledgedBy }}
+                    <br/>
+                    {{ item.createdAt|timeformat }}
+                    <br/>
+                    {{ item.createdAt|dateformat }}
+                  {% elif current_user.has_role('admin') %}
                     <form action="{{ url_for('.submit_service_update_acknowledgment', audit_id=item.id) }}" method="post">
                         <div style="display:none;">
                             <input name="csrf_token" type="hidden" value="{{ csrf }}">
@@ -128,12 +134,6 @@ Digital Marketplace admin
                         </div>
                         <button class="button-secondary">Acknowledge</button>
                     </form>
-                  {% else %}
-                    {{ item.acknowledgedBy }}
-                    <br/>
-                    {{ item.createdAt|timeformat }}
-                    <br/>
-                    {{ item.createdAt|dateformat }}
                   {% endif %}
                 {% endcall %}
               {% endcall %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -67,7 +67,7 @@
 
       {% for section in sections %}
         {{ summary.heading(section.name) }}
-        {% if section.editable %}
+        {% if section.editable and current_user.has_role('admin') %}
           {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section=section.id)) }}
         {% endif %}
         {% call(item) summary.list_table(
@@ -89,6 +89,7 @@
         {% endcall %}
       {% endfor %}
 
+      {% if current_user.has_role('admin') %}
       <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
           <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
           <fieldset class="question">
@@ -112,6 +113,7 @@
           </fieldset>
           <button type="submit" class="button-save">Update status</button>
       </form>
+      {% endif %}
 
     {% else %}
     <h1>Error</h1>

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -59,7 +59,7 @@
           </span>
         {% endcall %}
         {{ summary.edit_link(
-          'Details' if item.status == 'disabled' else 'Edit',
+          'Details' if item.status == 'disabled' or not current_user.has_role('admin') else 'Edit',
           url_for('.view', service_id=item.id)
         ) }}
       {% endcall %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -92,7 +92,7 @@
         {% endcall %}
 
         {% call summary.field() %}
-        {% if item.locked %}
+        {% if item.locked and current_user.has_role('admin') %}
         <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             {%
@@ -103,6 +103,8 @@
             {% include "toolkit/button.html" %}
             {% endwith %}
         </form>
+        {% elif item.locked %}
+            Yes
         {% else %}
             No
         {% endif %}
@@ -110,27 +112,35 @@
 
         {% call summary.field() %}
         {% if item.active %}
-        <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            {%
-                with
-                type = "destructive",
-                label = "Deactivate"
-            %}
-            {% include "toolkit/button.html" %}
-            {% endwith %}
-        </form>
+          {% if current_user.has_role('admin') %}
+            <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                {%
+                    with
+                    type = "destructive",
+                    label = "Deactivate"
+                %}
+                {% include "toolkit/button.html" %}
+                {% endwith %}
+            </form>
+          {% else %}
+            Active
+          {% endif %}
         {% else %}
-        <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            {%
-                with
-                type = "secondary",
-                label = "Activate"
-            %}
-            {% include "toolkit/button.html" %}
-            {% endwith %}
-        </form>
+          {% if current_user.has_role('admin') %}
+            <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                {%
+                    with
+                    type = "secondary",
+                    label = "Activate"
+                %}
+                {% include "toolkit/button.html" %}
+                {% endwith %}
+            </form>
+          {% else %}
+            Deactivated
+          {% endif %}
         {% endif %}
         {% endcall %}
 
@@ -139,7 +149,7 @@
     </div>
 
 
-
+    {% if current_user.has_role('admin') %}
     <div class='page-section'>
         <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
@@ -164,5 +174,6 @@
            <button class="button-save">Send invitation</button>
         </form>
     </div>
+    {% endif %}
 </div>
 {% endblock %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -25,14 +25,13 @@ class BaseApplicationTest(TestCase):
         self._default_suffix_patch.start()
 
         self._user_callback = login_manager.user_callback
+        login_manager.user_loader(self.user_loader)
 
-        def user_loader(user_id):
-            if user_id:
-                return User(
-                    user_id, 'test@example.com', None, None, False, True, 'tester', 'admin'
-                )
-
-        login_manager.user_loader(user_loader)
+    def user_loader(self, user_id):
+        if user_id:
+            return User(
+                user_id, 'test@example.com', None, None, False, True, 'tester', 'admin'
+            )
 
     def tearDown(self):
         self._s3_patch.stop()

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -7,7 +7,9 @@ try:
 except ImportError:
     from urllib.parse import urlsplit
 
-from ...helpers import BaseApplicationTest
+from dmutils.user import User
+
+from ...helpers import BaseApplicationTest, LoggedInApplicationTest
 
 
 def user_data(role='admin'):
@@ -184,3 +186,47 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
             "/admin/login",
             "Administrator login"
         )
+
+
+class TestRoleRequired(LoggedInApplicationTest):
+    def user_loader(self, user_id):
+        if user_id:
+            return User(
+                user_id, 'test@example.com', None, None, False, True, 'tester', 'admin-ccs'
+            )
+
+    def test_admin_ccs_can_view_admin_dashboard(self):
+        response = self.client.get('/admin')
+        assert_equal(200, response.status_code)
+
+    def test_admin_role_required_service_section_view(self):
+        response = self.client.get('/admin/services/1/edit/documents')
+        assert_equal(403, response.status_code)
+
+    def test_admin_role_required_service_section_edit(self):
+        response = self.client.post('/admin/services/1/edit/documents')
+        assert_equal(403, response.status_code)
+
+    def test_admin_role_required_service_status_edit(self):
+        response = self.client.post('/admin/services/status/1')
+        assert_equal(403, response.status_code)
+
+    def test_admin_role_required_audit_acknowledge(self):
+        response = self.client.post('/admin/service-updates/1/acknowledge')
+        assert_equal(403, response.status_code)
+
+    def test_admin_role_required_unlock_user(self):
+        response = self.client.post('/admin/suppliers/users/1/unlock')
+        assert_equal(403, response.status_code)
+
+    def test_admin_role_required_activate_user(self):
+        response = self.client.post('/admin/suppliers/users/1/activate')
+        assert_equal(403, response.status_code)
+
+    def test_admin_role_required_deactivate_user(self):
+        response = self.client.post('/admin/suppliers/users/1/deactivate')
+        assert_equal(403, response.status_code)
+
+    def test_admin_role_required_invite_user(self):
+        response = self.client.post('/admin/suppliers/1/invite-user')
+        assert_equal(403, response.status_code)


### PR DESCRIPTION
Part of [#101410132](https://www.pivotaltracker.com/story/show/101410132)

#### Allow users with 'admin-ccs' role to log in

#### Add 403 error handler and 403 page template
Shows a message when a user tries to access a page/view that requires
a different role.

#### Add `role_required` view decorator to check current_user role
Returns 403 if user has none of the roles listed in the decorator
arguments.

#### Add role_required('admin') decorator to non-read-only views
Limits users with 'admin-ccs' role to read-only actions by wrapping
POST and form-rendering views with `role_required('admin')`

#### Hide buttons and links to restricted actions based on user role
Adds `current_user.has_role` checks to the templates to hide service
section "Edit" links; status change, audit event "Acknowledge" and
user "Activate"/"Deactivate"/"Unlock" buttons.