### PR TITLE
Remove requests as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Bootstrap==3.3.0.1
 Flask-WTF==0.11
-requests==2.5.1
 pbkdf2==1.3
 python-dateutil==2.4.2
 six==1.9.0


### PR DESCRIPTION
require.io [says it’s insecure](https://requires.io/github/alphagov/digitalmarketplace-admin-frontend/requirements/?branch=master).

This updates to the latest version.

The vulnerability that has been fixed is:
> CVE-2015-2296: Fix handling of cookies on redirect. Previously a cookie
> without a host value set would use the hostname for the redirected URL exposing
> requests users to session fixation attacks and potentially cookie stealing. This
> was disclosed privately by Matthew Daley of BugFuzz. This affects all versions
> of requests from v2.1.0 to v2.5.3 (inclusive on both ends).