### PR TITLE
Only get the latest stats while framework is open

### DIFF
--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -25,7 +25,7 @@ def view_statistics(framework_slug):
             per_page=1260
         )['auditEvents']
         framework = data_api_client.get_framework(framework_slug)['frameworks']
-        if framework['status'] is 'open':
+        if framework['status'] == 'open':
             snapshots.append(
                 {
                     'data': data_api_client.get_framework_stats(framework_slug),

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -24,13 +24,14 @@ def view_statistics(framework_slug):
             audit_type=AuditTypes.snapshot_framework_stats,
             per_page=1260
         )['auditEvents']
-        latest = data_api_client.get_framework_stats(framework_slug)
-        snapshots.append(
-            {
-                'data': latest,
-                'createdAt': datetime.utcnow().strftime(DATETIME_FORMAT)
-            }
-        )
+        framework = data_api_client.get_framework(framework_slug)['frameworks']
+        if framework['status'] is 'open':
+            snapshots.append(
+                {
+                    'data': data_api_client.get_framework_stats(framework_slug),
+                    'createdAt': datetime.utcnow().strftime(DATETIME_FORMAT)
+                }
+            )
     except HTTPError as error:
         abort(error.status_code)
 


### PR DESCRIPTION
To keep the statistics fresh, we append the latest numbers to the table every time the page is loaded.

These numbers won’t change after close of submissions, so we should only do it when the framework is in an 'open' state.

![image](https://cloud.githubusercontent.com/assets/355079/11014493/6ce13ac6-8530-11e5-8264-801f5cfa9b91.png)
