### PR TITLE
Limit stats audit events to current framework

### DIFF
--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -21,6 +21,8 @@ def view_statistics(framework_slug):
 
     snapshots = data_api_client.find_audit_events(
         audit_type=AuditTypes.snapshot_framework_stats,
+        object_type='frameworks',
+        object_id=framework_slug,
         per_page=1260
     )['auditEvents']
     framework = data_api_client.get_framework(framework_slug)['frameworks']

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -16,6 +16,8 @@ class TestStats(LoggedInApplicationTest):
 
         data_api_client.find_audit_events.assert_called_with(
             audit_type=AuditTypes.snapshot_framework_stats,
+            object_type='frameworks',
+            object_id='g-cloud-7',
             per_page=1260
         )
 


### PR DESCRIPTION
When loading the stored stats from previous days on the stats page we need to limit it to the current framework.