### PR TITLE
Make stats page lot-agnostic

### DIFF
--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -52,11 +52,10 @@ def view_statistics(framework_slug):
             }
         }),
         services_by_lot=format_snapshots(snapshots, 'services', {
-            'iaas': {'lot': ['IaaS', 'iaas']},
-            'paas': {'lot': ['PaaS', 'paas']},
-            'saas': {'lot': ['SaaS', 'saas']},
-            'scs':  {'lot': ['SCS', 'scs']},
+            lot['slug']: {'lot': lot['slug']} for lot in framework['lots']
         }),
+        lots=framework['lots'],
+        lot_table_headings=["Date and time"] + [lot['name'] for lot in framework['lots']],
         interested_suppliers=format_snapshots(snapshots, 'interested_suppliers', {
             'interested_only': {
                 'declaration_status': None,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -44,7 +44,7 @@
                   <input type="text" name="service_id" id="service_id" class="text-box">
                   <input type="submit" value="Search" class="button-save">
               </form>
-            
+
               <form action="{{ url_for('.find_supplier_services') }}" method="get" class="question">
                   <label class="question-heading" for="supplier_id_for_services">Find services by supplier ID</label>
                   <p class='hint'>
@@ -63,7 +63,7 @@
                   <input type="submit" value="Search" class="button-save">
               </form>
               {% endif %}
-            
+
               <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
                 <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
                 <p class="hint">
@@ -90,19 +90,19 @@
   {% endif %}
 
 {% with items = [
-    {
-        "body": "View G-Cloud 7 statistics",
-        "link": "/admin/statistics/g-cloud-7",
-        "title": "G-Cloud 7 statistics"
-    },
-    {
-        "body": "View Digital Outcomes and Specialists statistics",
-        "link": "/admin/statistics/digital-outcomes-and-specialists",
-        "title": "Digital Outcomes and Specialists statistics"
-    }
-]
+      {
+          "body": "View G-Cloud 7 statistics",
+          "link": "/admin/statistics/g-cloud-7",
+          "title": "G-Cloud 7 statistics"
+      },
+      {
+          "body": "View Digital Outcomes and Specialists statistics",
+          "link": "/admin/statistics/digital-outcomes-and-specialists",
+          "title": "Digital Outcomes and Specialists statistics"
+      }
+  ]
 %}
-{% include "toolkit/browse-list.html" %}
+  {% include "toolkit/browse-list.html" %}
 {% endwith %}
 
 {% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
@@ -112,9 +112,9 @@
           "link": "/admin/agreements/g-cloud-7",
           "title": "G-Cloud 7 agreements"
       }
-  ]
+    ]
   %}
-  {% include "toolkit/browse-list.html" %}
+    {% include "toolkit/browse-list.html" %}
   {% endwith %}
 {% endif %}
 

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -70,23 +70,16 @@
       services_by_lot,
       empty_message="Data not available",
       caption="Services by lot",
-      field_headings=[
-        summary.hidden_field_heading("Date and time"),
-        "Software as a Service",
-        "Platform as a Service",
-        "Infrastructure as a Service",
-        "Specialist cloud services"
-      ],
+      field_headings=lot_table_headings,
       field_headings_visible=True
     ) %}
       {% call summary.row() %}
         {% call summary.field(first=True) %}
           {{ item.created_at[:19]|replace('T', ' ')|replace('-', '/') }}
         {% endcall %}
-        {{ summary.text(item.saas) }}
-        {{ summary.text(item.paas) }}
-        {{ summary.text(item.iaas) }}
-        {{ summary.text(item.scs) }}
+        {% for lot in lots %}
+          {{ summary.text(item[lot.slug]) }}
+        {% endfor %}
       {% endcall %}
     {% endcall %}
 

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -115,7 +115,7 @@
       caption="Users",
       field_headings=[
         summary.hidden_field_heading("Date and time"),
-        "Before July",
+        "Never",
         "Over a week ago",
         "In the last week",
       ],


### PR DESCRIPTION
Previous this was hard-coded to the G-Cloud lots.

![image](https://cloud.githubusercontent.com/assets/355079/11629321/70a2070e-9cef-11e5-816a-16caf33abd58.png)

Would appreciate someone testing this with their local data and seeing if it looks reasonable…