### PR TITLE
[#103325898] Strip leading and trailing whitespace from form fields.

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -4,6 +4,7 @@ from wtforms.validators import Optional, AnyOf, DataRequired, \
     Email
 from datetime import datetime
 from dmutils.formats import DATE_FORMAT
+from dmutils.forms import StripWhitespaceStringField
 
 
 class ServiceUpdateAuditEventsForm(Form):
@@ -45,7 +46,7 @@ class ServiceUpdateAuditEventsForm(Form):
 
 
 class LoginForm(Form):
-    email_address = StringField('Email address', validators=[
+    email_address = StripWhitespaceStringField('Email address', validators=[
         DataRequired(message='Email cannot be empty'),
         Email(message='Please enter a valid email address')
     ])
@@ -55,7 +56,7 @@ class LoginForm(Form):
 
 
 class EmailAddressForm(Form):
-    email_address = StringField('Email address', validators=[
+    email_address = StripWhitespaceStringField('Email address', validators=[
         DataRequired(message="Email can not be empty"),
         Email(message="Please enter a valid email address")
     ])

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ six==1.9.0
 boto==2.36.0
 markdown==2.6.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@8.3.0#egg=digitalmarketplace-utils==8.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@8.6.0#egg=digitalmarketplace-utils==8.6.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -49,6 +49,24 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 200)
 
     @mock.patch('app.main.views.login.data_api_client')
+    def test_should_strip_whitespace_surrounding_login_email_address_field(self, apiclient):
+        apiclient.authenticate_user.return_value = user_data()
+        self.client.post("/admin/login", data={
+            'email_address': '  valid@email.com  ',
+            'password': '1234567890'
+        })
+        apiclient.authenticate_user.assert_called_with('valid@email.com', '1234567890', supplier=False)
+
+    @mock.patch('app.main.views.login.data_api_client')
+    def test_should_not_strip_whitespace_surrounding_login_password_field(self, apiclient):
+        apiclient.authenticate_user.return_value = user_data()
+        self.client.post("/admin/login", data={
+            'email_address': 'valid@email.com',
+            'password': '  1234567890  '
+        })
+        apiclient.authenticate_user.assert_called_with('valid@email.com', '  1234567890  ', supplier=False)
+
+    @mock.patch('app.main.views.login.data_api_client')
     def test_ok_next_url_redirects_on_login(self, apiclient):
         apiclient.authenticate_user.return_value = user_data()
         res = self.client.post('/admin/login?next=/admin/safe', data={

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -37,8 +37,8 @@ class TestLogin(BaseApplicationTest):
         assert_in("Administrator login", res.get_data(as_text=True))
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_valid_login(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_valid_login(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         res = self.client.post('/admin/login', data={
             'email_address': 'valid@email.com',
             'password': '1234567890'
@@ -49,26 +49,26 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 200)
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_strip_whitespace_surrounding_login_email_address_field(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_should_strip_whitespace_surrounding_login_email_address_field(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         self.client.post("/admin/login", data={
             'email_address': '  valid@email.com  ',
             'password': '1234567890'
         })
-        apiclient.authenticate_user.assert_called_with('valid@email.com', '1234567890', supplier=False)
+        data_api_client.authenticate_user.assert_called_with('valid@email.com', '1234567890', supplier=False)
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_not_strip_whitespace_surrounding_login_password_field(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_should_not_strip_whitespace_surrounding_login_password_field(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         self.client.post("/admin/login", data={
             'email_address': 'valid@email.com',
             'password': '  1234567890  '
         })
-        apiclient.authenticate_user.assert_called_with('valid@email.com', '  1234567890  ', supplier=False)
+        data_api_client.authenticate_user.assert_called_with('valid@email.com', '  1234567890  ', supplier=False)
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_ok_next_url_redirects_on_login(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_ok_next_url_redirects_on_login(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         res = self.client.post('/admin/login?next=/admin/safe', data={
             'email_address': 'valid@example.com',
             'password': '1234567890',
@@ -77,8 +77,8 @@ class TestLogin(BaseApplicationTest):
         assert_equal(urlsplit(res.location).path, '/admin/safe')
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_bad_next_url_takes_user_to_dashboard(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_bad_next_url_takes_user_to_dashboard(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         res = self.client.post('/admin/login?next=http://badness.com', data={
             'email_address': 'valid@example.com',
             'password': '1234567890',
@@ -87,8 +87,8 @@ class TestLogin(BaseApplicationTest):
         assert_equal(urlsplit(res.location).path, '/admin')
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_have_cookie_on_redirect(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_should_have_cookie_on_redirect(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         with self.app.app_context():
             self.app.config['SESSION_COOKIE_DOMAIN'] = '127.0.0.1'
             self.app.config['SESSION_COOKIE_SECURE'] = True
@@ -102,8 +102,8 @@ class TestLogin(BaseApplicationTest):
             assert_in('Path=/admin', cookie_parts)
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_redirect_to_login_on_logout(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_should_redirect_to_login_on_logout(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         self.client.post('/admin/login', data={
             'email_address': 'valid@example.com',
             'password': '1234567890',
@@ -113,8 +113,8 @@ class TestLogin(BaseApplicationTest):
         assert_equal(urlsplit(res.location).path, '/admin/login')
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_logout_should_log_user_out(self, apiclient):
-        apiclient.authenticate_user.return_value = user_data()
+    def test_logout_should_log_user_out(self, data_api_client):
+        data_api_client.authenticate_user.return_value = user_data()
         self.client.post('/admin/login', data={
             'email_address': 'valid@example.com',
             'password': '1234567890',

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -542,6 +542,29 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
         self.assertEqual(res.status_code, 302)
         self.assertEqual(res.location, 'http://localhost/admin/suppliers/users?supplier_id=1234')
 
+    @mock.patch('app.main.views.suppliers.send_email')
+    @mock.patch('app.main.views.suppliers.data_api_client')
+    def test_should_strip_whitespace_surrounding_invite_user_email_address_field(self, data_api_client, send_email):
+        data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
+        data_api_client.find_users.return_value = self.load_example_listing("users_response")
+
+        self.client.post(
+            "/admin/suppliers/1234/invite-user",
+            data={
+                'email_address': '  this@isvalid.com  ',
+            }
+        )
+
+        send_email.assert_called_once_with(
+            'this@isvalid.com',
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY
+        )
+
     @mock.patch('app.main.views.suppliers.generate_token')
     @mock.patch('app.main.views.suppliers.render_template')
     @mock.patch('app.main.views.suppliers.send_email')


### PR DESCRIPTION
I've subclassed the WTF `StringField` class with one that preprocesses all user-inputted values.  Specifically, all submitted values will be stripped of leading and trailing whitespace.

What happens if I'm trying to login with my valid email and password:

Submitted values | Processed values | Result
------------ | ------------ | -------------
`'email@email.com'`, `'password'` | `'email@email.com'`, `'password'` | :white_check_mark:
`' email@email.com '`, `'password'` | `'email@email.com'`, `'password'` | :white_check_mark:
`'email@email.com'`, `' password '` | `'email@email.com'`, `' password '` | :x:
`' email@email.com '`, `' password '` | `'email@email.com'`, `' password '` | :x:

Also used when inviting a user.

[>> Story in Pivotal](https://www.pivotaltracker.com/story/show/103325898)

-

I haven't replaced the StringField in the `ServiceUpdateAuditEventsForm` because that one gets its input from a set of radio buttons, and if you're monkeying around with the `value` attribute in the HTML, then you shouldn't be.
