### PR TITLE
[#102567802] New role that can only view G-Gloud 7 stats

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -8,18 +8,19 @@
 // Digital Marketplace front end toolkit components
 $path: "/admin/static/images/";
 @import "toolkit/breadcrumb";
-@import "toolkit/page-headings";
-@import "toolkit/forms/summary";
-@import "toolkit/forms/questions";
-@import "toolkit/forms/hint";
-@import "toolkit/forms/textboxes";
-@import "toolkit/forms/word-counter";
-@import "toolkit/forms/list-entry";
-@import "toolkit/forms/selection-buttons";
-@import "toolkit/forms/validation";
+@import "toolkit/browse-list";
 @import "toolkit/buttons";
-@import "toolkit/notification-banners";
+@import "toolkit/forms/hint";
+@import "toolkit/forms/list-entry";
+@import "toolkit/forms/questions";
+@import "toolkit/forms/selection-buttons";
+@import "toolkit/forms/summary";
+@import "toolkit/forms/textboxes";
+@import "toolkit/forms/validation";
+@import "toolkit/forms/word-counter";
 @import "toolkit/link-button";
+@import "toolkit/notification-banners";
+@import "toolkit/page-headings";
 @import "_pagination.scss";
 @import "forms/_option-select.scss";
 

--- a/app/main/auth.py
+++ b/app/main/auth.py
@@ -12,7 +12,7 @@ def role_required(*roles):
     Should be applied before the `@login_required` decorator:
 
         @login_required
-        @role_required('admin', 'admin-ccs')
+        @role_required('admin', 'admin-ccs-category')
         def view():
             ...
 

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -25,7 +25,7 @@ def process_login():
             form.password.data,
             supplier=False)
 
-        if not any(user_has_role(user_json, role) for role in ['admin', 'admin-ccs']):
+        if not any(user_has_role(user_json, role) for role in ['admin', 'admin-ccs-category', 'admin-ccs-sourcing']):
             message = "login.fail: Failed to log in: %s"
             current_app.logger.info(message, form.email_address.data)
             flash('no_account', 'error')

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -15,6 +15,7 @@ from . import get_template_data
 
 @main.route('/service-updates', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category')
 def service_update_audits():
     form = ServiceUpdateAuditEventsForm(request.args, csrf_enabled=False)
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -28,6 +28,7 @@ def index():
 
 @main.route('/services', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category')
 def find():
     if request.args.get("service_id") is None:
         return render_template("index.html", **get_template_data()), 404
@@ -37,6 +38,7 @@ def find():
 
 @main.route('/services/<service_id>', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category')
 def view(service_id):
     try:
         service = data_api_client.get_service(service_id)
@@ -113,6 +115,8 @@ def edit(service_id, section):
     '/services/compare/<old_archived_service_id>...<new_archived_service_id>',
     methods=['GET']
 )
+@login_required
+@role_required('admin', 'admin-ccs-category')
 def compare(old_archived_service_id, new_archived_service_id):
 
     def validate_archived_services(old_archived_service, new_archived_service):

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -22,6 +22,7 @@ presenters = Presenters()
 
 @main.route('', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
 def index():
     return render_template("index.html", **get_template_data())
 

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -11,10 +11,12 @@ from ..helpers.sum_counts import format_snapshots
 from .. import main
 from . import get_template_data
 from ... import data_api_client
+from ..auth import role_required
 
 
 @main.route('/statistics/<string:framework_slug>', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
 def view_statistics(framework_slug):
 
     try:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -14,6 +14,7 @@ from dmutils.email import send_email, \
 
 @main.route('/suppliers', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category')
 def find_suppliers():
     suppliers = data_api_client.find_suppliers(prefix=request.args.get("supplier_name_prefix"))
 
@@ -26,6 +27,7 @@ def find_suppliers():
 
 @main.route('/suppliers/users', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category')
 def find_supplier_users():
     form = EmailAddressForm()
 
@@ -67,6 +69,7 @@ def deactivate_user(user_id):
 
 @main.route('/suppliers/services', methods=['GET'])
 @login_required
+@role_required('admin', 'admin-ccs-category')
 def find_supplier_services():
 
     supplier = get_supplier()

--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -8,9 +8,11 @@
     </nav>
     {% if current_user.email_address %}
       <ul id="proposition-links">
+        {% if current_user.has_role('admin') or current_user.has_role('admin-ccs-category') %}
         <li>
             <a href="{{ url_for('main.service_update_audits') }}">Service Updates</a>
         </li>
+        {% endif %}
         <li>
             <a href="{{ url_for('main.logout') }}">Log out</a>
         </li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -31,40 +31,55 @@
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
-  <form action="{{ url_for('.find') }}" method="get" class="question">
-      <label class="question-heading" for="service_id">Find a service by service ID</label>
-      <p class='hint'>
-        eg 1234567890123456
-      </p>
-      <input type="text" name="service_id" id="service_id" class="text-box">
-      <input type="submit" value="Search" class="button-save">
-  </form>
 
-  <form action="{{ url_for('.find_supplier_services') }}" method="get" class="question">
-      <label class="question-heading" for="supplier_id_for_services">Find services by supplier ID</label>
-      <p class='hint'>
-        eg 54321
-      </p>
-      <input type="text" name="supplier_id" id="supplier_id_for_services" class="text-box">
-      <input type="submit" value="Search" class="button-save">
-  </form>
+  {% if current_user.has_role('admin') or current_user.has_role('admin-ccs-category') %}
+      <form action="{{ url_for('.find') }}" method="get" class="question">
+          <label class="question-heading" for="service_id">Find a service by service ID</label>
+          <p class='hint'>
+            eg 1234567890123456
+          </p>
+          <input type="text" name="service_id" id="service_id" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+      </form>
+    
+      <form action="{{ url_for('.find_supplier_services') }}" method="get" class="question">
+          <label class="question-heading" for="supplier_id_for_services">Find services by supplier ID</label>
+          <p class='hint'>
+            eg 54321
+          </p>
+          <input type="text" name="supplier_id" id="supplier_id_for_services" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+      </form>
+    
+      <form action="{{ url_for('.find_supplier_users') }}" method="get" class="question">
+          <label class="question-heading" for="supplier_id_for_users">Find users by supplier ID</label>
+          <p class='hint'>
+            eg 54321
+          </p>
+          <input type="text" name="supplier_id" id="supplier_id_for_users" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+      </form>
+    
+      <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
+        <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
+        <p class="hint">
+          eg searching for c would give all suppliers starting with c
+        </p>
+        <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
+        <input type="submit" value="Search" class="button-save">
+      </form>
+  {% endif %}
 
-  <form action="{{ url_for('.find_supplier_users') }}" method="get" class="question">
-      <label class="question-heading" for="supplier_id_for_users">Find users by supplier ID</label>
-      <p class='hint'>
-        eg 54321
-      </p>
-      <input type="text" name="supplier_id" id="supplier_id_for_users" class="text-box">
-      <input type="submit" value="Search" class="button-save">
-  </form>
+{% with items = [
+    {
+        "body": "View G-Cloud 7 Statistics",
+        "link": "/admin/statistics/g-cloud-7",
+        "title": "G-Cloud 7 Statistics"
+    }
+]
+%}
+{% include "toolkit/browse-list.html" %}
+{% endwith %}
 
-  <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-    <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
-    <p class="hint">
-      eg searching for c would give all suppliers starting with c
-    </p>
-    <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
-    <input type="submit" value="Search" class="button-save">
-  </form>
 </div>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -72,9 +72,9 @@
 
 {% with items = [
     {
-        "body": "View G-Cloud 7 Statistics",
+        "body": "View G-Cloud 7 statistics",
         "link": "/admin/statistics/g-cloud-7",
-        "title": "G-Cloud 7 Statistics"
+        "title": "G-Cloud 7 statistics"
     }
 ]
 %}

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.4.2",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v10.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633",
     "hogan": "3.0.2",

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -130,7 +130,7 @@ class TestLogin(BaseApplicationTest):
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_can_login_with_admin_ccs_role(self, data_api_client):
-        data_api_client.authenticate_user.return_value = user_data(role='admin-ccs')
+        data_api_client.authenticate_user.return_value = user_data(role='admin-ccs-category')
 
         res = self.client.post('/admin/login', data={
             'email_address': 'valid@example.com',
@@ -192,7 +192,7 @@ class TestRoleRequired(LoggedInApplicationTest):
     def user_loader(self, user_id):
         if user_id:
             return User(
-                user_id, 'test@example.com', None, None, False, True, 'tester', 'admin-ccs'
+                user_id, 'test@example.com', None, None, False, True, 'tester', 'admin-ccs-category'
             )
 
     def test_admin_ccs_can_view_admin_dashboard(self):

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -129,7 +129,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         )
 
         self.assertIn(
-            '<button class="button-destructive">Deactivate</button>',
+            '<input type="submit" class="button-destructive"  value="Deactivate" />',
             response.get_data(as_text=True)
         )
 
@@ -154,7 +154,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
         self.assertIn(
-            '<button class="button-secondary">Unlock</button>',
+            '<input type="submit" class="button-secondary"  value="Unlock" />',
             response.get_data(as_text=True)
         )
 
@@ -174,7 +174,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
         self.assertIn(
-            '<button class="button-secondary">Activate</button>',
+            '<input type="submit" class="button-secondary"  value="Activate" />',
             response.get_data(as_text=True)
         )
 


### PR DESCRIPTION
See this story: https://www.pivotaltracker.com/story/show/102567802

This restricts access for users with role `admin-ccs-sourcing` to only the statistics page.  Their dashboard page when logging in looks like this:
![screen shot 2015-09-07 at 15 39 07](https://cloud.githubusercontent.com/assets/6525554/9718768/b0da842e-5576-11e5-8ce7-dfcdeb92dda3.png)

This PR would depend on this going in first: https://github.com/alphagov/digitalmarketplace-api/pull/240 if we currently had any users with the now-deprecated role `admin-ccs`, but we don't - so either way round should be fine.