### PR TITLE
Add G-Cloud 7 statistics page

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,7 +3,7 @@ from flask import Blueprint
 
 main = Blueprint('main', __name__)
 
-from .views import login, service_updates, services, suppliers
+from .views import login, service_updates, services, suppliers, stats
 from app.main import errors
 
 

--- a/app/main/helpers/sum_counts.py
+++ b/app/main/helpers/sum_counts.py
@@ -1,0 +1,15 @@
+def label_and_count(stats, groupings):
+    return [{
+        label: _sum_counts(stats, filters)
+        for label, filters in groupings.items()
+    }]
+
+
+def _sum_counts(stats, filter_by=None, sum_by='count'):
+    return sum(
+        statistic[sum_by] for statistic in stats
+        if not filter_by or all(
+            statistic.get(key) == value
+            for key, value in filter_by.items()
+        )
+    )

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -1,0 +1,73 @@
+from flask import render_template, abort
+from flask_login import login_required, current_user, flash
+
+from dmutils.apiclient import HTTPError
+
+from ..helpers.sum_counts import label_and_count
+from .. import main
+from . import get_template_data
+from ... import data_api_client
+
+
+@main.route('/statistics/<string:framework_slug>', methods=['GET'])
+@login_required
+def view_statistics(framework_slug):
+
+    try:
+        stats = data_api_client.get_framework_stats(framework_slug)
+    except HTTPError as error:
+        abort(error.status_code)
+
+    return render_template(
+        "view_statistics.html",
+        services_by_status=label_and_count(stats['services'], {
+            'draft': {
+                'status': 'not-submitted'
+            },
+            'complete': {
+                'status': 'submitted',
+                'declaration_made': False
+            },
+            'submitted': {
+                'status': 'submitted',
+                'declaration_made': True
+            }
+        }),
+        services_by_lot=label_and_count(stats['services'], {
+            'IaaS': {'lot': 'IaaS'},
+            'PaaS': {'lot': 'PaaS'},
+            'SaaS': {'lot': 'SaaS'},
+            'SCS':  {'lot': 'SCS'},
+        }),
+        interested_suppliers=label_and_count(stats['interested_suppliers'], {
+            'interested_only': {
+                'has_made_declaration': False,
+                'has_completed_services': False
+            },
+            'declaration_only': {
+                'has_made_declaration': True,
+                'has_completed_services': False
+            },
+            'completed_services_only': {
+                'has_made_declaration': False,
+                'has_completed_services': True
+            },
+            'valid_submission': {
+                'has_made_declaration': True,
+                'has_completed_services': True
+            }
+        }),
+        users=label_and_count(stats['supplier_users'], {
+            'never_logged_in': {
+                'recent_login': None
+            },
+            'not_logged_in_recently': {
+                'recent_login': False
+            },
+            'logged_in_recently': {
+                'recent_login': True
+            }
+        }),
+        stats=stats,
+        **get_template_data()
+    )

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -1,0 +1,119 @@
+{% import "toolkit/summary-table.html" as summary %}
+{% from 'macros/breadcrumb.html' import breadcrumb as breadcrumb %}
+
+{% extends "_base_page.html" %}
+{% block page_title %}
+  G-Cloud 7 Statistics – Digital Marketplace admin
+{% endblock %}
+
+{% block content %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+
+  <div class="page-container">
+    {%
+      with
+      context = "G-Cloud 7",
+      heading = "Statistics"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+
+    {{ summary.heading("Services by status") }}
+    {% call(item) summary.list_table(
+      services_by_status,
+      empty_message="Data not available",
+      caption="Services by status",
+      field_headings=[
+        "Draft",
+        "Complete",
+        "Submitted",
+      ],
+      field_headings_visible=True
+    ) %}
+      {% call summary.row() %}
+        {% call summary.field(first=True) %}
+          {{ item.draft }}
+        {% endcall %}
+        {{ summary.text(item.complete) }}
+        {{ summary.text(item.submitted) }}
+      {% endcall %}
+    {% endcall %}
+
+    {{ summary.heading("Services by lot") }}
+    {% call(item) summary.list_table(
+      services_by_lot,
+      empty_message="Data not available",
+      caption="Services by lot",
+      field_headings=[
+        "Infrastructure as a Service",
+        "Software as a Service",
+        "Platform as a Service",
+        "Specialist cloud services"
+      ],
+      field_headings_visible=True
+    ) %}
+      {% call summary.row() %}
+        {% call summary.field(first=True) %}
+          {{ item.IaaS }}
+        {% endcall %}
+        {{ summary.text(item.PaaS) }}
+        {{ summary.text(item.SaaS) }}
+        {{ summary.text(item.SCS) }}
+      {% endcall %}
+    {% endcall %}
+
+    {{ summary.heading("Suppliers") }}
+    {% call(item) summary.list_table(
+      interested_suppliers,
+      empty_message="Data not available",
+      caption="Suppliers",
+      field_headings=[
+        "Interested",
+        "Have made declaration only",
+        "Have completed services only",
+        "Have a valid submission",
+      ],
+      field_headings_visible=True
+    ) %}
+      {% call summary.row() %}
+        {% call summary.field(first=True) %}
+          {{ item.interested_only }}
+        {% endcall %}
+        {{ summary.text(item.declaration_only) }}
+        {{ summary.text(item.completed_services_only) }}
+        {{ summary.text(item.valid_submission) }}
+      {% endcall %}
+    {% endcall %}
+
+    {{ summary.heading("Users") }}
+    {% call(item) summary.list_table(
+      users,
+      empty_message="Data not available",
+      caption="Users",
+      field_headings=[
+        "Never logged in",
+        "Logged in not recently",
+        "Logged in recently",
+      ],
+      field_headings_visible=True
+    ) %}
+      {% call summary.row() %}
+        {% call summary.field(first=True) %}
+          {{ item.never_logged_in }}
+        {% endcall %}
+        {{ summary.text(item.not_logged_in_recently) }}
+        {{ summary.text(item.logged_in_recently) }}
+      {% endcall %}
+    {% endcall %}
+
+  </div>
+{% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.1.2",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633",
     "hogan": "3.0.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.1.0#egg=digitalmarketplace-utils==6.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.3.0#egg=digitalmarketplace-utils==6.3.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -29,7 +29,7 @@ class BaseApplicationTest(TestCase):
         def user_loader(user_id):
             if user_id:
                 return User(
-                    user_id, 'test@example.com', None, None, False, True, 'tester'
+                    user_id, 'test@example.com', None, None, False, True, 'tester', 'admin'
                 )
 
         login_manager.user_loader(user_loader)

--- a/tests/app/main/helpers/test_sum_counts.py
+++ b/tests/app/main/helpers/test_sum_counts.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+from unittest import TestCase
+from nose.tools import assert_equal
+
+from app.main.helpers.sum_counts import label_and_count, _sum_counts
+
+
+class TestLabelAndCount(TestCase):
+    def test_formatting(self):
+        assert_equal(
+            label_and_count({}, {
+                'one': {
+                    'filter_one': None
+                },
+                'two': {
+                    'filter_one': False,
+                    'filter_two': True,
+                },
+                'three': {
+                    'filter_two': True
+                }
+            }),
+            [{'one': 0, 'two': 0, 'three': 0}]
+        )
+
+
+class TestSumCounts(TestCase):
+    def test_summing_without_filtering(self):
+        assert_equal(
+            _sum_counts([
+                {'count': 1},
+                {'count': 2},
+                {'count': 3},
+                {'count': 4}
+            ]),
+            10
+        )
+
+    def test_summing_filtering_on_one_attribute(self):
+        assert_equal(
+            _sum_counts([
+                {'count': 1, 'include': False},
+                {'count': 2, 'include': True},
+                {'count': 3, 'include': True},
+                {'count': 4, 'include': False}
+            ], {
+                'include': True
+            }),
+            5
+        )
+
+    def test_summing_filtering_on_multiple_attributes(self):
+        assert_equal(
+            _sum_counts([
+                {'count': 1, 'include': False, 'exclude': True},
+                {'count': 2, 'include': True, 'exclude': False},
+                {'count': 3, 'include': True, 'exclude': True},
+                {'count': 4, 'include': False, 'exclude': False}
+            ], {
+                'include': True,
+                'exclude': False
+            }),
+            2
+        )
+
+    def test_summing_by_different_column(self):
+        assert_equal(
+            _sum_counts([
+                {'count': 1, 'new_count': 10},
+                {'count': 2, 'new_count': 20},
+                {'count': 3, 'new_count': 30},
+                {'count': 4, 'new_count': 40}
+            ], sum_by='new_count'),
+            100
+        )

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -1,0 +1,32 @@
+import mock
+
+from dmutils.apiclient import HTTPError
+from ...helpers import LoggedInApplicationTest
+
+
+@mock.patch('app.main.views.stats.data_api_client')
+class TestStats(LoggedInApplicationTest):
+
+    def test_get_stats_page(self, data_api_client):
+        data_api_client.get_framework_stats.return_value = {
+            'services': {}, 'interested_suppliers': {}, 'supplier_users': {}
+        }
+        response = self.client.get('/admin/statistics/g-cloud-7')
+
+        data_api_client.get_framework_stats.assert_called_with('g-cloud-7')
+
+        self.assertEquals(200, response.status_code)
+
+    def test_get_stats_page_for_invalid_framework(self, data_api_client):
+        api_response = mock.Mock()
+        api_response.status_code = 404
+        data_api_client.get_framework_stats.side_effect = HTTPError(api_response)
+        response = self.client.get('/admin/statistics/g-cloud-11')
+        self.assertEquals(404, response.status_code)
+
+    def test_get_stats_page_when_API_is_down(self, data_api_client):
+        api_response = mock.Mock()
+        api_response.status_code = 500
+        data_api_client.get_framework_stats.side_effect = HTTPError(api_response)
+        response = self.client.get('/admin/statistics/g-cloud-7')
+        self.assertEquals(500, response.status_code)


### PR DESCRIPTION
This PR takes the data produced by the API in… alphagov/digitalmarketplace-api#211

…and puts it, tabulated, onto the page, so that we can know:
- services broken down by status
- services broken down by lot
- suppliers broken down by how far through the process they are
- users broken down by how recently they logged in

This is a first step towards:
- showing the data over time
- transforming the data into graphs
- making a 'big screen' view

--

![image](https://cloud.githubusercontent.com/assets/355079/9442395/ae3a6968-4a73-11e5-9267-8ef3649cf68d.png)
