### PR TITLE
[#100305120] Remove local dates for dmutils dates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,6 @@ from flask_wtf.csrf import CsrfProtect
 from dmutils import apiclient, init_app, flask_featureflags, formats
 from dmutils.user import User
 from dmutils.content_loader import ContentLoader
-
 from config import configs
 
 
@@ -16,9 +15,6 @@ csrf = CsrfProtect()
 data_api_client = apiclient.DataAPIClient()
 feature_flags = flask_featureflags.FeatureFlag()
 login_manager = LoginManager()
-DISPLAY_DATE_FORMAT = '%d/%m/%Y'
-DISPLAY_TIME_FORMAT = '%H:%M:%S'
-DISPLAY_DATETIME_FORMAT = '%A, %d %B %Y at %H:%M'
 
 service_content = ContentLoader(
     "app/section_order.yml", "app/content/g6/"
@@ -55,20 +51,6 @@ def create_app(config_name):
     def remove_trailing_slash():
         if request.path != '/' and request.path.endswith('/'):
             return redirect(request.path[:-1], code=301)
-
-    @application.template_filter('timeformat')
-    def timeformat(value):
-        return datetime.strptime(
-            value, formats.DATETIME_FORMAT).strftime(DISPLAY_TIME_FORMAT)
-
-    @application.template_filter('dateformat')
-    def dateformat(value):
-        return datetime.strptime(
-            value, formats.DATETIME_FORMAT).strftime(DISPLAY_DATE_FORMAT)
-
-    @application.template_filter('displaydateformat')
-    def display_date_format(value):
-        return value.strftime(DISPLAY_DATE_FORMAT)
 
     return application
 

--- a/app/main/helpers/diff_tools.py
+++ b/app/main/helpers/diff_tools.py
@@ -6,8 +6,7 @@ except ImportError:
 from datetime import datetime
 from flask import Markup, escape
 from flask._compat import string_types
-from dmutils.formats import DATETIME_FORMAT
-from ... import DISPLAY_DATETIME_FORMAT
+from dmutils.formats import DATETIME_FORMAT, DISPLAY_DATETIME_FORMAT
 
 
 def get_diffs_from_service_data(

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -4,6 +4,7 @@ from flask import request, render_template, redirect, url_for
 from flask_login import login_required, current_user
 
 from dmutils.audit import AuditTypes
+from dmutils.formats import DATETIME_FORMAT
 
 from ... import data_api_client
 from .. import main
@@ -26,7 +27,7 @@ def service_update_audits():
 
         return render_template(
             "service_update_audits.html",
-            today=form.format_date_for_display(),
+            today=form.format_date_for_display().strftime(DATETIME_FORMAT),
             acknowledged=form.default_acknowledged(),
             audit_events=audit_events['auditEvents'],
             form=form,
@@ -34,7 +35,7 @@ def service_update_audits():
     else:
         return render_template(
             "service_update_audits.html",
-            today=datetime.utcnow(),
+            today=datetime.utcnow().strftime(DATETIME_FORMAT),
             acknowledged=form.default_acknowledged(),
             audit_events=[],
             form=form,
@@ -58,7 +59,7 @@ def submit_service_update_acknowledgment(audit_id):
     else:
         return render_template(
             "service_update_audits.html",
-            today=datetime.utcnow(),
+            today=datetime.utcnow().strftime(DATETIME_FORMAT),
             audit_events=None,
             acknowledged=form.default_acknowledged(),
             form=form,

--- a/app/templates/service_update_audits.html
+++ b/app/templates/service_update_audits.html
@@ -25,7 +25,7 @@ Digital Marketplace admin
 <div class="page-container">
     <div class="grid-row">
         <div class="service-title">
-            {{ page_heading(today|displaydateformat, "Activity for", "page-heading-smaller") }}
+            {{ page_heading(today|dateformat, "Activity for", "page-heading-smaller") }}
         </div>
     </div>
     <div class="grid-row">
@@ -107,7 +107,7 @@ Digital Marketplace admin
                 {% call summary.field() %}
                   {{ item.createdAt|timeformat }}
                   <br/>
-                  {{ item.createdAt|dateformat }}
+                  {{ item.createdAt|shortdateformat }}
                 {% endcall %}
                 {{ summary.edit_link(
                   "View changes",
@@ -124,7 +124,7 @@ Digital Marketplace admin
                     <br/>
                     {{ item.createdAt|timeformat }}
                     <br/>
-                    {{ item.createdAt|dateformat }}
+                    {{ item.createdAt|shortdateformat }}
                   {% elif current_user.has_role('admin') %}
                     <form action="{{ url_for('.submit_service_update_acknowledgment', audit_id=item.id) }}" method="post">
                         <div style="display:none;">

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -76,7 +76,7 @@
         {% call summary.field() %}
             {% if item.loggedInAt %}
                 {{ item.loggedInAt|timeformat }}<br/>
-                {{ item.loggedInAt|dateformat }}
+                {{ item.loggedInAt|shortdateformat }}
             {% else %}
                 Never
             {% endif %}
@@ -85,7 +85,7 @@
         {% call summary.field() %}
             {% if item.passwordChangedAt %}
                 {{ item.passwordChangedAt|timeformat }}<br/>
-                {{ item.passwordChangedAt|dateformat }}
+                {{ item.passwordChangedAt|shortdateformat }}
             {% else %}
                 Never
             {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.3.0#egg=digitalmarketplace-utils==6.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.2#egg=digitalmarketplace-utils==6.5.2
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -1,7 +1,7 @@
 import mock
 
 from datetime import datetime
-from app import DISPLAY_DATE_FORMAT
+from dmutils.formats import DISPLAY_DATE_FORMAT
 from dmutils.audit import AuditTypes
 
 from ...helpers import LoggedInApplicationTest
@@ -188,7 +188,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             Activity for
         </p>
         <h1>
-        01/01/2010
+        Friday 01 January 2010
         </h1>
         """
 
@@ -308,7 +308,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         )
         self.assertIn(
             self._replace_whitespace(
-               '<td class="summary-item-field"><span>08:49:22<br/>17/06/2015</span></td>'),  # noqa
+               '<td class="summary-item-field"><span>09:49:22<br/>17 June</span></td>'),  # noqa
             self._replace_whitespace(response.get_data(as_text=True))
         )
         self.assertIn(

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -462,35 +462,35 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
         response = self._get_archived_services_response('10', '20')
 
         # check title is there
-        self.assertTrue(
-            self.strip_all_whitespace('<h1>&lt;h1&gt;Cloudy&lt;/h1&gt; Cloud Service</h1>')  # noqa
-            in self.strip_all_whitespace(response.get_data(as_text=True))
+        self.assertIn(
+            self.strip_all_whitespace('<h1>&lt;h1&gt;Cloudy&lt;/h1&gt; Cloud Service</h1>'),
+            self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
         # check dates are right
-        self.assertTrue(
-            self.strip_all_whitespace('Monday, 01 December 2014 at 10:55')
-            in self.strip_all_whitespace(response.get_data(as_text=True))
+        self.assertIn(
+            self.strip_all_whitespace('Monday 01 December 2014 at 10:55'),
+            self.strip_all_whitespace(response.get_data(as_text=True))
         )
-        self.assertTrue(
-            self.strip_all_whitespace('Tuesday, 02 December 2014 at 10:55')
-            in self.strip_all_whitespace(response.get_data(as_text=True))
+        self.assertIn(
+            self.strip_all_whitespace('Tuesday 02 December 2014 at 10:55'),
+            self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
         # check lines are there
-        self.assertTrue(
-            self.strip_all_whitespace('<td class=\'line-content unchanged\'>Cloud Service</td>')  # noqa
-            in self.strip_all_whitespace(response.get_data(as_text=True))
+        self.assertIn(
+            self.strip_all_whitespace('<td class=\'line-content unchanged\'>Cloud Service</td>'),
+            self.strip_all_whitespace(response.get_data(as_text=True))
         )
-        self.assertTrue(
-                self.strip_all_whitespace('<td class=\'line-content addition\'><strong>&lt;h1&gt;Cloudy&lt;/h1&gt;</strong> Cloud Service</td>')  # noqa
-            in self.strip_all_whitespace(response.get_data(as_text=True))
+        self.assertIn(
+            self.strip_all_whitespace('<td class=\'line-content addition\'><strong>&lt;h1&gt;Cloudy&lt;/h1&gt;</strong> Cloud Service</td>'),  # noqa
+            self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
         # check status is right
-        self.assertTrue(self.strip_all_whitespace(
-            '<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />')  # noqa
-            in self.strip_all_whitespace(response.get_data(as_text=True))
+        self.assertIn(self.strip_all_whitespace(
+            '<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />'),  # noqa
+            self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
     @mock.patch('app.main.views.services.service_content')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -108,19 +108,19 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
         self.assertIn(
-            "09:33:53",
+            "10:33:53",
             response.get_data(as_text=True)
         )
         self.assertIn(
-            "23/07/2015",
+            "Thursday 23 July 2015",
             response.get_data(as_text=True)
         )
         self.assertIn(
-            "12:46:01",
+            "13:46:01",
             response.get_data(as_text=True)
         )
         self.assertIn(
-            "29/06/2015",
+            "Monday 29 June 2015",
             response.get_data(as_text=True)
         )
         self.assertIn(

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -112,7 +112,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
         self.assertIn(
-            "Thursday 23 July 2015",
+            "23 July",
             response.get_data(as_text=True)
         )
         self.assertIn(
@@ -120,7 +120,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
         self.assertIn(
-            "Monday 29 June 2015",
+            "29 June",
             response.get_data(as_text=True)
         )
         self.assertIn(


### PR DESCRIPTION
Got rid of all in-app date formats and presentation logic for their equivalents in dmutils.
This means that our times are now displayed in B<sub>ritish</sub>S<sub>tandard</sub>T<sub>ime</sub> rather than UTC.

I also switched up a few `assertTrue`s for `assertIn`s because the error messages you get back are more helpful.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/100305120)