### PR TITLE
Display changes in framework statistics over time

### DIFF
--- a/app/assets/javascripts/_tables-to-charts.js
+++ b/app/assets/javascripts/_tables-to-charts.js
@@ -2,16 +2,29 @@
 
   GOVUK.GDM.tablesToCharts = function() {
 
+    var isBigScreen = $("#framework-statistics-big-screen").length;
+
     $(".framework-statistics table")
       .each(function(tableIndex) {
 
-        var columns = [];
+        var columns = [], groups = [], types = {}, typesIndex = 0, typesList = [
+          "area", "line", "area", "area"
+        ];
 
         $("thead th", this).each(function(colIndex) {
-          console.log($.trim($(this).text()));
-          columns.push([
-            $.trim($(this).text())
-          ]);
+
+          var columnHeading = $.trim($(this).text()),
+              chartType = typesList[tableIndex];
+
+          columns.push([columnHeading]);
+
+          if (colIndex) {
+            if ("area" == chartType) {
+              groups.push(columnHeading);
+            }
+            types[columnHeading] = chartType;
+          }
+
         });
 
         $("tbody tr", this).each(function(rowIndex) {
@@ -26,22 +39,24 @@
 
         });
 
-        $(this).before($("<div id='chart-" + tableIndex + "'/>"));
-
-        console.log(columns);
+        $(this).before($("<div class='statistics-chart' id='chart-" + tableIndex + "'/>"));
 
         var chart = c3.generate({
             bindto: '#chart-' + tableIndex,
             data: {
               x: "Date and time",
-              xFormat: "%Y-%m-%dT%H:%M",
-              columns: columns
+              xFormat: "%Y/%m/%d %H:%M:%S",
+              columns: columns,
+              order: null,
+              types: types,
+              groups: [groups],
             },
             axis: {
               x: {
                 type: 'timeseries',
                 tick: {
-                  format: '%Y-%m-%d'
+                  format: '%Y-%m-%d %H:%M:%S',
+                  fit: false
                 },
                 show: false
               },
@@ -51,6 +66,18 @@
             },
             legend: {
               show: false
+            },
+            color: {
+              pattern: isBigScreen ?
+                ['#55ffee', '#ffee55', '#ff55ee', '#90ff00']
+                :
+                ['#D53880', '#2B8CC4', '#6F72AF', '#F47738']
+            },
+            size: {
+              height: isBigScreen ? 320 : 480
+            },
+            tooltip: {
+              show: !isBigScreen
             }
         });
 

--- a/app/assets/javascripts/_tables-to-charts.js
+++ b/app/assets/javascripts/_tables-to-charts.js
@@ -1,0 +1,61 @@
+(function(GOVUK, GDM) {
+
+  GOVUK.GDM.tablesToCharts = function() {
+
+    $(".framework-statistics table")
+      .each(function(tableIndex) {
+
+        var columns = [];
+
+        $("thead th", this).each(function(colIndex) {
+          console.log($.trim($(this).text()));
+          columns.push([
+            $.trim($(this).text())
+          ]);
+        });
+
+        $("tbody tr", this).each(function(rowIndex) {
+
+          $("td", this).each(function(colIndex) {
+
+            columns[colIndex].push(
+              $.trim($(this).text())
+            );
+
+          });
+
+        });
+
+        $(this).before($("<div id='chart-" + tableIndex + "'/>"));
+
+        console.log(columns);
+
+        var chart = c3.generate({
+            bindto: '#chart-' + tableIndex,
+            data: {
+              x: "Date and time",
+              xFormat: "%Y-%m-%dT%H:%M",
+              columns: columns
+            },
+            axis: {
+              x: {
+                type: 'timeseries',
+                tick: {
+                  format: '%Y-%m-%d'
+                },
+                show: false
+              },
+              y: {
+                show: false
+              }
+            },
+            legend: {
+              show: false
+            }
+        });
+
+      });
+
+  };
+
+}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,11 +7,15 @@
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
 //= include ../../../bower_components/jquery/dist/jquery.js
 //= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
+//= include ../../../bower_components/d3/d3.js
+//= include ../../../bower_components/c3/c3.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include _selection-buttons.js
 //= include _scroll-through-statistics.js
+//= include _tables-to-charts.js
+
 (function(GOVUK, GDM) {
 
   "use strict";

--- a/app/assets/scss/_c3.scss
+++ b/app/assets/scss/_c3.scss
@@ -1,0 +1,167 @@
+@import "colours";
+
+/*-- Chart --*/
+.c3 svg {
+  font-size: 14px;
+}
+
+.c3 path, .c3 line {
+  fill: none;
+  stroke: #000; }
+
+.c3 text {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none; }
+
+.c3-legend-item-tile, .c3-xgrid-focus, .c3-ygrid, .c3-event-rect, .c3-bars path {
+  shape-rendering: crispEdges; }
+
+.c3-chart-arc path {
+  stroke: #fff; }
+
+.c3-chart-arc text {
+  fill: #fff;
+  font-size: 14px; }
+
+/*-- Axis --*/
+/*-- Grid --*/
+.c3-grid line {
+  stroke: #aaa; }
+
+.c3-grid text {
+  fill: #aaa; }
+
+.c3-xgrid, .c3-ygrid {
+  stroke-dasharray: 3 3; }
+
+/*-- Text on Chart --*/
+.c3-text.c3-empty {
+  fill: #808080;
+  font-size: 2em; }
+
+/*-- Line --*/
+.c3-line {
+  stroke-width: 3px;
+}
+
+/*-- Point --*/
+.c3-circle {
+  display: none;
+}
+
+.c3-circle._expanded_ {
+  stroke-width: 1px;
+  stroke: white; }
+
+.c3-selected-circle {
+  fill: white;
+  stroke-width: 2px; }
+
+/*-- Bar --*/
+.c3-bar {
+  stroke-width: 0; }
+
+.c3-bar._expanded_ {
+  fill-opacity: 0.75; }
+
+/*-- Focus --*/
+.c3-target.c3-focused {
+  opacity: 1; }
+
+.c3-target.c3-focused path.c3-line, .c3-target.c3-focused path.c3-step {
+  stroke-width: 2px; }
+
+.c3-target.c3-defocused {
+  opacity: 0.3 !important; }
+
+/*-- Region --*/
+.c3-region {
+  fill: steelblue;
+  fill-opacity: 0.1; }
+
+/*-- Brush --*/
+.c3-brush .extent {
+  fill-opacity: 0.1; }
+
+/*-- Select - Drag --*/
+/*-- Legend --*/
+.c3-legend-item {
+  font-size: 12px; }
+
+.c3-legend-item-hidden {
+  opacity: 0.15; }
+
+.c3-legend-background {
+  opacity: 0.75;
+  fill: white;
+  stroke: lightgray;
+  stroke-width: 1; }
+
+/*-- Tooltip --*/
+.c3-tooltip-container {
+  z-index: 10; }
+
+.c3-tooltip {
+  border-collapse: collapse;
+  border-spacing: 0;
+  empty-cells: show;
+  -webkit-box-shadow: 7px 7px 12px -9px rgba($text-colour, 0.1);
+  -moz-box-shadow: 7px 7px 12px -9px rgba($text-colour, 0.1);
+  box-shadow: 7px 7px 12px -9px rgba($text-colour, 0.1);
+}
+
+.c3-tooltip tr {
+  background: rgba($white, 0.9);
+}
+
+.c3-tooltip th {
+  font-weight: bold;
+  padding: 5px;
+  text-align: left;
+  font-size: 14px;
+}
+
+.c3-tooltip td {
+  font-size: 14px;
+  padding: 5px;
+  margin-bottom: 12px;
+  border-top: 1px solid $border-colour;
+}
+
+.c3-tooltip td > span {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 6px; }
+
+.c3-tooltip td.value {
+  text-align: right; }
+
+/*-- Area --*/
+.c3-area {
+  stroke-width: 0;
+  opacity: 0.3; }
+
+/*-- Arc --*/
+.c3-chart-arcs-title {
+  dominant-baseline: middle;
+  font-size: 1.3em; }
+
+.c3-chart-arcs .c3-chart-arcs-background {
+  fill: #e0e0e0;
+  stroke: none; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-unit {
+  fill: #000;
+  font-size: 16px; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-max {
+  fill: #777; }
+
+.c3-chart-arcs .c3-chart-arcs-gauge-min {
+  fill: #777; }
+
+.c3-chart-arc .c3-gauge-value {
+  fill: #000;
+  /*  font-size: 28px !important;*/ }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -35,4 +35,4 @@ $path: "/admin/static/images/";
 @import "views/statistics";
 
 // Graphs
-@import "../../bower_components/c3/c3.css";
+@import "_c3";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -33,3 +33,6 @@ $path: "/admin/static/images/";
 @import "views/view_audits";
 @import "_diff.scss";
 @import "views/statistics";
+
+// Graphs
+@import "../../bower_components/c3/c3.css";

--- a/app/assets/scss/views/_statistics.scss
+++ b/app/assets/scss/views/_statistics.scss
@@ -1,11 +1,15 @@
 #framework-statistics-big-screen {
 
   position: relative;
-  background: $govuk-blue;
-  color: $white;
-  box-shadow: 0 0 0 100em $govuk-blue;
+  background: $link-colour;
+  box-shadow: 0 0 0 100em $link-colour;
   padding-bottom: 100em;
   z-index: 1000;
+
+  .summary-item-body,
+  .summary-item-heading {
+    color: $white;
+  }
 
   .summary-item-body {
     margin-bottom: 100%;
@@ -13,6 +17,10 @@
 
   .summary-item-field {
     @include bold-80;
+  }
+
+  .summary-item-field-headings-visible {
+    border-top: 3px solid $link-colour;
   }
 
   .summary-item-field-first,
@@ -26,6 +34,10 @@
 
   .summary-item-row {
     border-top: none;
+  }
+
+  table.summary-item-body {
+    border-bottom: 3px solid $grey-3;
   }
 
   table.summary-item-body tbody td {
@@ -56,8 +68,8 @@
 
   }
 
-  .c3 {
-    border-left: 1px solid $grey-2;
-  }
+}
 
+.statistics-chart {
+  margin: 0 -10px -8px -12px;
 }

--- a/app/assets/scss/views/_statistics.scss
+++ b/app/assets/scss/views/_statistics.scss
@@ -56,4 +56,8 @@
 
   }
 
+  .c3 {
+    border-left: 1px solid $grey-2;
+  }
+
 }

--- a/app/assets/scss/views/_statistics.scss
+++ b/app/assets/scss/views/_statistics.scss
@@ -11,17 +11,16 @@
     margin-bottom: 100%;
   }
 
-  .summary-item-field,
-  .summary-item-field-first {
+  .summary-item-field {
     @include bold-80;
   }
 
-  .summary-item-field-first {
-    width: auto;
+  .summary-item-field-first,
+  .summary-item-field-heading-first {
+    display: none;
   }
 
-  .summary-item-field-heading,
-  .summary-item-field-heading-first {
+  .summary-item-field-heading {
     @include core-24;
   }
 
@@ -31,6 +30,30 @@
 
   table.summary-item-body tbody td {
     padding-top: 0;
+  }
+
+  .summary-item-row {
+
+    display: none;
+
+    &:first-child {
+      display: table-row;
+    }
+
+    td {
+      position: relative;
+      left: -25px;
+    }
+
+  }
+
+  .summary-item-field-headings-visible {
+
+    th {
+      position: relative;
+      left: -25px;
+    }
+
   }
 
 }

--- a/app/assets/scss/views/_statistics.scss
+++ b/app/assets/scss/views/_statistics.scss
@@ -48,7 +48,7 @@
 
     display: none;
 
-    &:first-child {
+    &:last-child {
       display: table-row;
     }
 

--- a/app/main/helpers/sum_counts.py
+++ b/app/main/helpers/sum_counts.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 def process_snapshots(snapshots, category, groupings):
     return [
         label_and_count(

--- a/app/main/helpers/sum_counts.py
+++ b/app/main/helpers/sum_counts.py
@@ -1,15 +1,16 @@
 from datetime import datetime
 
-def process_snapshots(snapshots, category, groupings):
+
+def format_snapshots(snapshots, category, groupings):
     return [
-        label_and_count(
+        _label_and_count(
             snapshot['data'][category], groupings, snapshot['createdAt']
         )
         for snapshot in snapshots
     ]
 
 
-def label_and_count(stats, groupings, created_at):
+def _label_and_count(stats, groupings, created_at):
     data = {
         label: _sum_counts(stats, filters)
         for label, filters in groupings.items()

--- a/app/main/helpers/sum_counts.py
+++ b/app/main/helpers/sum_counts.py
@@ -1,8 +1,19 @@
-def label_and_count(stats, groupings):
-    return [{
+def process_snapshots(snapshots, category, groupings):
+    return [
+        label_and_count(
+            snapshot['data'][category], groupings, snapshot['createdAt']
+        )
+        for snapshot in snapshots
+    ]
+
+
+def label_and_count(stats, groupings, created_at):
+    data = {
         label: _sum_counts(stats, filters)
         for label, filters in groupings.items()
-    }]
+    }
+    data['created_at'] = created_at
+    return data
 
 
 def _sum_counts(stats, filter_by=None, sum_by='count'):

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -11,7 +11,7 @@ from ... import data_api_client
 
 
 @main.route('/statistics/<string:framework_slug>', methods=['GET'])
-@login_required
+#@login_required
 def view_statistics(framework_slug):
 
     try:

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -4,14 +4,14 @@ from flask_login import login_required, current_user, flash
 from dmutils.apiclient import HTTPError
 from dmutils.audit import AuditTypes
 
-from ..helpers.sum_counts import label_and_count, process_snapshots
+from ..helpers.sum_counts import format_snapshots
 from .. import main
 from . import get_template_data
 from ... import data_api_client
 
 
 @main.route('/statistics/<string:framework_slug>', methods=['GET'])
-#@login_required
+@login_required
 def view_statistics(framework_slug):
 
     try:

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -48,6 +48,7 @@
       empty_message="Data not available",
       caption="Services by status",
       field_headings=[
+        summary.hidden_field_heading("Date and time"),
         "Draft",
         "Complete",
         "Submitted",
@@ -56,8 +57,9 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.draft }}
+          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
         {% endcall %}
+        {{ summary.text(item.draft) }}
         {{ summary.text(item.complete) }}
         {{ summary.text(item.submitted) }}
       {% endcall %}
@@ -69,6 +71,7 @@
       empty_message="Data not available",
       caption="Services by lot",
       field_headings=[
+        summary.hidden_field_heading("Date and time"),
         "Infrastructure as a Service",
         "Software as a Service",
         "Platform as a Service",
@@ -78,8 +81,9 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.IaaS }}
+          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
         {% endcall %}
+        {{ summary.text(item.IaaS) }}
         {{ summary.text(item.PaaS) }}
         {{ summary.text(item.SaaS) }}
         {{ summary.text(item.SCS) }}
@@ -92,6 +96,7 @@
       empty_message="Data not available",
       caption="Suppliers",
       field_headings=[
+        summary.hidden_field_heading("Date and time"),
         "Interested",
         "Have made declaration only",
         "Have completed services only",
@@ -101,8 +106,9 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.interested_only }}
+          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
         {% endcall %}
+        {{ summary.text(item.interested_only) }}
         {{ summary.text(item.declaration_only) }}
         {{ summary.text(item.completed_services_only) }}
         {{ summary.text(item.valid_submission) }}
@@ -115,6 +121,7 @@
       empty_message="Data not available",
       caption="Users",
       field_headings=[
+        summary.hidden_field_heading("Date and time"),
         "Never logged in",
         "Logged in not recently",
         "Logged in recently",
@@ -123,8 +130,9 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.never_logged_in }}
+          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
         {% endcall %}
+        {{ summary.text(item.never_logged_in) }}
         {{ summary.text(item.not_logged_in_recently) }}
         {{ summary.text(item.logged_in_recently) }}
       {% endcall %}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -57,7 +57,7 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at[:16] }}
+          {{ item.created_at[:19]|replace('T', ' ')|replace('-', '/') }}
         {% endcall %}
         {{ summary.text(item.draft) }}
         {{ summary.text(item.complete) }}
@@ -81,7 +81,7 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at[:16] }}
+          {{ item.created_at[:19]|replace('T', ' ')|replace('-', '/') }}
         {% endcall %}
         {{ summary.text(item.IaaS) }}
         {{ summary.text(item.PaaS) }}
@@ -98,15 +98,15 @@
       field_headings=[
         summary.hidden_field_heading("Date and time"),
         "Interested",
-        "Have made declaration only",
-        "Have completed services only",
-        "Have a valid submission",
+        "Only made declaration",
+        "Only completed services",
+        "Eligible",
       ],
       field_headings_visible=True
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at[:16] }}
+          {{ item.created_at[:19]|replace('T', ' ')|replace('-', '/') }}
         {% endcall %}
         {{ summary.text(item.interested_only) }}
         {{ summary.text(item.declaration_only) }}
@@ -123,14 +123,14 @@
       field_headings=[
         summary.hidden_field_heading("Date and time"),
         "Never logged in",
-        "Logged in not recently",
-        "Logged in recently",
+        "Not logged in this week",
+        "Logged in this week",
       ],
       field_headings_visible=True
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at[:16] }}
+          {{ item.created_at[:19]|replace('T', ' ')|replace('-', '/') }}
         {% endcall %}
         {{ summary.text(item.never_logged_in) }}
         {{ summary.text(item.not_logged_in_recently) }}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -18,7 +18,7 @@
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
 
-  <div class="page-container" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
+  <div class="page-container framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
     <div class="grid-row">
       <div class="two-third-column">
         {%
@@ -57,7 +57,7 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
+          {{ item.created_at[:16] }}
         {% endcall %}
         {{ summary.text(item.draft) }}
         {{ summary.text(item.complete) }}
@@ -81,7 +81,7 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
+          {{ item.created_at[:16] }}
         {% endcall %}
         {{ summary.text(item.IaaS) }}
         {{ summary.text(item.PaaS) }}
@@ -106,7 +106,7 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
+          {{ item.created_at[:16] }}
         {% endcall %}
         {{ summary.text(item.interested_only) }}
         {{ summary.text(item.declaration_only) }}
@@ -130,7 +130,7 @@
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
-          {{ item.created_at|shortdateformat }}, {{ item.created_at|timeformat }}
+          {{ item.created_at[:16] }}
         {% endcall %}
         {{ summary.text(item.never_logged_in) }}
         {{ summary.text(item.not_logged_in_recently) }}

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633",
-    "hogan": "3.0.2"
+    "hogan": "3.0.2",
+    "c3": "0.4.10"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.2#egg=digitalmarketplace-utils==6.5.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.7.1#egg=digitalmarketplace-utils==6.7.1
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@6.7.1#egg=digitalma
 pyOpenSSL==0.14
 ndg-httpsclient==0.3.3
 pyasn1==0.1.7
+
+git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3

--- a/tests/app/main/helpers/test_sum_counts.py
+++ b/tests/app/main/helpers/test_sum_counts.py
@@ -2,13 +2,13 @@
 from unittest import TestCase
 from nose.tools import assert_equal, assert_true, assert_false
 
-from app.main.helpers.sum_counts import label_and_count, _sum_counts, _find
+from app.main.helpers.sum_counts import _label_and_count, _sum_counts, _find
 
 
 class TestLabelAndCount(TestCase):
     def test_formatting(self):
         assert_equal(
-            label_and_count({}, {
+            _label_and_count({}, {
                 'one': {
                     'filter_one': None
                 },

--- a/tests/app/main/helpers/test_sum_counts.py
+++ b/tests/app/main/helpers/test_sum_counts.py
@@ -19,8 +19,8 @@ class TestLabelAndCount(TestCase):
                 'three': {
                     'filter_two': True
                 }
-            }),
-            [{'one': 0, 'two': 0, 'three': 0}]
+            }, created_at='today'),
+            {'created_at': 'today', 'one': 0, 'two': 0, 'three': 0}
         )
 
 

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -1,6 +1,7 @@
 import mock
 
 from dmutils.apiclient import HTTPError
+from dmutils.audit import AuditTypes
 from ...helpers import LoggedInApplicationTest
 
 
@@ -8,25 +9,27 @@ from ...helpers import LoggedInApplicationTest
 class TestStats(LoggedInApplicationTest):
 
     def test_get_stats_page(self, data_api_client):
-        data_api_client.get_framework_stats.return_value = {
-            'services': {}, 'interested_suppliers': {}, 'supplier_users': {}
+        data_api_client.find_audit_events.return_value = {
+            'auditEvents': {}
         }
         response = self.client.get('/admin/statistics/g-cloud-7')
 
-        data_api_client.get_framework_stats.assert_called_with('g-cloud-7')
+        data_api_client.find_audit_events.assert_called_with(
+            audit_type=AuditTypes.snapshot_framework_stats
+        )
 
         self.assertEquals(200, response.status_code)
 
     def test_get_stats_page_for_invalid_framework(self, data_api_client):
         api_response = mock.Mock()
         api_response.status_code = 404
-        data_api_client.get_framework_stats.side_effect = HTTPError(api_response)
+        data_api_client.find_audit_events.side_effect = HTTPError(api_response)
         response = self.client.get('/admin/statistics/g-cloud-11')
         self.assertEquals(404, response.status_code)
 
     def test_get_stats_page_when_API_is_down(self, data_api_client):
         api_response = mock.Mock()
         api_response.status_code = 500
-        data_api_client.get_framework_stats.side_effect = HTTPError(api_response)
+        data_api_client.find_audit_events.side_effect = HTTPError(api_response)
         response = self.client.get('/admin/statistics/g-cloud-7')
         self.assertEquals(500, response.status_code)


### PR DESCRIPTION
![47690-st60](https://cloud.githubusercontent.com/assets/355079/9575708/9782ea00-4fc9-11e5-8fd9-802f31db1273.png)

# Use audit events rather than calling API directly

Previously the stats page called the API on every page load. It could only get the latest data.

This commit changes the stats page to get its data from audit events instead, where the stats are/will be snapshotted every hour, as per: alphagov/digitalmarketplace-api#222

TL;DR:
- less expensive API calls
- potential for showing change in data over time

# Get basic charts on the page

This commit creates charts using [C3](http://c3js.org/). Chosen because it is
- [MIT licensed](https://github.com/masayuki0812/c3/blob/master/LICENSE) (unline some other JS charting libraries)
- D3 based, which means the results look similar to Performance Platform

The code written in this commit extracts data from the tables on the statistics page and then passes it to C3 to generate the charts.

# Refine appearance and behaviour of charts

Including:
- some non-canon date formatting
- using a time series for the x axis, so that the points are properly spaced, even if they don't get captured at regular intervals
- using stacked area charts for most of the data (this seemed to make sense last time)
- some variations (colour, tooltip) depending on whether the page is being viewed in big screen mode or not
