### PR TITLE
Only count complete services in lot breakdown

### DIFF
--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -52,7 +52,10 @@ def view_statistics(framework_slug):
             }
         }),
         services_by_lot=format_snapshots(snapshots, 'services', {
-            lot['slug']: {'lot': lot['slug']} for lot in framework['lots']
+            lot['slug']: {
+                'lot': lot['slug'],
+                'status': 'submitted',
+            } for lot in framework['lots']
         }),
         lots=framework['lots'],
         lot_table_headings=["Date and time"] + [lot['name'] for lot in framework['lots']],

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -65,7 +65,7 @@
       {% endcall %}
     {% endcall %}
 
-    {{ summary.heading("Services by lot") }}
+    {{ summary.heading("Complete services by lot") }}
     {% call(item) summary.list_table(
       services_by_lot,
       empty_message="Data not available",


### PR DESCRIPTION
Because you automatically get a draft just for clicking into ‘outcomes’, ‘specialists’ or ‘research participants’ the numbers aren’t very meaningful.

I think it’s better to only count services that suppliers have marked as complete.