### PR TITLE
Fix view service table columns

### DIFF
--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -82,9 +82,7 @@
         ) %}
           {% call summary.row() %}
             {{ summary.field_name(item.question) }}
-            {% call summary.field() %}
-              {{ summary[item.type](service_data[item.id]) }}
-            {% endcall %}
+            {{ summary[item.type](service_data[item.id]) }}
           {% endcall %}
         {% endcall %}
       {% endfor %}


### PR DESCRIPTION
There was a miss-copy when moving this over from the supplier frontend.
The field macros already call `summary.field` so wrapping the call in another `summary.field` creates invalid HTML that browsers interpret as another column.