### PR TITLE
Allow an admin user to change a supplier’s name

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -25,6 +25,33 @@ def find_suppliers():
     )
 
 
+@main.route('/suppliers/<string:supplier_id>/edit/name', methods=['GET'])
+@login_required
+@role_required('admin', 'admin-ccs-category')
+def edit_supplier_name(supplier_id):
+
+    supplier = get_supplier(supplier_id)
+
+    return render_template(
+        "edit_supplier_name.html",
+        supplier=supplier["suppliers"],
+        **get_template_data()
+    )
+
+
+@main.route('/suppliers/<string:supplier_id>/edit/name', methods=['POST'])
+def update_supplier_name(supplier_id):
+
+    supplier = get_supplier(supplier_id)
+    new_supplier_name = request.form.get('new_supplier_name', '')
+
+    data_api_client.update_supplier(
+        supplier['suppliers']['id'], {'name': new_supplier_name}, current_user.email_address
+    )
+
+    return redirect(url_for('.find_suppliers', supplier_name_prefix=new_supplier_name[:1]))
+
+
 @main.route('/suppliers/users', methods=['GET'])
 @login_required
 @role_required('admin', 'admin-ccs-category')
@@ -160,18 +187,20 @@ def invite_user(supplier_id):
         ), 400
 
 
-def get_supplier():
+def get_supplier(supplier_id=None):
 
-    if "supplier_id" not in request.args or len(request.args.get("supplier_id")) <= 0:
-        abort(404, "Supplier not found")
+    if supplier_id is None:
+        if "supplier_id" not in request.args or len(request.args.get("supplier_id")) <= 0:
+            abort(404, "Supplier not found")
+        supplier_id = request.args.get("supplier_id")
 
     try:
-        int(request.args.get("supplier_id"))
+        int(supplier_id)
     except ValueError:
-        abort(400, "invalid supplier id {}".format(request.args.get("supplier_id")))
+        abort(400, "invalid supplier id {}".format(supplier_id))
 
     try:
-        return data_api_client.get_supplier(request.args.get("supplier_id"))
+        return data_api_client.get_supplier(supplier_id)
     except HTTPError as e:
         if e.status_code != 404:
             raise

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -27,7 +27,7 @@ def find_suppliers():
 
 @main.route('/suppliers/<string:supplier_id>/edit/name', methods=['GET'])
 @login_required
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin')
 def edit_supplier_name(supplier_id):
 
     supplier = get_supplier(supplier_id)
@@ -40,6 +40,8 @@ def edit_supplier_name(supplier_id):
 
 
 @main.route('/suppliers/<string:supplier_id>/edit/name', methods=['POST'])
+@login_required
+@role_required('admin')
 def update_supplier_name(supplier_id):
 
     supplier = get_supplier(supplier_id)

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -1,0 +1,45 @@
+{% from 'macros/page_heading.html' import page_heading %}
+
+{% extends "_base_page.html" %}
+{% block page_title %}
+  Change name – {{ supplier.name }} – Digital Marketplace admin
+{% endblock %}
+
+{% block content %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      },
+      {
+        "label": supplier.name
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+  <div class="page-container">
+    {% with heading = "Change supplier name" %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    <form method="post">
+      <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+      {%
+        with
+        question = "New name",
+        name = "new_supplier_name",
+        value = supplier.name
+      %}
+        {% include "toolkit/forms/textbox.html" %}
+      {% endwith %}
+      {%
+        with
+        type = "save",
+        label = "Save"
+      %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+    </form>
+  </div>
+{% endblock %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -32,12 +32,18 @@
           summary.hidden_field_heading("Edit name"),
           summary.hidden_field_heading("Users"),
           summary.hidden_field_heading("Services"),
+        ] if current_user.has_role('admin') else [
+          "Name",
+          summary.hidden_field_heading("Users"),
+          summary.hidden_field_heading("Services"),
         ],
         field_headings_visible=True)
       %}
         {% call summary.row() %}
           {{ summary.field_name(item.name) }}
-          {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
+          {% if current_user.has_role('admin') %}
+            {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
+          {% endif %}
           {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
           {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
         {% endcall %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -29,19 +29,18 @@
         empty_message="No suppliers were found",
         field_headings=[
           "Name",
+          summary.hidden_field_heading("Edit name"),
           summary.hidden_field_heading("Users"),
           summary.hidden_field_heading("Services"),
         ],
         field_headings_visible=True)
       %}
-      {% call summary.row() %}
-
-      {{ summary.field_name(item.name) }}
-
-      {{ summary.service_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
-      {{ summary.service_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
-
-      {% endcall %}
+        {% call summary.row() %}
+          {{ summary.field_name(item.name) }}
+          {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
+          {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
+          {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
+        {% endcall %}
       {% endcall %}
     </div>
 </div>


### PR DESCRIPTION
# Add a 'change name' link to the list of suppliers

![image](https://cloud.githubusercontent.com/assets/355079/9848163/8f4e029e-5ad6-11e5-925f-38ad9760423b.png)


# Add a new route, and a corresponding page with a form to enter a new supplier name

![image](https://cloud.githubusercontent.com/assets/355079/9848170/9bbcc48e-5ad6-11e5-81cb-aec940faf47c.png)

# Add a `post` endpoint for the new route which makes an API call to change the supplier’s name

![image](https://cloud.githubusercontent.com/assets/355079/9848184/b2761f0e-5ad6-11e5-97ca-9b7dc2abd653.png)

--

There's no length limit on the new name. I think we can trust our admin users for now?

--

Completes [story 103088044](https://www.pivotaltracker.com/story/show/103088044).