### PR TITLE
Make big screen view clearer

### DIFF
--- a/app/assets/javascripts/_tables-to-charts.js
+++ b/app/assets/javascripts/_tables-to-charts.js
@@ -2,19 +2,30 @@
 
   GOVUK.GDM.tablesToCharts = function() {
 
-    var isBigScreen = $("#framework-statistics-big-screen").length;
+    var isBigScreen = $("#framework-statistics-big-screen").length,
+        colourSequence = isBigScreen ?
+          ['#55ffee', '#ffee55', '#ff55ee', '#90ff00']
+          :
+          ['#D53880', '#2B8CC4', '#6F72AF', '#F47738'],
+        typeSequence = [
+          "area", "line", "area", "area"
+        ];
 
     $(".framework-statistics table")
       .each(function(tableIndex) {
 
-        var columns = [], groups = [], types = {}, typesIndex = 0, typesList = [
-          "area", "line", "area", "area"
-        ];
+        var columns = [], groups = [], types = {};
 
         $("thead th", this).each(function(colIndex) {
 
           var columnHeading = $.trim($(this).text()),
-              chartType = typesList[tableIndex];
+              chartType = typeSequence[tableIndex];
+
+          $(this).append("<span class='key' />");
+
+          $(".key", this).css(
+            "background", colourSequence[colIndex - 1]
+          );
 
           columns.push([columnHeading]);
 
@@ -68,10 +79,7 @@
               show: false
             },
             color: {
-              pattern: isBigScreen ?
-                ['#55ffee', '#ffee55', '#ff55ee', '#90ff00']
-                :
-                ['#D53880', '#2B8CC4', '#6F72AF', '#F47738']
+              pattern: colourSequence
             },
             size: {
               height: isBigScreen ? 320 : 480

--- a/app/assets/scss/views/_statistics.scss
+++ b/app/assets/scss/views/_statistics.scss
@@ -29,7 +29,17 @@
   }
 
   .summary-item-field-heading {
+
     @include core-24;
+
+    .key {
+      display: inline-block;
+      width: 0.6em;
+      height: 0.6em;
+      border-radius: 50%;
+      margin: 0 0 -1px 0.1em;
+    }
+
   }
 
   .summary-item-row {

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -115,16 +115,16 @@
       {% endcall %}
     {% endcall %}
 
-    {{ summary.heading("Users") }}
+    {{ summary.heading("Users by last login time") }}
     {% call(item) summary.list_table(
       users,
       empty_message="Data not available",
       caption="Users",
       field_headings=[
         summary.hidden_field_heading("Date and time"),
-        "Never logged in",
-        "Not logged in this week",
-        "Logged in this week",
+        "Before Python",
+        "Over a week ago",
+        "In the last week",
       ],
       field_headings_visible=True
     ) %}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -122,7 +122,7 @@
       caption="Users",
       field_headings=[
         summary.hidden_field_heading("Date and time"),
-        "Before Python",
+        "Before July",
         "Over a week ago",
         "In the last week",
       ],


### PR DESCRIPTION
<img width="1074" alt="screen shot 2015-09-02 at 07 37 31" src="https://cloud.githubusercontent.com/assets/355079/9624529/bb594992-5145-11e5-8732-0a0ff780943e.png">

**Add key to big screen view**

Because big screen view doesn't have tooltip, it's hard to identify which line is which in the charts.

This commit adds a colour-coded key to the table headings to relate the numbers to the lines more clearly.

--

**Relabel users table to be clearer**