### PR TITLE
Enable admin to post new files

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,7 +3,7 @@ from flask import Blueprint
 
 main = Blueprint('main', __name__)
 
-from .views import login, agreements, service_updates, services, suppliers, stats, users
+from .views import login, agreements, communications, service_updates, services, suppliers, stats, users
 from app.main import errors
 
 

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -78,7 +78,6 @@ def upload_communication(framework_slug):
             flash('itt_pack', 'upload_communication')
 
     if len(errors) > 0:
-        print errors
         for category, message in errors.items():
             flash(category, message)
     return redirect(url_for('.manage_communications', framework_slug=framework_slug))

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -1,0 +1,84 @@
+from flask import render_template, redirect, url_for, current_app, \
+    request, flash
+from flask_login import login_required
+
+from .. import main
+from ..auth import role_required
+from ... import data_api_client
+from . import get_template_data
+
+from dmutils import s3
+from dmutils.documents import file_is_pdf, file_is_zip
+
+
+def _get_path(framework_slug, path):
+    return '{}/communications/{}'.format(framework_slug, path)
+
+
+def _get_itt_pack_path(framework_slug):
+    return '{0}/communications/{0}-itt-pack.zip'.format(framework_slug)
+
+
+@main.route('/communications/<framework_slug>', methods=['GET'])
+@login_required
+@role_required('admin')
+def manage_communications(framework_slug):
+    communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+
+    itt_pack = next(iter(communications_bucket.list(_get_itt_pack_path(framework_slug))), None)
+    clarification = next(iter(communications_bucket.list(_get_path(framework_slug, 'updates/clarifications'))), None)
+    communication = next(iter(communications_bucket.list(_get_path(framework_slug, 'updates/communications'))), None)
+
+    return render_template(
+        'manage_communications.html',
+        itt_pack=itt_pack,
+        clarification=clarification,
+        communication=communication,
+        framework=framework,
+        **get_template_data()
+    )
+
+
+@main.route('/communications/<framework_slug>', methods=['POST'])
+@login_required
+@role_required('admin')
+def upload_communication(framework_slug):
+    communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
+    errors = {}
+
+    if request.files.get('communication'):
+        the_file = request.files['communication']
+        if not file_is_pdf(the_file):
+            errors['communication'] = 'not_pdf'
+
+        if 'communication' not in errors.keys():
+            filename = _get_path(framework_slug, 'updates/communications') + '/' + the_file.filename
+            communications_bucket.save(filename, the_file)
+            flash('communication', 'upload_communication')
+
+    if request.files.get('clarification'):
+        the_file = request.files['clarification']
+        if not file_is_pdf(the_file):
+            errors['clarification'] = 'not_pdf'
+
+        if 'clarification' not in errors.keys():
+            filename = _get_path(framework_slug, 'updates/clarifications') + '/' + the_file.filename
+            communications_bucket.save(filename, the_file)
+            flash('clarification', 'upload_communication')
+
+    if request.files.get('itt_pack'):
+        the_file = request.files['itt_pack']
+        if not file_is_zip(the_file):
+            errors['itt_pack'] = 'not_zip'
+
+        if 'itt_pack' not in errors.keys():
+            filename = _get_itt_pack_path(framework_slug)
+            communications_bucket.save(filename, the_file)
+            flash('itt_pack', 'upload_communication')
+
+    if len(errors) > 0:
+        print errors
+        for category, message in errors.items():
+            flash(category, message)
+    return redirect(url_for('.manage_communications', framework_slug=framework_slug))

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -89,28 +89,40 @@
       </div>
   {% endif %}
 
+{% with
+    smaller = True,
+    heading = "Statistics"
+%}
+  {% include "toolkit/page-heading.html" %}
+{% endwith %}
 {% with items = [
-      {
-          "body": "View G-Cloud 7 statistics",
-          "link": "/admin/statistics/g-cloud-7",
-          "title": "G-Cloud 7 statistics"
-      },
-      {
-          "body": "View Digital Outcomes and Specialists statistics",
-          "link": "/admin/statistics/digital-outcomes-and-specialists",
-          "title": "Digital Outcomes and Specialists statistics"
-      }
-  ]
+    {
+        "body": "View G-Cloud 7 statistics",
+        "link": "/admin/statistics/g-cloud-7",
+        "title": "G-Cloud 7"
+    },
+    {
+        "body": "View Digital Outcomes and Specialists statistics",
+        "link": "/admin/statistics/digital-outcomes-and-specialists",
+        "title": "Digital Outcomes and Specialists"
+    }
+]
 %}
   {% include "toolkit/browse-list.html" %}
 {% endwith %}
 
 {% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
+  {% with
+      smaller = True,
+      heading = "Agreements"
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
   {% with items = [
       {
           "body": "G-Cloud 7 agreements",
           "link": "/admin/agreements/g-cloud-7",
-          "title": "G-Cloud 7 agreements"
+          "title": "G-Cloud 7"
       }
     ]
   %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -130,5 +130,24 @@
   {% endwith %}
 {% endif %}
 
+{% if current_user.has_any_role('admin') %}
+  {% with
+      smaller = True,
+      heading = "Communications"
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  {% with items = [
+    {
+        "body": "Manage Digital Outcomes and Specialists communications",
+        "link": "/admin/communications/digital-outcomes-and-specialists",
+        "title": "Digital Outcomes and Specialists"
+    }
+  ]
+  %}
+  {% include "toolkit/browse-list.html" %}
+  {% endwith %}
+{% endif %}
+
 </div>
 {% endblock %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -1,0 +1,106 @@
+{% import 'macros/toolkit_forms.html' as forms %}
+
+{% extends "_base_page.html" %}
+
+{% block content %}
+{%
+    with items = [
+        {
+            "link": url_for('.index'),
+            "label": "Admin home"
+        }
+    ]
+%}
+{% include "toolkit/breadcrumb.html" %}
+{% endwith %}
+
+<div class="page-container">
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% if messages %}
+{% for category, message in messages %}
+{% if category == 'upload_communication' %}
+  <div class="banner-success-without-action">
+    <p class="banner-message">
+    {% if message == 'itt_pack' %}
+      ITT pack was uploaded.
+    {% elif message == 'clarification' %}
+      New clarification was uploaded.
+    {% elif message == 'communication' %}
+      New communication was uploaded.
+    {% endif %}
+    </p>
+  </div>
+{% elif category == 'not_pdf' %}
+  <div class="banner-destructive-without-action">
+    <p class="banner-message">
+      {% if message == 'communication' %}
+      Communication file is not a PDF.
+      {% elif message == 'clarification' %}
+      Clarification file is not a PDF.
+      {% endif %}
+    </p>
+  </div>
+{% elif category == 'not_zip' and message == 'itt_pack' %}
+  <div class="banner-destructive-without-action">
+    <p class="banner-message">
+      ITT pack is not a zip file.
+    </p>
+  </div>
+{% endif %}
+
+{% endfor %}
+{% endif %}
+{% endwith %}
+
+  {% with heading = "Upload {} communications".format(framework.name) %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  <div class="page-section">
+    <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      {% with
+         question="Communication",
+         hint="This must be PDF",
+         name="communication",
+         value="Last modified {}".format(communication.last_modified),
+         error=communication_error
+      %}
+        {% include "toolkit/forms/upload.html" %}
+      {% endwith %}
+
+      {% if framework.status in ['open'] %}
+      {% with
+         question="Clarification answers",
+         hint="This must be PDF",
+         name="clarification",
+         value="Last modified {}".format(clarification.last_modified),
+         error=clarification_error
+      %}
+        {% include "toolkit/forms/upload.html" %}
+      {% endwith %}
+      {% endif %}
+
+      {% if framework.status in ['open', 'closed'] %}
+      {% with
+         question="ITT pack",
+         hint="This must be ZIP",
+         name="itt_pack",
+         value="Last modified {}".format(itt_pack.last_modified),
+         error=itt_pack_error
+      %}
+        {% include "toolkit/forms/upload.html" %}
+      {% endwith %}
+      {% endif %}
+      {%
+        with
+        type = "save",
+        label = "Upload files"
+      %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+    </form>
+  </div>
+</div>
+
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -24,6 +24,7 @@ class Config(object):
     SECRET_KEY = os.getenv('DM_ADMIN_FRONTEND_COOKIE_SECRET')
 
     DM_AGREEMENTS_BUCKET = None
+    DM_COMMUNICATIONS_BUCKET = None
     DM_ASSETS_URL = None
 
     STATIC_URL_PATH = '/admin/static'
@@ -73,12 +74,14 @@ class Test(Config):
     SHARED_EMAIL_KEY = 'KEY'
     INVITE_EMAIL_SALT = 'SALT'
     DM_MANDRILL_API_KEY = "MANDRILL"
+    DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
 
 
 class Development(Config):
     DEBUG = True
     SESSION_COOKIE_SECURE = False
     AUTHENTICATION = True
+    DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
 
 
 class Live(Config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ werkzeug==0.10.4
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@13.5.0#egg=digitalmarketplace-utils==13.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.10.0#egg=digitalmarketplace-utils==15.10.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -170,7 +170,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             ],
         }}
         response = self.client.get(
-            '/admin/services/1/edit/features_and_benefits'
+            '/admin/services/1/edit/features-and-benefits'
         )
         self.assertEquals(200, response.status_code)
         self.assertIn(
@@ -180,7 +180,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             b'id="input-serviceFeatures-1" class="text-box" value=""',
             response.data)
         response = self.client.post(
-            '/admin/services/1/edit/features_and_benefits',
+            '/admin/services/1/edit/features-and-benefits',
             data={
                 'serviceFeatures': 'foo',
                 'serviceBenefits': 'foo',
@@ -198,7 +198,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'lot': 'SaaS'
         }}
         response = self.client.get(
-            '/admin/services/1/edit/features_and_benefits')
+            '/admin/services/1/edit/features-and-benefits')
 
         data_api_client.get_service.assert_called_with('1')
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -679,7 +679,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
     def test_should_404_if_supplier_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.side_effect = APIError(Response(404))
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g_cloud_7_essentials')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
         eq_(response.status_code, 404)
         data_api_client.get_supplier.assert_called_with('1234')
@@ -689,7 +689,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.get_framework.side_effect = APIError(Response(404))
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g_cloud_7_essentials')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
         eq_(response.status_code, 404)
         data_api_client.get_supplier.assert_called_with('1234')
@@ -709,7 +709,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
         data_api_client.get_supplier_declaration.side_effect = APIError(Response(404))
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g_cloud_7_essentials')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
         eq_(response.status_code, 200)
         data_api_client.get_supplier.assert_called_with('1234')
@@ -721,7 +721,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
         data_api_client.get_supplier_declaration.return_value = self.load_example_listing('declaration_response')
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g_cloud_7_essentials')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
         document = html.fromstring(response.get_data(as_text=True))
 
         eq_(response.status_code, 200)
@@ -734,11 +734,13 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_supplier_declaration.return_value = self.load_example_listing('declaration_response')
 
         response = self.client.post(
-            '/admin/suppliers/1234/edit/declarations/g-cloud-7/g_cloud_7_essentials',
+            '/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials',
             data={'PR1': 'false'})
 
         declaration = self.load_example_listing('declaration_response')['declaration']
         declaration['PR1'] = False
+        declaration['SQ1-3'] = None
+        declaration['SQC3'] = None
 
         data_api_client.set_supplier_declaration.assert_called_with(
             '1234', 'g-cloud-7', declaration, 'test@example.com')


### PR DESCRIPTION
Pivotal: [#107188452](https://www.pivotaltracker.com/story/show/107188452)

As an admin user I want to upload new clarification answers in pdf, new ITT packs in zip format and their accompanying email in PDFs from the admin app so that I don't have to get a developer involved each time. 