### PR TITLE
Button added to remove users from suppliers

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -67,6 +67,14 @@ def deactivate_user(user_id):
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
 
 
+@main.route('/suppliers/users/<int:user_id>/remove-from-supplier', methods=['POST'])
+@login_required
+@role_required('admin')
+def remove_from_supplier(user_id):
+    data_api_client.update_user(user_id, role='buyer')
+    return redirect(url_for('.find_supplier_users', supplier_id=request.form['supplier_id']))
+
+
 @main.route('/suppliers/services', methods=['GET'])
 @login_required
 @role_required('admin', 'admin-ccs-category')

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -25,7 +25,7 @@
 
 <div class="page-container">
 
-    {% with heading = "Users" %}
+    {% with heading = supplier.name %}
     {% include "toolkit/page-heading.html" %}
     {% endwith %}
 
@@ -141,6 +141,22 @@
           {% else %}
             Deactivated
           {% endif %}
+        {% endif %}
+        {% endcall %}
+
+        {% call summary.field() %}
+        {% if current_user.has_role('admin') %}
+        <form action="{{ url_for('.remove_from_supplier', user_id=item.id) }}" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <input type="hidden" name="supplier_id" value="{{ item.supplier.supplierId }}"/>
+            {%
+                with
+                type = "secondary",
+                label = "Remove from supplier"
+            %}
+            {% include "toolkit/button.html" %}
+            {% endwith %}
+        </form>
         {% endif %}
         {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.8.0#egg=digitalmarketplace-utils==6.8.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.9.1#egg=digitalmarketplace-utils==6.9.1
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -138,6 +138,16 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
 
+        self.assertIn(
+            '<input type="submit" class="button-secondary"  value="Remove from supplier" />',
+            response.get_data(as_text=True)
+        )
+
+        self.assertIn(
+            '<form action="/admin/suppliers/users/999/remove-from-supplier" method="post">',
+            response.get_data(as_text=True)
+        )
+
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_unlock_button_if_user_locked(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
@@ -207,9 +217,27 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
 
-        response = self.client.post('/admin/suppliers/users/999/deactivate')
+        response = self.client.post(
+            '/admin/suppliers/users/999/deactivate',
+            data={'supplier_id': 1000}
+        )
 
         data_api_client.update_user.assert_called_with(999, active=False)
+
+        self.assertEquals(302, response.status_code)
+        self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
+
+    @mock.patch('app.main.views.suppliers.data_api_client')
+    def test_should_call_api_to_remove_user_from_supplier(self, data_api_client):
+        data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
+        data_api_client.update_user.return_value = self.load_example_listing("user_response")
+
+        response = self.client.post(
+            '/admin/suppliers/users/999/remove-from-supplier',
+            data={'supplier_id': 1000}
+        )
+
+        data_api_client.update_user.assert_called_with(999, role='buyer')
 
         self.assertEquals(302, response.status_code)
         self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)


### PR DESCRIPTION
- on supplier user page there is now a 'remove from supplier' button
- this will change the role of that user to buyer
- redirects back to the page

Requires this API update:
- [x] https://github.com/alphagov/digitalmarketplace-api/pull/244/files