### PR TITLE
Framework agreements

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,7 +3,7 @@ from flask import Blueprint
 
 main = Blueprint('main', __name__)
 
-from .views import login, service_updates, services, suppliers, stats, users
+from .views import login, agreements, service_updates, services, suppliers, stats, users
 from app.main import errors
 
 

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,5 +1,8 @@
 from flask import render_template
 from flask_login import login_required
+from dateutil.parser import parse as parse_date
+
+from dmutils.formats import datetimeformat
 
 from .. import main
 from ..auth import role_required
@@ -15,6 +18,10 @@ def list_agreements(framework_slug):
     supplier_frameworks = data_api_client.find_framework_suppliers(
         framework_slug, agreement_returned=True
     )['supplierFrameworks']
+
+    for supplier_framework in supplier_frameworks:
+        supplier_framework['agreementReturnedAt'] = datetimeformat(
+            parse_date(supplier_framework['agreementReturnedAt']))
 
     return render_template(
         'view_agreements.html',

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,0 +1,24 @@
+from flask import render_template
+from flask_login import login_required
+
+from .. import main
+from ..auth import role_required
+from ... import data_api_client
+from . import get_template_data
+
+
+@main.route('/agreements/<framework_slug>', methods=['GET'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def list_agreements(framework_slug):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    supplier_frameworks = data_api_client.find_framework_suppliers(
+        framework_slug, agreement_returned=True
+    )['supplierFrameworks']
+
+    return render_template(
+        'view_agreements.html',
+        framework=framework,
+        supplier_frameworks=supplier_frameworks,
+        **get_template_data()
+    )

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -9,7 +9,7 @@ from . import get_template_data
 
 @main.route('/agreements/<framework_slug>', methods=['GET'])
 @login_required
-@role_required('admin-ccs-sourcing')
+@role_required('admin', 'admin-ccs-sourcing')
 def list_agreements(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     supplier_frameworks = data_api_client.find_framework_suppliers(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -65,7 +65,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>/<document_name>', methods=['GET'])
 @login_required
-@role_required('admin-ccs-sourcing')
+@role_required('admin', 'admin-ccs-sourcing')
 def download_agreement_file(supplier_id, framework_slug, document_name):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -67,9 +67,12 @@ def view_supplier_declaration(supplier_id, framework_slug):
 @login_required
 @role_required('admin', 'admin-ccs-sourcing')
 def download_agreement_file(supplier_id, framework_slug, document_name):
-    supplier = data_api_client.get_supplier(supplier_id)['suppliers']
+    supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
+    if not supplier_framework.get('declaration'):
+        abort(404)
+    legal_supplier_name = supplier_framework['declaration']['SQ1-1a']
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    path = get_agreement_document_path(framework_slug, supplier_id, supplier['name'], document_name)
+    path = get_agreement_document_path(framework_slug, supplier_id, legal_supplier_name, document_name)
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
         abort(404)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -67,8 +67,9 @@ def view_supplier_declaration(supplier_id, framework_slug):
 @login_required
 @role_required('admin-ccs-sourcing')
 def download_agreement_file(supplier_id, framework_slug, document_name):
+    supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    path = get_agreement_document_path(framework_slug, supplier_id, document_name)
+    path = get_agreement_document_path(framework_slug, supplier_id, supplier['name'], document_name)
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
         abort(404)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -100,5 +100,18 @@
 {% include "toolkit/browse-list.html" %}
 {% endwith %}
 
+{% if current_user.has_any_role('admin-ccs-sourcing') %}
+  {% with items = [
+      {
+          "body": "G-Cloud 7 agreements",
+          "link": "/admin/agreements/g-cloud-7",
+          "title": "G-Cloud 7 agreements"
+      }
+  ]
+  %}
+  {% include "toolkit/browse-list.html" %}
+  {% endwith %}
+{% endif %}
+
 </div>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -100,7 +100,7 @@
 {% include "toolkit/browse-list.html" %}
 {% endwith %}
 
-{% if current_user.has_any_role('admin-ccs-sourcing') %}
+{% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
   {% with items = [
       {
           "body": "G-Cloud 7 agreements",

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -1,0 +1,46 @@
+{% import "toolkit/summary-table.html" as summary %}
+{% from 'macros/breadcrumb.html' import breadcrumb as breadcrumb %}
+{% from 'macros/page_heading.html' import page_heading %}
+
+{% extends "_base_page.html" %}
+
+{% block content %}
+{%
+    with items = [
+        {
+            "link": url_for('.index'),
+            "label": "Admin home"
+        }
+    ]
+%}
+{% include "toolkit/breadcrumb.html" %}
+{% endwith %}
+
+<div class="page-container">
+    {% with heading = "Uploaded {} framework agreements".format(framework.name) %}
+    {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+
+    <div class="page-section">
+      {% set field_headings = [
+        "Supplier name",
+        "Date uploaded",
+        summary.hidden_field_heading("Download supplier declaration"),
+      ] %}
+      {% call(supplier_framework) summary.list_table(
+        supplier_frameworks,
+        caption="Uploaded {} framework agreements".format(framework.name),
+        empty_message="No agreements have been uploaded",
+        field_headings=field_headings,
+        field_headings_visible=True)
+      %}
+        {% call summary.row() %}
+          {{ summary.field_name(supplier_framework.supplierName) }}
+          {{ summary.field_name(supplier_framework.agreementReturnedAt) }}
+          {{ summary.service_link("Download agreement", url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.frameworkSlug, document_name="signed-framework-agreement.pdf")) }}
+        {% endcall %}
+      {% endcall %}
+    </div>
+</div>
+
+{% endblock %}

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -37,7 +37,9 @@
         {% call summary.row() %}
           {{ summary.field_name(supplier_framework.supplierName) }}
           {{ summary.field_name(supplier_framework.agreementReturnedAt) }}
-          {{ summary.service_link("Download agreement", url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.frameworkSlug, document_name="signed-framework-agreement.pdf")) }}
+          {% call summary.field(wide=True) %}
+            <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.frameworkSlug, document_name="signed-framework-agreement.pdf") }}" download>Download agreement</a>
+          {% endcall %}
         {% endcall %}
       {% endcall %}
     </div>

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -34,6 +34,7 @@
         {% set field_headings = [
           "Name",
           summary.hidden_field_heading("Change declarations"),
+          summary.hidden_field_heading("Download signed agreements"),
         ] %}
       {% else %}
         {% set field_headings = [
@@ -57,6 +58,7 @@
           {% endif %}
           {% if current_user.has_role('admin-ccs-sourcing') %}
             {{ summary.edit_link("G-Cloud 7 declaration", url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7")) }}
+            {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name="signed-framework-agreement.pdf")) }}
           {% endif %}
           {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
             {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}

--- a/config.py
+++ b/config.py
@@ -23,6 +23,9 @@ class Config(object):
     DM_DATA_API_AUTH_TOKEN = None
     SECRET_KEY = os.getenv('DM_ADMIN_FRONTEND_COOKIE_SECRET')
 
+    DM_AGREEMENTS_BUCKET = None
+    DM_ASSETS_URL = None
+
     STATIC_URL_PATH = '/admin/static'
     ASSET_PATH = STATIC_URL_PATH + '/'
     BASE_TEMPLATE_DATA = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ werkzeug==0.10.4
 boto==2.36.0
 markdown==2.6.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@11.4.0#egg=digitalmarketplace-utils==11.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@13.2.0#egg=digitalmarketplace-utils==13.2.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ werkzeug==0.10.4
 boto==2.36.0
 markdown==2.6.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@11.1.2#egg=digitalmarketplace-utils==11.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@11.4.0#egg=digitalmarketplace-utils==11.4.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Bootstrap==3.3.0.1
 Flask-WTF==0.11
 requests==2.5.1
 pbkdf2==1.3
+python-dateutil==2.4.2
 six==1.9.0
 werkzeug==0.10.4
 

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -36,7 +36,7 @@ class TestListAgreements(LoggedInApplicationTest):
         eq_(len(rows), 2)
 
     def test_unauthorised_roles_are_rejected_access(self, data_api_client):
-        self.user_role = 'admin'
+        self.user_role = 'admin-ccs-category'
 
         response = self.client.get('/admin/agreements/g-cloud-7')
 

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -1,0 +1,43 @@
+import mock
+from lxml import html
+from nose.tools import eq_
+
+from ...helpers import LoggedInApplicationTest
+
+
+@mock.patch('app.main.views.agreements.data_api_client')
+class TestListAgreements(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_happy_path(self, data_api_client):
+        data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
+        data_api_client.find_framework_suppliers.return_value = {
+            'supplierFrameworks': [
+                {
+                    'supplierName': 'My Supplier',
+                    'supplierId': 11111,
+                    'agreementReturned': True,
+                    'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
+                },
+                {
+                    'supplierName': 'My other supplier',
+                    'supplierId': 11112,
+                    'agreementReturned': True,
+                    'agreementReturnedAt': '2015-10-30T01:01:01.000000Z',
+                },
+            ]
+        }
+
+        response = self.client.get('/admin/agreements/g-cloud-7')
+        page = html.fromstring(response.get_data(as_text=True))
+
+        eq_(response.status_code, 200)
+        rows = page.cssselect('.summary-item-row')
+        eq_(len(rows), 2)
+
+    def test_unauthorised_roles_are_rejected_access(self, data_api_client):
+        self.user_role = 'admin'
+
+        response = self.client.get('/admin/agreements/g-cloud-7')
+
+        eq_(response.status_code, 403)

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -742,3 +742,32 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
 
         data_api_client.set_supplier_declaration.assert_called_with(
             '1234', 'g-cloud-7', declaration, 'test@example.com')
+
+
+@mock.patch('app.main.views.suppliers.s3')
+class TestDownloadAgreementFile(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_admin_user_should_not_be_able_to_download(self, s3):
+        self.user_role = 'admin'
+
+        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
+
+        eq_(response.status_code, 403)
+
+    def test_should_404_if_document_does_not_exist(self, s3):
+        s3.S3.return_value.get_signed_url.return_value = None
+
+        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
+
+        eq_(response.status_code, 404)
+
+    def test_should_redirect(self, s3):
+        s3.S3.return_value.get_signed_url.return_value = 'http://foo/blah?extra'
+
+        self.app.config['DM_ASSETS_URL'] = 'https://example'
+
+        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
+
+        eq_(response.status_code, 302)
+        eq_(response.location, 'https://example/blah?extra')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -54,10 +54,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/users')
         self.assertEquals(404, response.status_code)
 
-    def test_should_400_if_invalid_supplier_id(self):
-        response = self.client.get('/admin/suppliers/users?supplier_id=invalid')
-        self.assertEquals(400, response.status_code)
-
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_apis_with_supplier_id(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
@@ -255,10 +251,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
     def test_should_404_if_no_supplier_id_on_services(self):
         response = self.client.get('/admin/suppliers/users')
         self.assertEquals(404, response.status_code)
-
-    def test_should_400_if_invalid_supplier_id_on_services(self):
-        response = self.client.get('/admin/suppliers/services?supplier_id=invalid')
-        self.assertEquals(400, response.status_code)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_service_apis_with_supplier_id(self, data_api_client):

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -757,22 +757,26 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
         eq_(response.status_code, 403)
 
     def test_should_404_if_document_does_not_exist(self, s3, data_api_client):
-        data_api_client.get_supplier.return_value = {'suppliers': {'name': 'My Supplier'}}
+        data_api_client.get_supplier_framework_info.return_value = {
+            'frameworkInterest': {'declaration': {'SQ1-1a': 'Supplier name'}}
+        }
         s3.S3.return_value.get_signed_url.return_value = None
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 
-        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/My_Supplier-1234-foo.pdf')
+        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf')
         eq_(response.status_code, 404)
 
     def test_should_redirect(self, s3, data_api_client):
-        data_api_client.get_supplier.return_value = {'suppliers': {'name': 'My Supplier'}}
+        data_api_client.get_supplier_framework_info.return_value = {
+            'frameworkInterest': {'declaration': {'SQ1-1a': 'Supplier name'}}
+        }
         s3.S3.return_value.get_signed_url.return_value = 'http://foo/blah?extra'
 
         self.app.config['DM_ASSETS_URL'] = 'https://example'
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 
-        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/My_Supplier-1234-foo.pdf')
+        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf')
         eq_(response.status_code, 302)
         eq_(response.location, 'https://example/blah?extra')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -750,7 +750,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
     def test_admin_user_should_not_be_able_to_download(self, s3, data_api_client):
-        self.user_role = 'admin'
+        self.user_role = 'admin-ccs-category'
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 


### PR DESCRIPTION
[#105012790](https://www.pivotaltracker.com/story/show/105012790)

## Get rid of get_supplier helper function
Now that the admin frontend translates API errors into the appropriate Flask response this helper does not offer much. One change here is that the supplier_id is no longer validated. This is left up to the API.

## Add signed agreement download link
Add a link to the `admin-ccs-sourcing` supplier list that allows them to download signed agreement documents.

## listing page for signed framework agreements

This adds a page that lists signed framework agreements in reverse chronological order (most recent first). This allows the CCS sourcing team to easily find recently uploaded agreements that need action.

![screen shot 2015-11-09 at 10 53 33](https://cloud.githubusercontent.com/assets/14287/11031989/32637f20-86d0-11e5-8e9a-c64ce1575a92.png)

## Depends on
- [x] Sign off from Cath
- [ ] :sparkles: Functional tests :sparkles: 