### PR TITLE
Update MI page to work with declaration status

### DIFF
--- a/app/main/helpers/sum_counts.py
+++ b/app/main/helpers/sum_counts.py
@@ -9,7 +9,7 @@ def _sum_counts(stats, filter_by=None, sum_by='count'):
     return sum(
         statistic[sum_by] for statistic in stats
         if not filter_by or all(
-            statistic.get(key) == value
+            statistic.get(key) in value if isinstance(value, list) else statistic.get(key) == value
             for key, value in filter_by.items()
         )
     )

--- a/app/main/helpers/sum_counts.py
+++ b/app/main/helpers/sum_counts.py
@@ -9,7 +9,14 @@ def _sum_counts(stats, filter_by=None, sum_by='count'):
     return sum(
         statistic[sum_by] for statistic in stats
         if not filter_by or all(
-            statistic.get(key) in value if isinstance(value, list) else statistic.get(key) == value
+            _find(statistic.get(key), value)
             for key, value in filter_by.items()
         )
     )
+
+
+def _find(statistic, filter_value):
+    if isinstance(filter_value, list):
+        return statistic in filter_value
+    else:
+        return statistic == filter_value

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -41,19 +41,19 @@ def view_statistics(framework_slug):
         }),
         interested_suppliers=label_and_count(stats['interested_suppliers'], {
             'interested_only': {
-                'has_made_declaration': False,
+                'declaration_status': None,
                 'has_completed_services': False
             },
             'declaration_only': {
-                'has_made_declaration': True,
+                'declaration_status': 'complete',
                 'has_completed_services': False
             },
             'completed_services_only': {
-                'has_made_declaration': False,
+                'declaration_status': [None, 'started'],
                 'has_completed_services': True
             },
             'valid_submission': {
-                'has_made_declaration': True,
+                'declaration_status': 'complete',
                 'has_completed_services': True
             }
         }),

--- a/tests/app/main/helpers/test_sum_counts.py
+++ b/tests/app/main/helpers/test_sum_counts.py
@@ -63,6 +63,19 @@ class TestSumCounts(TestCase):
             2
         )
 
+    def test_summing_filtering_on_various_acceptable_attributes(self):
+        assert_equal(
+            _sum_counts([
+                {'count': 1, 'colour': 'cyan'},
+                {'count': 2, 'colour': 'yellow'},
+                {'count': 3, 'colour': 'magenta'},
+                {'count': 4, 'colour': 'black'}
+            ], {
+                'colour': ['cyan', 'yellow', 'magenta']
+            }),
+            6
+        )
+
     def test_summing_by_different_column(self):
         assert_equal(
             _sum_counts([

--- a/tests/app/main/helpers/test_sum_counts.py
+++ b/tests/app/main/helpers/test_sum_counts.py
@@ -1,8 +1,8 @@
 # coding=utf-8
 from unittest import TestCase
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true, assert_false
 
-from app.main.helpers.sum_counts import label_and_count, _sum_counts
+from app.main.helpers.sum_counts import label_and_count, _sum_counts, _find
 
 
 class TestLabelAndCount(TestCase):
@@ -85,4 +85,51 @@ class TestSumCounts(TestCase):
                 {'count': 4, 'new_count': 40}
             ], sum_by='new_count'),
             100
+        )
+
+
+class TestFind(TestCase):
+    def test_find_string(self):
+        assert_true(
+            _find('word', 'word'),
+        )
+        assert_false(
+            _find('drow', 'word')
+        )
+
+    def test_doesnt_match_substring(self):
+        assert_false(
+            _find('word', 'word1234')
+        )
+
+    def test_find_number(self):
+        assert_true(
+            _find(99, 99)
+        )
+        assert_false(
+            _find(99, 99.99)
+        )
+
+    def test_find_none(self):
+        assert_true(
+            _find(None, None),
+        )
+        assert_false(
+            _find(None, 'None')
+        )
+
+    def test_find_boolean(self):
+        assert_true(
+            _find(True, True),
+        )
+        assert_false(
+            _find(False, True)
+        )
+
+    def test_find_in_list(self):
+        assert_true(
+            _find('yes', [True, 0, 'yes']),
+        )
+        assert_false(
+            _find('no', [True, 0, 'yes']),
         )


### PR DESCRIPTION
Declaration status has changed from being true false to:

- `null` if declaration wasn't started (first page wasn't saved)
- `"started"` if declaration was started but not complete
- `"complete"` if declaration is complete

This commit doesn't expose this difference to the user (we can consider this later) but keeps the stats working.