### PR TITLE
Adding search by email to the admin app

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,7 +3,7 @@ from flask import Blueprint
 
 main = Blueprint('main', __name__)
 
-from .views import login, service_updates, services, suppliers, stats
+from .views import login, service_updates, services, suppliers, stats, users
 from app.main import errors
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -48,6 +48,8 @@ def find_supplier_users():
 @role_required('admin')
 def unlock_user(user_id):
     user = data_api_client.update_user(user_id, locked=False)
+    if "source" in request.form:
+        return redirect(request.form["source"])
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
 
 
@@ -56,6 +58,8 @@ def unlock_user(user_id):
 @role_required('admin')
 def activate_user(user_id):
     user = data_api_client.update_user(user_id, active=True)
+    if "source" in request.form:
+        return redirect(request.form["source"])
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
 
 
@@ -64,6 +68,8 @@ def activate_user(user_id):
 @role_required('admin')
 def deactivate_user(user_id):
     user = data_api_client.update_user(user_id, active=False)
+    if "source" in request.form:
+        return redirect(request.form["source"])
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
 
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -31,4 +31,3 @@ def find_user_by_email_address():
             users=list(),
             email_address=None,
             **get_template_data()), 404
-

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,0 +1,34 @@
+from flask import render_template, request
+from flask_login import login_required, current_user, flash
+
+from .. import main
+from . import get_template_data
+from ... import data_api_client
+from ..auth import role_required
+
+
+@main.route('/users', methods=['GET'])
+@login_required
+@role_required('admin', 'admin-ccs-category')
+def find_user_by_email_address():
+    template = "view_users.html"
+    users = None
+
+    email_address = request.args.get("email_address", None)
+    if email_address:
+        users = data_api_client.get_user(email_address=request.args.get("email_address"))
+
+    if users:
+        return render_template(
+            template,
+            users=[users['users']],
+            email_address=request.args.get("email_address"),
+            **get_template_data())
+    else:
+        flash('no_users', 'error')
+        return render_template(
+            template,
+            users=list(),
+            email_address=None,
+            **get_template_data()), 404
+

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -50,7 +50,7 @@
           <input type="text" name="supplier_id" id="supplier_id_for_services" class="text-box">
           <input type="submit" value="Search" class="button-save">
       </form>
-    
+
       <form action="{{ url_for('.find_supplier_users') }}" method="get" class="question">
           <label class="question-heading" for="supplier_id_for_users">Find users by supplier ID</label>
           <p class='hint'>
@@ -67,6 +67,15 @@
         </p>
         <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
         <input type="submit" value="Search" class="button-save">
+      </form>
+
+      <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
+          <label class="question-heading" for="email_address">Find users by email address</label>
+          <p class='hint'>
+            eg john@smokeyjoes.com
+          </p>
+          <input type="text" name="email_address" id="email_address" class="text-box">
+          <input type="submit" value="Search" class="button-save">
       </form>
   {% endif %}
 

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -25,7 +25,7 @@
 
 <div class="page-container">
 
-    {% with heading = "Users" %}
+    {% with heading = supplier.name %}
     {% include "toolkit/page-heading.html" %}
     {% endwith %}
 
@@ -62,8 +62,7 @@
                 'Email address',
                 'Last login',
                 'Last password change',
-                'Locked',
-                summary.hidden_field_heading("Change status")
+                'Locked'
             ],
             field_headings_visible=True)
         %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -63,7 +63,7 @@
 
         {{ summary.field_name(item.name) }}
 
-        {{ summary.field_name(item.role) }}
+        {{ summary.text(item.role) }}
 
         {% call summary.field() %}
             {% if item.role == 'supplier' %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -1,0 +1,163 @@
+{% import "toolkit/summary-table.html" as summary %}
+{% from 'macros/breadcrumb.html' import breadcrumb as breadcrumb %}
+{% from 'macros/page_heading.html' import page_heading %}
+
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+    Users – Digital Marketplace admin
+{% endblock %}
+
+{% block content %}
+{%
+    with items = [
+        {
+            "link": url_for('.index'),
+            "label": "Admin home"
+        },
+    ]
+%}
+{% include "toolkit/breadcrumb.html" %}
+{% endwith %}
+
+<div class="page-container">
+
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            {% if message == 'no_users' %}
+                {% set displayed_message = "Sorry, we couldn't find an account with that email address" %}
+            {% endif %}
+            {%
+            with
+                message = displayed_message,
+                type = "destructive" if category == 'error' else "success"
+            %}
+            {% include "toolkit/notification-banner.html" %}
+            {% endwith %}
+        {% endfor %}
+    {% endif %}
+    {% endwith %}
+
+    {% with heading = email_address if email_address %}
+    {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+
+    {% call(item) summary.list_table(
+            users,
+            caption="Users",
+            empty_message="No users to show",
+            field_headings=[
+                'Name',
+                'Role',
+                'Supplier',
+                'Last login',
+                'Last password change',
+                'Locked',
+                summary.hidden_field_heading("Change status")
+            ],
+            field_headings_visible=True)
+        %}
+        {% call summary.row() %}
+
+        {{ summary.field_name(item.name) }}
+
+        {{ summary.field_name(item.role) }}
+
+        {% call summary.field() %}
+            {% if item.role == 'supplier' %}
+            <a href="{{ url_for('.find_supplier_users', supplier_id=item.supplier.supplierId) }}">{{ item.supplier.name }}</a>
+            {% endif %}
+        {% endcall %}
+
+        {% call summary.field() %}
+            {% if item.loggedInAt %}
+                {{ item.loggedInAt|timeformat }}<br/>
+                {{ item.loggedInAt|shortdateformat }}
+            {% else %}
+                Never
+            {% endif %}
+        {% endcall %}
+
+        {% call summary.field() %}
+            {% if item.passwordChangedAt %}
+                {{ item.passwordChangedAt|timeformat }}<br/>
+                {{ item.passwordChangedAt|shortdateformat }}
+            {% else %}
+                Never
+            {% endif %}
+        {% endcall %}
+
+        {% call summary.field() %}
+        {% if item.locked and current_user.has_role('admin') %}
+        <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+            {%
+                with
+                type = "secondary",
+                label = "Unlock"
+            %}
+            {% include "toolkit/button.html" %}
+            {% endwith %}
+        </form>
+        {% elif item.locked %}
+            Yes
+        {% else %}
+            No
+        {% endif %}
+        {% endcall %}
+
+        {% call summary.field() %}
+            {% if item.active %}
+              {% if current_user.has_role('admin') %}
+                <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+                    {%
+                        with
+                        type = "destructive",
+                        label = "Deactivate"
+                    %}
+                    {% include "toolkit/button.html" %}
+                    {% endwith %}
+                </form>
+              {% else %}
+                Active
+              {% endif %}
+            {% else %}
+              {% if current_user.has_role('admin') %}
+                <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+                    {%
+                        with
+                        type = "secondary",
+                        label = "Activate"
+                    %}
+                    {% include "toolkit/button.html" %}
+                    {% endwith %}
+                </form>
+              {% else %}
+                Deactivated
+              {% endif %}
+            {% endif %}
+        {% endcall %}
+
+        {% endcall %}
+        {% endcall %}
+    <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
+      <label class="question-heading" for="email_address">Find users by email address</label>
+      <p class='hint'>
+        eg john@smokeyjoes.com
+      </p>
+      <input type="text" name="email_address" id="email_address" class="text-box" maxlength="200">
+      <input type="submit" value="Search" class="button-save">
+    </form>
+    </div>
+
+</div>
+
+
+{% endblock %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -150,7 +150,7 @@
     <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
       <label class="question-heading" for="email_address">Find users by email address</label>
       <p class='hint'>
-        eg john@smokeyjoes.com
+        eg name@example.com
       </p>
       <input type="text" name="email_address" id="email_address" class="text-box" maxlength="200">
       <input type="submit" value="Search" class="button-save">

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -36,7 +36,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
 
     def test_should_search_by_prefix(self, data_api_client):
         data_api_client.find_suppliers.side_effect = HTTPError(Response(404))
-        response = self.client.get("/admin/suppliers?supplier_name_prefix=foo")
+        self.client.get("/admin/suppliers?supplier_name_prefix=foo")
 
         data_api_client.find_suppliers.assert_called_once_with(prefix="foo")
 

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -1,0 +1,171 @@
+try:
+    from urlparse import urlsplit
+    from StringIO import StringIO
+except ImportError:
+    from urllib.parse import urlsplit
+    from io import BytesIO as StringIO
+import mock
+from lxml import html
+from ...helpers import LoggedInApplicationTest
+
+
+@mock.patch('app.main.views.users.data_api_client')
+class TestUsersView(LoggedInApplicationTest):
+
+    def test_should_be_a_404_if_user_not_found(self, data_api_client):
+        data_api_client.get_user.return_value = None
+        response = self.client.get('/admin/users?email_address=some@email.com')
+        self.assertEquals(response.status_code, 404)
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        page_title = document.xpath(
+            '//p[@class="banner-message"]//text()')[0].strip()
+        self.assertEqual("Sorry, we couldn't find an account with that email address", page_title)
+
+        page_title = document.xpath(
+            '//p[@class="summary-item-no-content"]//text()')[0].strip()
+        self.assertEqual("No users to show", page_title)
+
+    def test_should_be_a_404_if_no_email_provided(self, data_api_client):
+        data_api_client.get_user.return_value = None
+        response = self.client.get('/admin/users?email_address=')
+        self.assertEquals(response.status_code, 404)
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        page_title = document.xpath(
+            '//p[@class="banner-message"]//text()')[0].strip()
+        self.assertEqual("Sorry, we couldn't find an account with that email address", page_title)
+
+        page_title = document.xpath(
+            '//p[@class="summary-item-no-content"]//text()')[0].strip()
+        self.assertEqual("No users to show", page_title)
+
+    def test_should_be_a_404_if_no_email_param_provided(self, data_api_client):
+        data_api_client.get_user.return_value = None
+        response = self.client.get('/admin/users')
+        self.assertEquals(response.status_code, 404)
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        page_title = document.xpath(
+            '//p[@class="banner-message"]//text()')[0].strip()
+        self.assertEqual("Sorry, we couldn't find an account with that email address", page_title)
+
+        page_title = document.xpath(
+            '//p[@class="summary-item-no-content"]//text()')[0].strip()
+        self.assertEqual("No users to show", page_title)
+
+    def test_should_show_buyer_user(self, data_api_client):
+        buyer = self.load_example_listing("user_response")
+        buyer.pop('supplier', None)
+        buyer['users']['role'] = 'buyer'
+        data_api_client.get_user.return_value = buyer
+        response = self.client.get('/admin/users?email_address=test.user@sme.com')
+        self.assertEquals(response.status_code, 200)
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        email_address = document.xpath(
+            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+        self.assertEqual("test.user@sme.com", email_address)
+
+        name = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[0].strip()
+        self.assertEqual("Test User", name)
+
+        role = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()
+        self.assertEqual("buyer", role)
+
+        supplier = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[2].strip()
+        self.assertEquals('', supplier)
+
+        last_login = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[3].strip()
+        self.assertEquals('10:33:53', last_login)
+
+        last_login_day = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[4].strip()
+        self.assertEquals('23 July', last_login_day)
+
+        last_password_changed = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[5].strip()
+        self.assertEquals('13:46:01', last_password_changed)
+
+        last_password_changed_day = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[6].strip()
+        self.assertEquals('29 June', last_password_changed_day)
+
+        locked = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[7].strip()
+        self.assertEquals('No', locked)
+
+        button = document.xpath(
+            '//input[@class="button-destructive"]')[0].value
+        self.assertEquals('Deactivate', button)
+
+    def test_should_show_supplier_user(self, data_api_client):
+        buyer = self.load_example_listing("user_response")
+        data_api_client.get_user.return_value = buyer
+        response = self.client.get('/admin/users?email_address=test.user@sme.com')
+        self.assertEquals(response.status_code, 200)
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        email_address = document.xpath(
+            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+        self.assertEqual("test.user@sme.com", email_address)
+
+        role = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()
+        self.assertEqual("supplier", role)
+
+        supplier = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/a/text()')[0].strip()
+        self.assertEquals('SME Corp UK Limited', supplier)
+
+        supplier_link = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/a')[0]
+        self.assertEquals('/admin/suppliers/users?supplier_id=1000', supplier_link.attrib['href'])
+
+    def test_should_show_unlock_button(self, data_api_client):
+        buyer = self.load_example_listing("user_response")
+        buyer['users']['locked'] = True
+
+        data_api_client.get_user.return_value = buyer
+        response = self.client.get('/admin/users?email_address=test.user@sme.com')
+        self.assertEquals(response.status_code, 200)
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        unlock_button = document.xpath(
+            '//input[@class="button-secondary"]')[0].attrib['value']
+        unlock_link = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/form')[0]
+        return_link = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/form/input')[1]
+        self.assertEquals('/admin/suppliers/users/999/unlock', unlock_link.attrib['action'])
+        self.assertEquals('Unlock', unlock_button)
+        self.assertEquals('/admin/users?email_address=test.user%40sme.com', return_link.attrib['value'])
+
+    def test_should_show_deactivate_button(self, data_api_client):
+        buyer = self.load_example_listing("user_response")
+
+        data_api_client.get_user.return_value = buyer
+        response = self.client.get('/admin/users?email_address=test.user@sme.com')
+        self.assertEquals(response.status_code, 200)
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        deactivate_button = document.xpath(
+            '//input[@class="button-destructive"]')[0].attrib['value']
+        deactivate_link = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/form')[0]
+        return_link = document.xpath(
+            '//tr[@class="summary-item-row"]//td/span/form/input')[1]
+        self.assertEquals('/admin/suppliers/users/999/deactivate', deactivate_link.attrib['action'])
+        self.assertEquals('Deactivate', deactivate_button)
+        self.assertEquals('/admin/users?email_address=test.user%40sme.com', return_link.attrib['value'])


### PR DESCRIPTION
- adds new search by email on index page
- new users controller to handle looking up by email
- re-use of suppliers-users table to show user
- links to supplier page for supplier users
- allows finding ALL user types
- Adds unlock/activate buttons
- uses a hidden field for the return link so can share the change status code and return to correct page.