### PR TITLE
Multi-extension agreement download

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -72,7 +72,11 @@ def download_agreement_file(supplier_id, framework_slug, document_name):
         abort(404)
     legal_supplier_name = supplier_framework['declaration']['SQ1-1a']
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    path = get_agreement_document_path(framework_slug, supplier_id, legal_supplier_name, document_name)
+    prefix = get_agreement_document_path(framework_slug, supplier_id, legal_supplier_name, document_name)
+    agreement_documents = agreements_bucket.list(prefix=prefix)
+    if not len(agreement_documents):
+        abort(404)
+    path = agreement_documents[-1]['path']
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
         abort(404)

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -38,7 +38,7 @@
           {{ summary.field_name(supplier_framework.supplierName) }}
           {{ summary.field_name(supplier_framework.agreementReturnedAt) }}
           {% call summary.field(wide=True) %}
-            <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name="signed-framework-agreement.pdf") }}" download>Download agreement</a>
+            <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name="signed-framework-agreement") }}" download>Download agreement</a>
           {% endcall %}
         {% endcall %}
       {% endcall %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -58,7 +58,7 @@
           {% endif %}
           {% if current_user.has_role('admin-ccs-sourcing') %}
             {{ summary.edit_link("G-Cloud 7 declaration", url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7")) }}
-            {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name="signed-framework-agreement.pdf")) }}
+            {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name="signed-framework-agreement")) }}
           {% endif %}
           {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
             {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}


### PR DESCRIPTION
This change adds support for framework agreements potentially having different extensions introduced in https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/340

Because the full path is no longer known, instead the prefix is provided and the most recent matching file is returned. This works because the agreement file names do not overlap and the timestamp is added to the start of the archive file name. If the supplier first uploads a PDF and then uploads a JPEG the JPEG will be returned here because it is the most recent matching upload.