### PR TITLE
Allow up to 1260 historic data points on graphs

### DIFF
--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -19,7 +19,8 @@ def view_statistics(framework_slug):
 
     try:
         snapshots = data_api_client.find_audit_events(
-            audit_type=AuditTypes.snapshot_framework_stats
+            audit_type=AuditTypes.snapshot_framework_stats,
+            per_page=1260
         )['auditEvents']
         latest = data_api_client.get_framework_stats(framework_slug)
         snapshots.append(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.7.1#egg=digitalmarketplace-utils==6.7.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.8.0#egg=digitalmarketplace-utils==6.8.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -15,7 +15,8 @@ class TestStats(LoggedInApplicationTest):
         response = self.client.get('/admin/statistics/g-cloud-7')
 
         data_api_client.find_audit_events.assert_called_with(
-            audit_type=AuditTypes.snapshot_framework_stats
+            audit_type=AuditTypes.snapshot_framework_stats,
+            per_page=1260
         )
 
         self.assertEquals(200, response.status_code)


### PR DESCRIPTION
(35 days * 24 snapshots per day) * 50% for safety = 1260

Depends on
https://github.com/alphagov/digitalmarketplace-api/pull/237
https://github.com/alphagov/digitalmarketplace-utils/pull/156