### PR TITLE
Edit supplier declaration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,10 +18,8 @@ data_api_client = apiclient.DataAPIClient()
 feature_flags = flask_featureflags.FeatureFlag()
 login_manager = LoginManager()
 
-service_content = ContentLoader(
-    "app/content/frameworks/g-cloud-6/manifests/edit_service_as_admin.yml",
-    "app/content/frameworks/g-cloud-6/questions/services/"
-)
+content_loader = ContentLoader('app/content')
+content_loader.load_manifest('g-cloud-6', 'edit_service_as_admin', 'services')
 
 
 from app.main.helpers.service import parse_document_upload_time

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,7 @@ feature_flags = flask_featureflags.FeatureFlag()
 login_manager = LoginManager()
 
 content_loader = ContentLoader('app/content')
-content_loader.load_manifest('g-cloud-6', 'edit_service_as_admin', 'services')
+content_loader.load_manifest('g-cloud-6', 'services', 'edit_service_as_admin')
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,6 +20,7 @@ login_manager = LoginManager()
 
 content_loader = ContentLoader('app/content')
 content_loader.load_manifest('g-cloud-6', 'edit_service_as_admin', 'services')
+content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
 
 
 from app.main.helpers.service import parse_document_upload_time

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -37,6 +37,7 @@ $path: "/admin/static/images/";
 @import "views/view_audits";
 @import "_diff.scss";
 @import "views/statistics";
+@import "views/view_declaration";
 
 // Graphs
 @import "_c3";

--- a/app/assets/scss/views/_view_declaration.scss
+++ b/app/assets/scss/views/_view_declaration.scss
@@ -1,3 +1,3 @@
-.my-special-page thead .summary-item-field-heading-first {
+.declaration-summary thead .summary-item-field-heading-first {
   width: 60%;
 }

--- a/app/assets/scss/views/_view_declaration.scss
+++ b/app/assets/scss/views/_view_declaration.scss
@@ -1,0 +1,3 @@
+.my-special-page thead .summary-item-field-heading-first {
+  width: 60%;
+}

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -11,7 +11,7 @@ from dmutils.s3 import S3
 
 
 from ... import data_api_client
-from ... import service_content
+from ... import content_loader
 from .. import main
 from . import get_template_data
 
@@ -51,7 +51,7 @@ def view(service_id):
         return redirect(url_for('.index'))
 
     service_data['priceString'] = format_service_price(service_data)
-    content = service_content.get_builder().filter(service_data)
+    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin')
 
     template_data = get_template_data(
         sections=content,
@@ -101,7 +101,7 @@ def update_service_status(service_id):
 def edit(service_id, section):
     service_data = data_api_client.get_service(service_id)['services']
 
-    content = service_content.get_builder().filter(service_data)
+    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service_data)
 
     template_data = get_template_data(
         section=content.get_section(section),
@@ -153,7 +153,7 @@ def compare(old_archived_service_id, new_archived_service_id):
     except (HTTPError, KeyError, ValueError):
         return abort(404)
 
-    content = service_content.get_builder().filter(service_data)
+    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service_data)
 
     # It's possible to have an empty array if none of the lines were changed.
     # TODO This possibility isn't actually handled.
@@ -188,7 +188,7 @@ def update(service_id, section_id):
         abort(404)
     service = service['services']
 
-    content = service_content.get_builder().filter(service)
+    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service)
     section = content.get_section(section_id)
     if section is None or not section.editable:
         abort(404)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -51,7 +51,7 @@ def view(service_id):
         return redirect(url_for('.index'))
 
     service_data['priceString'] = format_service_price(service_data)
-    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin')
+    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service_data)
 
     template_data = get_template_data(
         sections=content,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -44,7 +44,12 @@ def edit_supplier_name(supplier_id):
 def view_supplier_declaration(supplier_id, framework_slug):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
-    declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
+    try:
+        declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
+    except APIError as e:
+        if e.status_code != 404:
+            raise
+        declaration = {}
 
     content = content_loader.get_builder(framework_slug, 'declaration').filter(declaration)
 
@@ -65,16 +70,24 @@ def view_supplier_declaration(supplier_id, framework_slug):
 def edit_supplier_declaration_section(supplier_id, framework_slug, section_id):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
-    declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
+    try:
+        declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
+    except APIError as e:
+        if e.status_code != 404:
+            raise
+        declaration = {}
 
     content = content_loader.get_builder(framework_slug, 'declaration').filter(declaration)
+    section = content.get_section(section_id)
+    if section is None:
+        abort(404)
 
     return render_template(
         "suppliers/edit_declaration.html",
         supplier=supplier,
         framework=framework,
         declaration=declaration,
-        section=content.get_section(section_id),
+        section=section,
         **get_template_data())
 
 
@@ -84,10 +97,17 @@ def edit_supplier_declaration_section(supplier_id, framework_slug, section_id):
 def update_supplier_declaration_section(supplier_id, framework_slug, section_id):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
-    declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
+    try:
+        declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
+    except APIError as e:
+        if e.status_code != 404:
+            raise
+        declaration = {}
 
     content = content_loader.get_builder(framework_slug, 'declaration').filter(declaration)
     section = content.get_section(section_id)
+    if section is None:
+        abort(404)
 
     posted_data = section.get_data(request.form)
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,6 +35,7 @@
   {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
       <div class="grid-row">
           <div class="column-two-thirds">
+              {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
               <form action="{{ url_for('.find') }}" method="get" class="question">
                   <label class="question-heading" for="service_id">Find a service by service ID</label>
                   <p class='hint'>
@@ -61,6 +62,7 @@
                   <input type="text" name="supplier_id" id="supplier_id_for_users" class="text-box">
                   <input type="submit" value="Search" class="button-save">
               </form>
+              {% endif %}
             
               <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
                 <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
@@ -71,6 +73,8 @@
                 <input type="submit" value="Search" class="button-save">
               </form>
 
+              {% if current_user.has_any_role('admin') %}
+
               <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
                   <label class="question-heading" for="email_address">Find users by email address</label>
                   <p class='hint'>
@@ -79,6 +83,8 @@
                   <input type="text" name="email_address" id="email_address" class="text-box">
                   <input type="submit" value="Search" class="button-save">
               </form>
+
+              {% endif %}
           </div>
       </div>
   {% endif %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -32,7 +32,7 @@
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
-  {% if current_user.has_role('admin') or current_user.has_role('admin-ccs-category') %}
+  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
       <div class="grid-row">
           <div class="column-two-thirds">
               <form action="{{ url_for('.find') }}" method="get" class="question">

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -1,0 +1,46 @@
+{% import 'macros/toolkit_forms.html' as forms %}
+
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+  Change {{ framework.name }} declaration
+{% endblock %}
+
+{% block content %}
+  <div class="page-container edit-section">
+      <div class="grid-row">
+        <div class="service-title">
+          {%
+            with
+            context = supplier.name,
+            heading = section.name,
+            smaller = True
+          %}
+            {% include "toolkit/page-heading.html" %}
+          {% endwith %}
+        </div>
+      </div>
+
+      <form method="post" enctype="multipart/form-data">
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+            {% for question in section.questions %}
+              {{ forms[question.type](question, declaration, {}) }}
+            {% endfor %}
+            {%
+              with
+              type = "save",
+              label = "Save and return to summary"
+            %}
+              {% include "toolkit/button.html" %}
+            {% endwith %}
+            <p>
+              <a href="{{ url_for('.view_supplier_declaration', supplier_id=supplier.id, framework_slug=framework.slug) }}">Return without saving</a>
+            </p>
+            </div>
+          </div>
+        </div>
+      </form>
+  </div>
+{% endblock %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -1,0 +1,44 @@
+{% import "toolkit/summary-table.html" as summary %}
+
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+  Change {{ framework.name }} declaration
+{% endblock %}
+
+{% block content %}
+  <div class="page-container my-special-page">
+      <div class="grid-row">
+        <div class="service-title">
+          {%
+            with
+            context = supplier.name,
+            heading = framework.name + " declaration",
+            smaller = True
+          %}
+            {% include "toolkit/page-heading.html" %}
+          {% endwith %}
+        </div>
+      </div>
+
+      {% for section in content %}
+        {{ summary.heading(section.name) }}
+        {{ summary.top_link("Edit", url_for('.edit_supplier_declaration_section', supplier_id=supplier.id, framework_slug=framework.slug, section_id=section.id)) }}
+        {% call(item) summary.list_table(
+          section.questions,
+          caption="Declaration",
+          empty_message="This supplier not made a declaration",
+          field_headings=[
+            'Declaration question',
+            'Declaration answer'
+          ]
+        ) %}
+          {% call summary.row() %}
+            {{ summary.field_name(item.question) }}
+            {{ summary[item.type](declaration[item.id]) }}
+          {% endcall %}
+        {% endcall %}
+      {% endfor %}
+  </div>
+
+{% endblock %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="page-container my-special-page">
+  <div class="page-container declaration-summary">
       <div class="grid-row">
         <div class="service-title">
           {%

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -23,20 +23,31 @@
     {% endwith %}
 
     <div class="page-section">
+      {% if current_user.has_role("admin") %}
+        {% set field_headings = [
+          "Name",
+          summary.hidden_field_heading("Change name"),
+          summary.hidden_field_heading("Users"),
+          summary.hidden_field_heading("Services"),
+        ] %}
+      {% elif current_user.has_role("admin-ccs-sourcing") %}
+        {% set field_headings = [
+          "Name",
+          summary.hidden_field_heading("Change declarations"),
+        ] %}
+      {% else %}
+        {% set field_headings = [
+          "Name",
+          summary.hidden_field_heading("Users"),
+          summary.hidden_field_heading("Services"),
+        ] %}
+      {% endif %}
+
       {% call(item) summary.list_table(
         suppliers,
         caption="Suppliers",
         empty_message="No suppliers were found",
-        field_headings=[
-          "Name",
-          summary.hidden_field_heading("Edit name"),
-          summary.hidden_field_heading("Users"),
-          summary.hidden_field_heading("Services"),
-        ] if current_user.has_role('admin') else [
-          "Name",
-          summary.hidden_field_heading("Users"),
-          summary.hidden_field_heading("Services"),
-        ],
+        field_headings=field_headings,
         field_headings_visible=True)
       %}
         {% call summary.row() %}
@@ -44,8 +55,13 @@
           {% if current_user.has_role('admin') %}
             {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
           {% endif %}
-          {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
-          {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
+          {% if current_user.has_role('admin-ccs-sourcing') %}
+            {{ summary.edit_link("G-Cloud 7 declaration", url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7")) }}
+          {% endif %}
+          {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+            {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
+            {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
+          {% endif %}
         {% endcall %}
       {% endcall %}
     </div>

--- a/example_responses/declaration_response.json
+++ b/example_responses/declaration_response.json
@@ -1,0 +1,17 @@
+{
+  "declaration": {
+    "PR1": true,
+    "PR2": false,
+    "SQC2": true,
+    "PR5": false,
+    "PR3": true,
+    "PR4": false,
+    "SQ1-3": [],
+    "SQA2": false,
+    "SQA3": true,
+    "SQA4": false,
+    "SQA5": true,
+    "AQA3": false,
+    "SQC3": ["race", "sexual orientation"]
+  }
+}

--- a/example_responses/framework_response.json
+++ b/example_responses/framework_response.json
@@ -1,0 +1,6 @@
+{
+  "frameworks": {
+    "slug": "g-cloud-7",
+    "name": "G-Cloud 7"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ six==1.9.0
 boto==2.36.0
 markdown==2.6.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@8.6.0#egg=digitalmarketplace-utils==8.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@10.0.0#egg=digitalmarketplace-utils==10.0.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -24,19 +24,9 @@ class BaseApplicationTest(TestCase):
         )
         self._default_suffix_patch.start()
 
-        self._user_callback = login_manager.user_callback
-        login_manager.user_loader(self.user_loader)
-
-    def user_loader(self, user_id):
-        if user_id:
-            return User(
-                user_id, 'test@example.com', None, None, False, True, 'tester', 'admin'
-            )
-
     def tearDown(self):
         self._s3_patch.stop()
         self._default_suffix_patch.stop()
-        login_manager.user_loader(self._user_callback)
 
     def load_example_listing(self, name):
         file_path = os.path.join("example_responses", "{}.json".format(name))
@@ -89,8 +79,18 @@ class LoggedInApplicationTest(BaseApplicationTest):
             'password': '1234567890'
         })
 
+        self._user_callback = login_manager.user_callback
+        login_manager.user_loader(self.user_loader)
+
+    def user_loader(self, user_id):
+        if user_id:
+            return User(
+                user_id, 'test@example.com', None, None, False, True, 'tester', 'admin'
+            )
+
     def tearDown(self):
         self._data_api_client.stop()
+        login_manager.user_loader(self._user_callback)
 
     def _replace_whitespace(self, string, replacement_substring=""):
             # Replace all runs of whitespace with replacement_substring

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -54,8 +54,11 @@ class Response:
 
 
 class LoggedInApplicationTest(BaseApplicationTest):
+    user_role = 'admin'
+
     def setUp(self):
         super(LoggedInApplicationTest, self).setUp()
+
         patch_config = {
             'authenticate_user.return_value': {
                 'users': {
@@ -85,7 +88,7 @@ class LoggedInApplicationTest(BaseApplicationTest):
     def user_loader(self, user_id):
         if user_id:
             return User(
-                user_id, 'test@example.com', None, None, False, True, 'tester', 'admin'
+                user_id, 'test@example.com', None, None, False, True, 'tester', self.user_role
             )
 
     def tearDown(self):

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -36,9 +36,11 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 200)
         assert_in("Administrator login", res.get_data(as_text=True))
 
+    @mock.patch('app.data_api_client')
     @mock.patch('app.main.views.login.data_api_client')
-    def test_valid_login(self, data_api_client):
-        data_api_client.authenticate_user.return_value = user_data()
+    def test_valid_login(self, login_data_api_client, init_data_api_client):
+        login_data_api_client.authenticate_user.return_value = user_data()
+        init_data_api_client.get_user.return_value = user_data()
         res = self.client.post('/admin/login', data={
             'email_address': 'valid@email.com',
             'password': '1234567890'
@@ -101,9 +103,11 @@ class TestLogin(BaseApplicationTest):
             assert_in('HttpOnly', cookie_parts)
             assert_in('Path=/admin', cookie_parts)
 
+    @mock.patch('app.data_api_client')
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_redirect_to_login_on_logout(self, data_api_client):
-        data_api_client.authenticate_user.return_value = user_data()
+    def test_should_redirect_to_login_on_logout(self, login_data_api_client, init_data_api_client):
+        login_data_api_client.authenticate_user.return_value = user_data()
+        init_data_api_client.get_user.return_value = user_data()
         self.client.post('/admin/login', data={
             'email_address': 'valid@example.com',
             'password': '1234567890',
@@ -112,9 +116,11 @@ class TestLogin(BaseApplicationTest):
         assert_equal(res.status_code, 302)
         assert_equal(urlsplit(res.location).path, '/admin/login')
 
+    @mock.patch('app.data_api_client')
     @mock.patch('app.main.views.login.data_api_client')
-    def test_logout_should_log_user_out(self, data_api_client):
-        data_api_client.authenticate_user.return_value = user_data()
+    def test_logout_should_log_user_out(self, login_data_api_client, init_data_api_client):
+        login_data_api_client.authenticate_user.return_value = user_data()
+        init_data_api_client.get_user.return_value = user_data()
         self.client.post('/admin/login', data={
             'email_address': 'valid@example.com',
             'password': '1234567890',

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -454,15 +454,15 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
         response = self._get_archived_services_response('30', '40')
         self.assertEqual(404, response.status_code)
 
-    @mock.patch('app.main.views.services.service_content')
-    def test_can_get_archived_services_with_dates_and_diffs(self, service_content):
+    @mock.patch('app.main.views.services.content_loader')
+    def test_can_get_archived_services_with_dates_and_diffs(self, content_loader):
 
         class TestBuilder(object):
             @staticmethod
             def filter(*args):
                 return self.TestContent()
 
-        service_content.get_builder.return_value = TestBuilder()
+        content_loader.get_builder.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '20')
 
         # check title is there
@@ -497,14 +497,14 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
             self.strip_all_whitespace(response.get_data(as_text=True))
         )
 
-    @mock.patch('app.main.views.services.service_content')
-    def test_can_get_archived_services_with_differing_keys(self, service_content):
+    @mock.patch('app.main.views.services.content_loader')
+    def test_can_get_archived_services_with_differing_keys(self, content_loader):
 
         class TestBuilder(object):
             @staticmethod
             def filter(*args):
                 return self.TestContent()
 
-        service_content.get_builder.return_value = TestBuilder()
+        content_loader.get_builder.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '50')
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
This adds the ability for a CCS Sourcing team member to view and edit G-Cloud 7 supplier declarations. In the supplier listing the only link they will see alongside a supplier is 'G-Cloud 7 declaration'. This will
take them to the G-Cloud 7 supplier declaration overview where they can edit each section. This uses the new ContentLoader but hard codes the G-Cloud 7 link in the supplier list as it is the only framework they can edit at the moment.

Note that this does no validation, it is assumed that the CCS Sourcing team know the rules.

![screen shot 2015-10-09 at 16 45 54](https://cloud.githubusercontent.com/assets/14287/10398497/505b6166-6ea5-11e5-8d59-a3e2965a8413.png)

![screen shot 2015-10-09 at 16 46 02](https://cloud.githubusercontent.com/assets/14287/10398511/59e0ae44-6ea5-11e5-82ef-a8539240c6ba.png)

## Relates to
- [#103091058](https://www.pivotaltracker.com/story/show/103091058)

## Signoff
- Has been signed off by Cath
- :sparkles: has got functional tests https://github.com/alphagov/digitalmarketplace-functional-tests/pull/94 :sparkles:

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/182