### PR TITLE
Update bower to stop it complaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "engine": "node >= 0.10.0",
   "dependencies": {
-    "bower": "1.3.12",
+    "bower": "1.7.1",
     "del": "1.1.1",
     "govuk_frontend_toolkit": "3.1.0",
     "gulp": "3.8.7",


### PR DESCRIPTION
When it complains, it tells you to update the
global install. This assumes your installation is
global which ours isn't.

![image](https://cloud.githubusercontent.com/assets/87140/11897855/084b5b98-a58b-11e5-90eb-66ad39c9e256.png)

This message is therefore dangerous to follow.

Following it and updating bower is sensible anyway.