### PR TITLE
Update to latest utils version

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -82,9 +82,7 @@ def update_service_status(service_id):
     try:
         data_api_client.update_service_status(
             service_id, backend_status,
-            current_user.email_address,
-            "Status changed to '{0}'".format(
-                backend_status))
+            current_user.email_address)
 
     except HTTPError as e:
         flash({'status_error': e.message}, 'error')
@@ -221,8 +219,7 @@ def update(service_id, section):
             data_api_client.update_service(
                 service_data['id'],
                 update_data,
-                current_user.email_address,
-                "admin app")
+                current_user.email_address)
         except HTTPError as e:
             return e.message
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -76,7 +76,7 @@ def find_supplier_users():
 @login_required
 @role_required('admin')
 def unlock_user(user_id):
-    user = data_api_client.update_user(user_id, locked=False)
+    user = data_api_client.update_user(user_id, locked=False, updater=current_user.email_address)
     if "source" in request.form:
         return redirect(request.form["source"])
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
@@ -86,7 +86,7 @@ def unlock_user(user_id):
 @login_required
 @role_required('admin')
 def activate_user(user_id):
-    user = data_api_client.update_user(user_id, active=True)
+    user = data_api_client.update_user(user_id, active=True, updater=current_user.email_address)
     if "source" in request.form:
         return redirect(request.form["source"])
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
@@ -96,7 +96,7 @@ def activate_user(user_id):
 @login_required
 @role_required('admin')
 def deactivate_user(user_id):
-    user = data_api_client.update_user(user_id, active=False)
+    user = data_api_client.update_user(user_id, active=False, updater=current_user.email_address)
     if "source" in request.form:
         return redirect(request.form["source"])
     return redirect(url_for('.find_supplier_users', supplier_id=user['users']['supplier']['supplierId']))
@@ -106,7 +106,7 @@ def deactivate_user(user_id):
 @login_required
 @role_required('admin')
 def remove_from_supplier(user_id):
-    data_api_client.update_user(user_id, role='buyer')
+    data_api_client.update_user(user_id, role='buyer', updater=current_user.email_address)
     return redirect(url_for('.find_supplier_users', supplier_id=request.form['supplier_id']))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six==1.9.0
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.9.1#egg=digitalmarketplace-utils==6.9.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@7.0.0#egg=digitalmarketplace-utils==7.0.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -117,7 +117,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         data_api_client.update_service.assert_called_with(1, {
             'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-7/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
             'sfiaRateDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-7/2/1-sfia-rate-card-2015-01-01-1200.pdf',  # noqa
-        }, 'test@example.com', 'admin app')
+        }, 'test@example.com')
 
         self.assertEquals(302, response.status_code)
 
@@ -146,7 +146,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         data_api_client.get_service.assert_called_with('1')
         data_api_client.update_service.assert_called_with(1, {
             'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-7/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
-        }, 'test@example.com', 'admin app')
+        }, 'test@example.com')
 
         self.assertIn(b'Your document is not in an open format', response.data)
         self.assertIn(b'This question requires an answer', response.data)
@@ -185,7 +185,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         data_api_client.update_service.assert_called_with(1, {
             'serviceFeatures': ['foo'],
             'serviceBenefits': ['foo'],
-        }, 'test@example.com', 'admin app')
+        }, 'test@example.com')
         self.assertEquals(response.status_code, 302)
 
     @mock.patch('app.main.views.services.data_api_client')
@@ -267,8 +267,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'removed'})
         data_api_client.update_service_status.assert_called_with(
-            '1', 'disabled', 'test@example.com',
-            "Status changed to 'disabled'")
+            '1', 'disabled', 'test@example.com')
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
                           'http://localhost/admin/services/1')
@@ -281,8 +280,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'private'})
         data_api_client.update_service_status.assert_called_with(
-            '1', 'enabled', 'test@example.com',
-            "Status changed to 'enabled'")
+            '1', 'enabled', 'test@example.com')
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
                           'http://localhost/admin/services/1')
@@ -295,8 +293,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'public'})
         data_api_client.update_service_status.assert_called_with(
-            '1', 'published', 'test@example.com',
-            "Status changed to 'published'")
+            '1', 'published', 'test@example.com')
         self.assertEquals(302, response1.status_code)
         self.assertEquals(response1.location,
                           'http://localhost/admin/services/1')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -195,7 +195,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.post('/admin/suppliers/users/999/unlock')
 
-        data_api_client.update_user.assert_called_with(999, locked=False)
+        data_api_client.update_user.assert_called_with(999, locked=False, updater="test@example.com")
 
         self.assertEquals(302, response.status_code)
         self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
@@ -207,7 +207,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.post('/admin/suppliers/users/999/activate')
 
-        data_api_client.update_user.assert_called_with(999, active=True)
+        data_api_client.update_user.assert_called_with(999, active=True, updater="test@example.com")
 
         self.assertEquals(302, response.status_code)
         self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
@@ -222,7 +222,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             data={'supplier_id': 1000}
         )
 
-        data_api_client.update_user.assert_called_with(999, active=False)
+        data_api_client.update_user.assert_called_with(999, active=False, updater="test@example.com")
 
         self.assertEquals(302, response.status_code)
         self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
@@ -237,7 +237,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             data={'supplier_id': 1000}
         )
 
-        data_api_client.update_user.assert_called_with(999, role='buyer')
+        data_api_client.update_user.assert_called_with(999, role='buyer', updater="test@example.com")
 
         self.assertEquals(302, response.status_code)
         self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)


### PR DESCRIPTION
Update methods no longer take a `reason` parameter.

It's not desperate to make this change now, but I think this is the only place other than the supplier app (updated here: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/293) that still passes a reason in to updates, so makes sense to tidy it all up at the same time.

Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/166/files