### PR TITLE
Use same layout container as supplier + buyer apps

### DIFF
--- a/app/assets/scss/_layout.scss
+++ b/app/assets/scss/_layout.scss
@@ -5,7 +5,7 @@
   background: $red;
 }
 
-.page-container {
+#wrapper {
   @extend %site-width-container;
   padding-bottom: $gutter * 2;
 }

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -14,6 +14,15 @@
   {% include "_proposition_header.html" %}
 {% endblock %}
 
+{% block content %}
+  {% block breadcrumb %}{% endblock %}
+  <div id="wrapper">
+    <main id="content" role="main">
+      {% block main_content %}{% endblock %}
+    </main>
+  </div>
+{% endblock %}
+
 {% block footer_top %}
   {% include "_footer_categories.html" %}
 {% endblock %}

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -7,13 +7,10 @@
   {{ service_data['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
-  {{ breadcrumb() }}
-  <div class="page-container">
-
-{% with messages = get_flashed_messages(with_categories=true) %}
-{% if messages %}
-{% for category, message in messages %}
+{% block main_content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  {% for category, message in messages %}
     {% if category == 'error' %}
         <div class="banner-destructive-without-action">
     {% else %}
@@ -32,7 +29,7 @@
   </div>
   {% endif %}
   {% endwith %}
-          
+
     {% if service_data %}
       <div class="grid-row">
         <div class="service-title">

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -7,7 +7,7 @@
   {{ section.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
+{% block breadcrumb %}
   {%
     with items = [
       {
@@ -22,63 +22,64 @@
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
-  <div class="page-container edit-section">
-    {%
-      with
-      heading = section.name,
-      smaller = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    {% if errors %}
-      <div class="validation-masthead">
-        <h2 class="validation-masthead-heading">
-          There were problems with your response to the following questions:
-        </h2>
-        <ul>
-          {% for question in section.questions %}
-            {% if question.id in errors %}
-              <li>
-                <a class="validation-masthead-link" href="#{{ question.id }}">{{ question.question }}</a>
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
+{% endblock %}
+
+{% block main_content %}
+  {%
+    with
+    heading = section.name,
+    smaller = True
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  {% if errors %}
+    <div class="validation-masthead">
+      <h2 class="validation-masthead-heading">
+        There were problems with your response to the following questions:
+      </h2>
+      <ul>
+        {% for question in section.questions %}
+          {% if question.id in errors %}
+            <li>
+              <a class="validation-masthead-link" href="#{{ question.id }}">{{ question.question }}</a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  <form method="post" enctype="multipart/form-data">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+        {% for question in section.questions %}
+          {% if errors and errors[question.id] %}
+            {{ forms[question.type](question, service_data, errors) }}
+          {% else %}
+            {{ forms[question.type](question, service_data, {}) }}
+          {% endif %}
+          {% if question.assuranceApproach %}
+            <div class='assurance-question'>
+              {{ assurance_question(
+                name=question.id,
+                service_data=service_data,
+                type=question.assuranceApproach,
+                errors=errors if errors else {}
+              ) }}
+            </div>
+          {% endif %}
+        {% endfor %}
+        {%
+          with
+          type = "save",
+          label = "Save and return to summary"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+        <p>
+          <a href="{{ url_for('.view', service_id=service_data.id) }}">Return without saving</a>
+        </p>
       </div>
-    {% endif %}
-    <form method="post" enctype="multipart/form-data">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
-          {% for question in section.questions %}
-            {% if errors and errors[question.id] %}
-              {{ forms[question.type](question, service_data, errors) }}
-            {% else %}
-              {{ forms[question.type](question, service_data, {}) }}
-            {% endif %}
-            {% if question.assuranceApproach %}
-              <div class='assurance-question'>
-                {{ assurance_question(
-                  name=question.id,
-                  service_data=service_data,
-                  type=question.assuranceApproach,
-                  errors=errors if errors else {}
-                ) }}
-              </div>
-            {% endif %}
-          {% endfor %}
-          {%
-            with
-            type = "save",
-            label = "Save and return to summary"
-          %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
-          <p>
-            <a href="{{ url_for('.view', service_id=service_data.id) }}">Return without saving</a>
-          </p>
-        </div>
-      </div>
-    </form>
-  </div>
+    </div>
+  </form>
 {% endblock %}

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -5,7 +5,7 @@
   Change name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
+{% block breadcrumb %}
   {%
     with items = [
       {
@@ -19,31 +19,32 @@
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
-  <div class="page-container">
-    {% with heading = "Change supplier name" %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    <form method="post">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-          {%
-            with
-            question = "New name",
-            name = "new_supplier_name",
-            value = supplier.name
-          %}
-            {% include "toolkit/forms/textbox.html" %}
-          {% endwith %}
-          {%
-            with
-            type = "save",
-            label = "Save"
-          %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
-        </div>
+{% endblock %}
+
+{% block main_content %}
+  {% with heading = "Change supplier name" %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  <form method="post">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+        {%
+          with
+          question = "New name",
+          name = "new_supplier_name",
+          value = supplier.name
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+        {%
+          with
+          type = "save",
+          label = "Save"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
       </div>
-    </form>
-  </div>
+    </div>
+  </form>
 {% endblock %}

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -2,13 +2,11 @@
 
 {% block page_title %}Access denied - 403 – Digital Marketplace{% endblock %}
 
-{% block content %}
-  <div class="page-container">
-    {% with heading = "You don’t have permission to perform this action" %}
-      {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
-    <p>
-      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need to access this content.
-    </p>
-  </div>
+{% block main_content %}
+  {% with heading = "You don’t have permission to perform this action" %}
+    {% include 'toolkit/page-heading.html' %}
+  {% endwith %}
+  <p>
+    Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need to access this content.
+  </p>
 {% endblock %}

--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -1,17 +1,15 @@
 {% extends "_base_page.html" %}
 
-{% block content %}
-  <div class="page-container">
-    {% with heading = "Page could not be found" %}
-      {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
-    <p>
-      Check you've entered the correct web address or start again on the
-      Digital Marketplace homepage.
-    </p>
-    <p>
-      If you can't find what you're looking for, contact us at
-      <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-    </p>
-  </div>
+{% block main_content %}
+  {% with heading = "Page could not be found" %}
+    {% include 'toolkit/page-heading.html' %}
+  {% endwith %}
+  <p>
+    Check you've entered the correct web address or start again on the
+    Digital Marketplace homepage.
+  </p>
+  <p>
+    If you can't find what you're looking for, contact us at
+    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+  </p>
 {% endblock %}

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -1,12 +1,10 @@
 {% extends "_base_page.html" %}
 
-{% block content %}
-  <div class="page-container">
-    {% with heading = "Sorry, we’re experiencing technical difficulties" %}
-      {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
-    <p>
-        Try again later.
-    </p>
-  </div>
+{% block main_content %}
+  {% with heading = "Sorry, we’re experiencing technical difficulties" %}
+    {% include 'toolkit/page-heading.html' %}
+  {% endwith %}
+  <p>
+      Try again later.
+  </p>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,8 +5,7 @@
   Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
-<div class="page-container">
+{% block main_content %}
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -89,65 +88,64 @@
       </div>
   {% endif %}
 
-{% with
-    smaller = True,
-    heading = "Statistics"
-%}
-  {% include "toolkit/page-heading.html" %}
-{% endwith %}
-{% with items = [
-    {
-        "body": "View G-Cloud 7 statistics",
-        "link": "/admin/statistics/g-cloud-7",
-        "title": "G-Cloud 7 statistics"
-    },
-    {
-        "body": "View Digital Outcomes and Specialists statistics",
-        "link": "/admin/statistics/digital-outcomes-and-specialists",
-        "title": "Digital Outcomes and Specialists statistics"
-    }
-]
-%}
-  {% include "toolkit/browse-list.html" %}
-{% endwith %}
-
-{% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
   {% with
       smaller = True,
-      heading = "Agreements"
+      heading = "Statistics"
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
   {% with items = [
       {
-          "body": "G-Cloud 7 agreements",
-          "link": "/admin/agreements/g-cloud-7",
-          "title": "G-Cloud 7 agreements"
+          "body": "View G-Cloud 7 statistics",
+          "link": "/admin/statistics/g-cloud-7",
+          "title": "G-Cloud 7"
+      },
+      {
+          "body": "View Digital Outcomes and Specialists statistics",
+          "link": "/admin/statistics/digital-outcomes-and-specialists",
+          "title": "Digital Outcomes and Specialists"
       }
-    ]
+  ]
   %}
     {% include "toolkit/browse-list.html" %}
   {% endwith %}
-{% endif %}
 
-{% if current_user.has_any_role('admin') %}
-  {% with
-      smaller = True,
-      heading = "Communications"
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-  {% with items = [
-    {
-        "body": "Manage Digital Outcomes and Specialists communications",
-        "link": "/admin/communications/digital-outcomes-and-specialists",
-        "title": "Digital Outcomes and Specialists communications"
-    }
-  ]
-  %}
-  {% include "toolkit/browse-list.html" %}
-  {% endwith %}
-{% endif %}
+  {% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
+    {% with
+        smaller = True,
+        heading = "Agreements"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    {% with items = [
+        {
+            "body": "G-Cloud 7 agreements",
+            "link": "/admin/agreements/g-cloud-7",
+            "title": "G-Cloud 7"
+        }
+      ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+  {% endif %}
 
-</div>
+  {% if current_user.has_any_role('admin') %}
+    {% with
+        smaller = True,
+        heading = "Communications"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    {% with items = [
+      {
+          "body": "Manage Digital Outcomes and Specialists communications",
+          "link": "/admin/communications/digital-outcomes-and-specialists",
+          "title": "Digital Outcomes and Specialists communications"
+      }
+    ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+  {% endif %}
+
 {% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -5,9 +5,7 @@
   Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
-<div class="page-container">
-
+{% block main_content %}
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}
@@ -80,5 +78,4 @@
         </div>
     </div>
   </form>
-</div>
 {% endblock %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -2,105 +2,103 @@
 
 {% extends "_base_page.html" %}
 
-{% block content %}
-{%
-    with items = [
-        {
-            "link": url_for('.index'),
-            "label": "Admin home"
-        }
-    ]
-%}
-{% include "toolkit/breadcrumb.html" %}
-{% endwith %}
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
 
-<div class="page-container">
-{% with messages = get_flashed_messages(with_categories=true) %}
-{% if messages %}
-{% for category, message in messages %}
-{% if category == 'upload_communication' %}
-  <div class="banner-success-without-action">
-    <p class="banner-message">
-    {% if message == 'itt_pack' %}
-      ITT pack was uploaded.
-    {% elif message == 'clarification' %}
-      New clarification was uploaded.
-    {% elif message == 'communication' %}
-      New communication was uploaded.
-    {% endif %}
-    </p>
-  </div>
-{% elif category == 'not_pdf' %}
-  <div class="banner-destructive-without-action">
-    <p class="banner-message">
-      {% if message == 'communication' %}
-      Communication file is not a PDF.
+{% block main_content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  {% for category, message in messages %}
+  {% if category == 'upload_communication' %}
+    <div class="banner-success-without-action">
+      <p class="banner-message">
+      {% if message == 'itt_pack' %}
+        ITT pack was uploaded.
       {% elif message == 'clarification' %}
-      Clarification file is not a PDF.
+        New clarification was uploaded.
+      {% elif message == 'communication' %}
+        New communication was uploaded.
       {% endif %}
-    </p>
-  </div>
-{% elif category == 'not_zip' and message == 'itt_pack' %}
-  <div class="banner-destructive-without-action">
-    <p class="banner-message">
-      ITT pack is not a zip file.
-    </p>
-  </div>
-{% endif %}
+      </p>
+    </div>
+  {% elif category == 'not_pdf' %}
+    <div class="banner-destructive-without-action">
+      <p class="banner-message">
+        {% if message == 'communication' %}
+        Communication file is not a PDF.
+        {% elif message == 'clarification' %}
+        Clarification file is not a PDF.
+        {% endif %}
+      </p>
+    </div>
+  {% elif category == 'not_zip' and message == 'itt_pack' %}
+    <div class="banner-destructive-without-action">
+      <p class="banner-message">
+        ITT pack is not a zip file.
+      </p>
+    </div>
+  {% endif %}
 
-{% endfor %}
-{% endif %}
-{% endwith %}
+  {% endfor %}
+  {% endif %}
+  {% endwith %}
 
   {% with heading = "Upload {} communications".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
-  <div class="page-section">
-    <form method="post" enctype="multipart/form-data">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      {% with
-         question="Communication",
-         hint="This must be PDF",
-         name="communication",
-         value="Last modified {}".format(communication.last_modified),
-         error=communication_error
-      %}
-        {% include "toolkit/forms/upload.html" %}
-      {% endwith %}
+  <form method="post" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    {% with
+       question="Communication",
+       hint="This must be PDF",
+       name="communication",
+       value="Last modified {}".format(communication.last_modified),
+       error=communication_error
+    %}
+      {% include "toolkit/forms/upload.html" %}
+    {% endwith %}
 
-      {% if framework.status in ['open'] %}
-      {% with
-         question="Clarification answers",
-         hint="This must be PDF",
-         name="clarification",
-         value="Last modified {}".format(clarification.last_modified),
-         error=clarification_error
-      %}
-        {% include "toolkit/forms/upload.html" %}
-      {% endwith %}
-      {% endif %}
+    {% if framework.status in ['open'] %}
+    {% with
+       question="Clarification answers",
+       hint="This must be PDF",
+       name="clarification",
+       value="Last modified {}".format(clarification.last_modified),
+       error=clarification_error
+    %}
+      {% include "toolkit/forms/upload.html" %}
+    {% endwith %}
+    {% endif %}
 
-      {% if framework.status in ['open', 'closed'] %}
-      {% with
-         question="ITT pack",
-         hint="This must be ZIP",
-         name="itt_pack",
-         value="Last modified {}".format(itt_pack.last_modified),
-         error=itt_pack_error
-      %}
-        {% include "toolkit/forms/upload.html" %}
-      {% endwith %}
-      {% endif %}
-      {%
-        with
-        type = "save",
-        label = "Upload files"
-      %}
-        {% include "toolkit/button.html" %}
-      {% endwith %}
-    </form>
-  </div>
-</div>
+    {% if framework.status in ['open', 'closed'] %}
+    {% with
+       question="ITT pack",
+       hint="This must be ZIP",
+       name="itt_pack",
+       value="Last modified {}".format(itt_pack.last_modified),
+       error=itt_pack_error
+    %}
+      {% include "toolkit/forms/upload.html" %}
+    {% endwith %}
+    {% endif %}
+    {%
+      with
+      type = "save",
+      label = "Upload files"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+  </form>
 
 {% endblock %}

--- a/app/templates/service_update_audits.html
+++ b/app/templates/service_update_audits.html
@@ -3,12 +3,12 @@
 
 {% extends "_base_page.html" %}
 {% block page_title %}
-Digital Marketplace admin
+  Digital Marketplace admin
 {% endblock %}
 
 {% set csrf = csrf_token() %}
 
-{% block content %}
+{% block breadcrumb %}
   {%
     with items = [
       {
@@ -22,7 +22,8 @@ Digital Marketplace admin
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
-<div class="page-container">
+{% endblock %}
+{% block main_content %}
     <div class="grid-row">
         <div class="service-title">
             {{ page_heading(today|dateformat, "Activity for", "page-heading-smaller") }}
@@ -30,20 +31,17 @@ Digital Marketplace admin
     </div>
     <div class="grid-row">
         {% if form.errors|length >= 1 %}
-        <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-            <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-                There was a problem with your answer to the following questions
-            </h3>
-            {% for field_name, field_errors in form.errors|dictsort if field_errors %}
-            {% for error in field_errors %}
-            <a href="#example-textbox" class="validation-masthead-link">{{ form[field_name].label }}</a>
-            {% endfor %}
-            {% endfor %}
-        </div>
+          <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
+              <h3 class="validation-masthead-heading" id="validation-masthead-heading">
+                  There was a problem with your answer to the following questions
+              </h3>
+              {% for field_name, field_errors in form.errors|dictsort if field_errors %}
+                {% for error in field_errors %}
+                  <a href="#example-textbox" class="validation-masthead-link">{{ form[field_name].label }}</a>
+                {% endfor %}
+              {% endfor %}
+          </div>
         {% endif %}
-
-
-
 
         <div class="column-one-third">
             <form action="{{ url_for('.service_update_audits') }}" method="get" class="question">
@@ -158,6 +156,5 @@ Digital Marketplace admin
             {% endwith %}
         </div>
     </div>
-</div>
 
 {% endblock %}

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -6,41 +6,39 @@
   Change {{ framework.name }} declaration
 {% endblock %}
 
-{% block content %}
-  <div class="page-container edit-section">
-      <div class="grid-row">
-        <div class="service-title">
-          {%
-            with
-            context = supplier.name,
-            heading = section.name,
-            smaller = True
-          %}
-            {% include "toolkit/page-heading.html" %}
-          {% endwith %}
+{% block main_content %}
+  <div class="grid-row">
+    <div class="service-title">
+      {%
+        with
+        context = supplier.name,
+        heading = section.name,
+        smaller = True
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+        {% for question in section.questions %}
+          {{ forms[question.type](question, declaration, {}) }}
+        {% endfor %}
+        {%
+          with
+          type = "save",
+          label = "Save and return to summary"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+        <p>
+          <a href="{{ url_for('.view_supplier_declaration', supplier_id=supplier.id, framework_slug=framework.slug) }}">Return without saving</a>
+        </p>
         </div>
       </div>
-
-      <form method="post" enctype="multipart/form-data">
-        <div class="grid-row">
-          <div class="column-two-thirds">
-            <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
-            {% for question in section.questions %}
-              {{ forms[question.type](question, declaration, {}) }}
-            {% endfor %}
-            {%
-              with
-              type = "save",
-              label = "Save and return to summary"
-            %}
-              {% include "toolkit/button.html" %}
-            {% endwith %}
-            <p>
-              <a href="{{ url_for('.view_supplier_declaration', supplier_id=supplier.id, framework_slug=framework.slug) }}">Return without saving</a>
-            </p>
-            </div>
-          </div>
-        </div>
-      </form>
-  </div>
+    </div>
+  </form>
 {% endblock %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -6,39 +6,37 @@
   Change {{ framework.name }} declaration
 {% endblock %}
 
-{% block content %}
-  <div class="page-container declaration-summary">
-      <div class="grid-row">
-        <div class="service-title">
-          {%
-            with
-            context = supplier.name,
-            heading = framework.name + " declaration",
-            smaller = True
-          %}
-            {% include "toolkit/page-heading.html" %}
-          {% endwith %}
-        </div>
-      </div>
-
-      {% for section in content %}
-        {{ summary.heading(section.name) }}
-        {{ summary.top_link("Edit", url_for('.edit_supplier_declaration_section', supplier_id=supplier.id, framework_slug=framework.slug, section_id=section.id)) }}
-        {% call(item) summary.list_table(
-          section.questions,
-          caption="Declaration",
-          empty_message="This supplier not made a declaration",
-          field_headings=[
-            'Declaration question',
-            'Declaration answer'
-          ]
-        ) %}
-          {% call summary.row() %}
-            {{ summary.field_name(item.question) }}
-            {{ summary[item.type](declaration[item.id]) }}
-          {% endcall %}
-        {% endcall %}
-      {% endfor %}
+{% block main_content %}
+  <div class="grid-row">
+    <div class="service-title">
+      {%
+        with
+        context = supplier.name,
+        heading = framework.name + " declaration",
+        smaller = True
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+    </div>
   </div>
+
+  {% for section in content %}
+    {{ summary.heading(section.name) }}
+    {{ summary.top_link("Edit", url_for('.edit_supplier_declaration_section', supplier_id=supplier.id, framework_slug=framework.slug, section_id=section.id)) }}
+    {% call(item) summary.list_table(
+      section.questions,
+      caption="Declaration",
+      empty_message="This supplier not made a declaration",
+      field_headings=[
+        'Declaration question',
+        'Declaration answer'
+      ]
+    ) %}
+      {% call summary.row() %}
+        {{ summary.field_name(item.question) }}
+        {{ summary[item.type](declaration[item.id]) }}
+      {% endcall %}
+    {% endcall %}
+  {% endfor %}
 
 {% endblock %}

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -4,45 +4,44 @@
 
 {% extends "_base_page.html" %}
 
-{% block content %}
-{%
-    with items = [
-        {
-            "link": url_for('.index'),
-            "label": "Admin home"
-        }
-    ]
-%}
-{% include "toolkit/breadcrumb.html" %}
-{% endwith %}
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
 
-<div class="page-container">
-    {% with heading = "Uploaded {} framework agreements".format(framework.name) %}
+{% block main_content %}
+
+  {% with heading = "Uploaded {} framework agreements".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+  {% endwith %}
 
-    <div class="page-section">
-      {% set field_headings = [
-        "Supplier name",
-        "Date uploaded",
-        summary.hidden_field_heading("Download supplier declaration"),
-      ] %}
-      {% call(supplier_framework) summary.list_table(
-        supplier_frameworks,
-        caption="Uploaded {} framework agreements".format(framework.name),
-        empty_message="No agreements have been uploaded",
-        field_headings=field_headings,
-        field_headings_visible=True)
-      %}
-        {% call summary.row() %}
-          {{ summary.field_name(supplier_framework.supplierName) }}
-          {{ summary.field_name(supplier_framework.agreementReturnedAt) }}
-          {% call summary.field(wide=True) %}
-            <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name="signed-framework-agreement") }}" download>Download agreement</a>
-          {% endcall %}
-        {% endcall %}
+  {% set field_headings = [
+    "Supplier name",
+    "Date uploaded",
+    summary.hidden_field_heading("Download supplier declaration"),
+  ] %}
+  {% call(supplier_framework) summary.list_table(
+    supplier_frameworks,
+    caption="Uploaded {} framework agreements".format(framework.name),
+    empty_message="No agreements have been uploaded",
+    field_headings=field_headings,
+    field_headings_visible=True)
+  %}
+    {% call summary.row() %}
+      {{ summary.field_name(supplier_framework.supplierName) }}
+      {{ summary.field_name(supplier_framework.agreementReturnedAt) }}
+      {% call summary.field(wide=True) %}
+        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name="signed-framework-agreement") }}" download>Download agreement</a>
       {% endcall %}
-    </div>
-</div>
+    {% endcall %}
+  {% endcall %}
 
 {% endblock %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -8,7 +8,7 @@
   {{ service_data['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
+{% block breadcrumb %}
   {%
     with items = [
       {
@@ -23,71 +23,72 @@
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
+{% endblock %}
 
-  <div class="page-container">
+{% block main_content %}
 
-{% with messages = get_flashed_messages(with_categories=true) %}
-{% if messages %}
-{% for category, message in messages %}
-    {% if category == 'error' %}
-        <div class="banner-destructive-without-action">
-    {% else %}
-        <div class="banner-success-without-action">
-    {% endif %}
-      <p class="banner-message">
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        {% if category == 'error' %}
+            <div class="banner-destructive-without-action">
+        {% else %}
+            <div class="banner-success-without-action">
+        {% endif %}
+        <p class="banner-message">
           {% if message['bad_status'] %}
-          Not a valid status: '{{ message['bad_status'] }}'
+            Not a valid status: '{{ message['bad_status'] }}'
           {% elif message['status_error'] %}
-          Error trying to update status of service: {{ message['status_error'] }}
+            Error trying to update status of service: {{ message['status_error'] }}
           {% elif message['status_updated'] %}
-          Service status has been updated to: {{ message['status_updated']|title }}
+            Service status has been updated to: {{ message['status_updated']|title }}
           {% endif %}
-      </p>
+        </p>
       {% endfor %}
-  </div>
-  {% endif %}
+      </div>
+    {% endif %}
   {% endwith %}
 
-    {% if service_data %}
-      <div class="grid-row">
-        <div class="service-title">
-          {%
-            with
-            context = service_data['supplierName'],
-            heading = service_data['serviceName'],
-            smaller = True
-          %}
-            {% include "toolkit/page-heading.html" %}
-          {% endwith %}
-        </div>
-        <div class="service-view">
-          <a href="/g-cloud/services/{{ service_id }}">View service</a>
-        </div>
+  {% if service_data %}
+    <div class="grid-row">
+      <div class="service-title">
+        {%
+          with
+          context = service_data['supplierName'],
+          heading = service_data['serviceName'],
+          smaller = True
+        %}
+          {% include "toolkit/page-heading.html" %}
+        {% endwith %}
       </div>
+      <div class="service-view">
+        <a href="/g-cloud/services/{{ service_id }}">View service</a>
+      </div>
+    </div>
 
-      {% for section in sections %}
-        {{ summary.heading(section.name) }}
-        {% if section.editable and current_user.has_role('admin') %}
-          {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section=section.id)) }}
-        {% endif %}
-        {% call(item) summary.list_table(
-          section.questions,
-          caption="Services",
-          empty_message="This supplier has no services on the Digital Marketplace",
-          field_headings=[
-            'Service attribute name',
-            'Service attribute'
-          ],
-          field_headings_visible=False
-        ) %}
-          {% call summary.row() %}
-            {{ summary.field_name(item.question) }}
-            {{ summary[item.type](service_data[item.id]) }}
-          {% endcall %}
+    {% for section in sections %}
+      {{ summary.heading(section.name) }}
+      {% if section.editable and current_user.has_role('admin') %}
+        {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section=section.id)) }}
+      {% endif %}
+      {% call(item) summary.list_table(
+        section.questions,
+        caption="Services",
+        empty_message="This supplier has no services on the Digital Marketplace",
+        field_headings=[
+          'Service attribute name',
+          'Service attribute'
+        ],
+        field_headings_visible=False
+      ) %}
+        {% call summary.row() %}
+          {{ summary.field_name(item.question) }}
+          {{ summary[item.type](service_data[item.id]) }}
         {% endcall %}
-      {% endfor %}
+      {% endcall %}
+    {% endfor %}
 
-      {% if current_user.has_role('admin') %}
+    {% if current_user.has_role('admin') %}
       <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
           <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
           <fieldset class="question">
@@ -111,13 +112,12 @@
           </fieldset>
           <button type="submit" class="button-save">Update status</button>
       </form>
-      {% endif %}
+    {% endif %}
 
-    {% else %}
+  {% else %}
     <h1>Error</h1>
     <p>
       No service data
     </p>
-    {% endif %}
-  </div>
+  {% endif %}
 {% endblock %}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -6,7 +6,7 @@
   {{ framework.name }} Statistics – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
+{% block breadcrumb %}
   {%
     with items = [
       {
@@ -17,8 +17,10 @@
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
+{% endblock %}
 
-  <div class="page-container framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
+{% block main_content %}
+  <div class="framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
     <div class="grid-row">
       <div class="column-two-thirds">
         {%
@@ -29,7 +31,7 @@
           {% include "toolkit/page-heading.html" %}
         {% endwith %}
       </div>
-      <div class="column-two-thirds">
+      <div class="column-one-third">
         {% if not big_screen_mode %}
           {%
             with

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -8,7 +8,7 @@
   {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
+{% block breadcrumb %}
   {%
     with items = [
       {
@@ -22,47 +22,47 @@
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
-  <div class="page-container">
-    {% with heading = "Services" %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    {% call(item) summary.list_table(
-      services,
-      caption="Services",
-      empty_message="This supplier has no services on the Digital Marketplace",
-      field_headings=[
-        'Name',
-        'Service ID',
-        'Framework',
-        'Lot',
-        'Status',
-        summary.hidden_field_heading("Action")
-      ],
-      field_headings_visible=True
-    ) %}
-      {% call summary.row() %}
-        {{ summary.service_link(item.serviceName, '/service/' + item.id|string) }}
-        {{ summary.text(item.id) }}
-        {{ summary.text(item.frameworkName) }}
-        {{ summary.text(item.lotName) }}
-        {% call summary.field() %}
-          <span class="service-status-{{ item.status }}">
-            {% if item.status == "published" %}
-              Public
-            {% elif item.status == "enabled" %}
-              Private
-            {% elif item.status == "disabled" %}
-              Removed
-            {% else %}
-              {{ item.status|title }}
-            {% endif %}
-          </span>
-        {% endcall %}
-        {{ summary.edit_link(
-          'Details' if item.status == 'disabled' or not current_user.has_role('admin') else 'Edit',
-          url_for('.view', service_id=item.id)
-        ) }}
+{% endblock %}
+{% block main_content %}
+  {% with heading = "Services" %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  {% call(item) summary.list_table(
+    services,
+    caption="Services",
+    empty_message="This supplier has no services on the Digital Marketplace",
+    field_headings=[
+      'Name',
+      'Service ID',
+      'Framework',
+      'Lot',
+      'Status',
+      summary.hidden_field_heading("Action")
+    ],
+    field_headings_visible=True
+  ) %}
+    {% call summary.row() %}
+      {{ summary.service_link(item.serviceName, '/service/' + item.id|string) }}
+      {{ summary.text(item.id) }}
+      {{ summary.text(item.frameworkName) }}
+      {{ summary.text(item.lotName) }}
+      {% call summary.field() %}
+        <span class="service-status-{{ item.status }}">
+          {% if item.status == "published" %}
+            Public
+          {% elif item.status == "enabled" %}
+            Private
+          {% elif item.status == "disabled" %}
+            Removed
+          {% else %}
+            {{ item.status|title }}
+          {% endif %}
+        </span>
       {% endcall %}
+      {{ summary.edit_link(
+        'Details' if item.status == 'disabled' or not current_user.has_role('admin') else 'Edit',
+        url_for('.view', service_id=item.id)
+      ) }}
     {% endcall %}
-  </div>
+  {% endcall %}
 {% endblock %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -5,194 +5,195 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-    {{ supplier.name }} – Digital Marketplace admin
+  {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
-{%
-    with items = [
-        {
-            "link": url_for('.index'),
-            "label": "Admin home"
-        },
-        {
-            "label": supplier.name
-        }
-    ]
-%}
-{% include "toolkit/breadcrumb.html" %}
-{% endwith %}
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          },
+          {
+              "label": supplier.name
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
 
-<div class="page-container">
-
-    {% with heading = supplier.name %}
-    {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+{% block main_content %}
 
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-    {% for category, message in messages %}
-    {% if category == 'error' %}
-      <div class="banner-destructive-without-action">
-    {% elif category == 'success' %}
-      <div class="banner-success-without-action">
-    {% endif %}
-    {% if message == 'user_invited' %}
-    <p class="banner-message">
-        User invited
-    </p>
-    {% elif message == 'user_not_invited' %}
-    <p class="banner-message">
-        Not Invited
-    </p>
-    {% endif %}
-          </div>
-    {% endfor %}
-    {% endif %}
-    {% endwith %}
+  {% with heading = supplier.name %}
+  {% include "toolkit/page-heading.html" %}
+  {% endwith %}
 
-    <div class='page-section'>
-        {% call(item) summary.list_table(
-            users,
-            caption="Users",
-            empty_message="This supplier has no users on the Digital Marketplace",
-            field_headings=[
-                'Name',
-                'Email address',
-                'Last login',
-                'Last password change',
-                'Locked'
-            ],
-            field_headings_visible=True)
-        %}
-        {% call summary.row() %}
 
-        {{ summary.field_name(item.name) }}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  {% for category, message in messages %}
+  {% if category == 'error' %}
+    <div class="banner-destructive-without-action">
+  {% elif category == 'success' %}
+    <div class="banner-success-without-action">
+  {% endif %}
+  {% if message == 'user_invited' %}
+  <p class="banner-message">
+      User invited
+  </p>
+  {% elif message == 'user_not_invited' %}
+  <p class="banner-message">
+      Not Invited
+  </p>
+  {% endif %}
+        </div>
+  {% endfor %}
+  {% endif %}
+  {% endwith %}
 
-        {{ summary.text(item.emailAddress) }}
+  <div class='page-section'>
+      {% call(item) summary.list_table(
+          users,
+          caption="Users",
+          empty_message="This supplier has no users on the Digital Marketplace",
+          field_headings=[
+              'Name',
+              'Email address',
+              'Last login',
+              'Last password change',
+              'Locked'
+          ],
+          field_headings_visible=True)
+      %}
+      {% call summary.row() %}
 
-        {% call summary.field() %}
-            {% if item.loggedInAt %}
-                {{ item.loggedInAt|timeformat }}<br/>
-                {{ item.loggedInAt|shortdateformat }}
-            {% else %}
-                Never
-            {% endif %}
-        {% endcall %}
+      {{ summary.field_name(item.name) }}
 
-        {% call summary.field() %}
-            {% if item.passwordChangedAt %}
-                {{ item.passwordChangedAt|timeformat }}<br/>
-                {{ item.passwordChangedAt|shortdateformat }}
-            {% else %}
-                Never
-            {% endif %}
-        {% endcall %}
+      {{ summary.text(item.emailAddress) }}
 
-        {% call summary.field() %}
-        {% if item.locked and current_user.has_role('admin') %}
-        <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            {%
-                with
-                type = "secondary",
-                label = "Unlock"
-            %}
-            {% include "toolkit/button.html" %}
-            {% endwith %}
-        </form>
-        {% elif item.locked %}
-            Yes
-        {% else %}
-            No
-        {% endif %}
-        {% endcall %}
-
-        {% call summary.field() %}
-        {% if item.active %}
-          {% if current_user.has_role('admin') %}
-            <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                {%
-                    with
-                    type = "destructive",
-                    label = "Deactivate"
-                %}
-                {% include "toolkit/button.html" %}
-                {% endwith %}
-            </form>
+      {% call summary.field() %}
+          {% if item.loggedInAt %}
+              {{ item.loggedInAt|timeformat }}<br/>
+              {{ item.loggedInAt|shortdateformat }}
           {% else %}
-            Active
+              Never
           {% endif %}
-        {% else %}
-          {% if current_user.has_role('admin') %}
-            <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                {%
-                    with
-                    type = "secondary",
-                    label = "Activate"
-                %}
-                {% include "toolkit/button.html" %}
-                {% endwith %}
-            </form>
-          {% else %}
-            Deactivated
-          {% endif %}
-        {% endif %}
-        {% endcall %}
+      {% endcall %}
 
-        {% call summary.field() %}
+      {% call summary.field() %}
+          {% if item.passwordChangedAt %}
+              {{ item.passwordChangedAt|timeformat }}<br/>
+              {{ item.passwordChangedAt|shortdateformat }}
+          {% else %}
+              Never
+          {% endif %}
+      {% endcall %}
+
+      {% call summary.field() %}
+      {% if item.locked and current_user.has_role('admin') %}
+      <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {%
+              with
+              type = "secondary",
+              label = "Unlock"
+          %}
+          {% include "toolkit/button.html" %}
+          {% endwith %}
+      </form>
+      {% elif item.locked %}
+          Yes
+      {% else %}
+          No
+      {% endif %}
+      {% endcall %}
+
+      {% call summary.field() %}
+      {% if item.active %}
         {% if current_user.has_role('admin') %}
-        <form action="{{ url_for('.remove_from_supplier', user_id=item.id) }}" method="post">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            <input type="hidden" name="supplier_id" value="{{ item.supplier.supplierId }}"/>
-            {%
-                with
-                type = "secondary",
-                label = "Remove from supplier"
-            %}
-            {% include "toolkit/button.html" %}
-            {% endwith %}
-        </form>
+          <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              {%
+                  with
+                  type = "destructive",
+                  label = "Deactivate"
+              %}
+              {% include "toolkit/button.html" %}
+              {% endwith %}
+          </form>
+        {% else %}
+          Active
         {% endif %}
-        {% endcall %}
+      {% else %}
+        {% if current_user.has_role('admin') %}
+          <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              {%
+                  with
+                  type = "secondary",
+                  label = "Activate"
+              %}
+              {% include "toolkit/button.html" %}
+              {% endwith %}
+          </form>
+        {% else %}
+          Deactivated
+        {% endif %}
+      {% endif %}
+      {% endcall %}
 
-        {% endcall %}
-        {% endcall %}
-    </div>
+      {% call summary.field() %}
+      {% if current_user.has_role('admin') %}
+      <form action="{{ url_for('.remove_from_supplier', user_id=item.id) }}" method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <input type="hidden" name="supplier_id" value="{{ item.supplier.supplierId }}"/>
+          {%
+              with
+              type = "secondary",
+              label = "Remove from supplier"
+          %}
+          {% include "toolkit/button.html" %}
+          {% endwith %}
+      </form>
+      {% endif %}
+      {% endcall %}
+
+      {% endcall %}
+      {% endcall %}
+  </div>
 
 
-    {% if current_user.has_role('admin') %}
-    <div class='page-section'>
-        <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
-            <div class="grid-row">
-                <div class="column-two-thirds">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                    {% if form.email_address.errors %}
-                    <div class="validation-wrapper">
-                        {% endif %}
-                        <div class="question">
-                            {{ form.email_address.label(class="question-heading-with-hint") }}
-                            <p class="hint">
-                                Enter the email address you of the user you wish to add
-                            </p>
-                            {% if form.email_address.errors %}
-                            <p class="validation-message" id="error-email-address-textbox">
-                                {% for error in form.email_address.errors %}{{ error }}{% endfor %}
-                            </p>
-                            {% endif %}
-                            {{ form.email_address(class="text-box", autocomplete="off") }}
-                        </div>
-                        {% if form.email_address.errors %}
-                    </div>
-                    {% endif %}
-                   <button class="button-save">Send invitation</button>
-                </div>
-            </div>
-        </form>
-    </div>
-    {% endif %}
-</div>
+  {% if current_user.has_role('admin') %}
+  <div class='page-section'>
+      <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
+          <div class="grid-row">
+              <div class="column-two-thirds">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                  {% if form.email_address.errors %}
+                  <div class="validation-wrapper">
+                      {% endif %}
+                      <div class="question">
+                          {{ form.email_address.label(class="question-heading-with-hint") }}
+                          <p class="hint">
+                              Enter the email address you of the user you wish to add
+                          </p>
+                          {% if form.email_address.errors %}
+                          <p class="validation-message" id="error-email-address-textbox">
+                              {% for error in form.email_address.errors %}{{ error }}{% endfor %}
+                          </p>
+                          {% endif %}
+                          {{ form.email_address(class="text-box", autocomplete="off") }}
+                      </div>
+                      {% if form.email_address.errors %}
+                  </div>
+                  {% endif %}
+                 <button class="button-save">Send invitation</button>
+              </div>
+          </div>
+      </form>
+  </div>
+  {% endif %}
 {% endblock %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -4,69 +4,68 @@
 
 {% extends "_base_page.html" %}
 
-{% block content %}
-{%
-    with items = [
-        {
-            "link": url_for('.index'),
-            "label": "Admin home"
-        }
-    ]
-%}
-{% include "toolkit/breadcrumb.html" %}
-{% endwith %}
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
 
-<div class="page-container">
+{% block main_content %}
 
-    {% with heading = "Suppliers" %}
+  {% with heading = "Suppliers" %}
     {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+  {% endwith %}
 
-    <div class="page-section">
-      {% if current_user.has_role("admin") %}
-        {% set field_headings = [
-          "Name",
-          summary.hidden_field_heading("Change name"),
-          summary.hidden_field_heading("Users"),
-          summary.hidden_field_heading("Services"),
-        ] %}
-      {% elif current_user.has_role("admin-ccs-sourcing") %}
-        {% set field_headings = [
-          "Name",
-          summary.hidden_field_heading("Change declarations"),
-          summary.hidden_field_heading("Download signed agreements"),
-        ] %}
-      {% else %}
-        {% set field_headings = [
-          "Name",
-          summary.hidden_field_heading("Users"),
-          summary.hidden_field_heading("Services"),
-        ] %}
-      {% endif %}
+  <div class="page-section">
+    {% if current_user.has_role("admin") %}
+      {% set field_headings = [
+        "Name",
+        summary.hidden_field_heading("Change name"),
+        summary.hidden_field_heading("Users"),
+        summary.hidden_field_heading("Services"),
+      ] %}
+    {% elif current_user.has_role("admin-ccs-sourcing") %}
+      {% set field_headings = [
+        "Name",
+        summary.hidden_field_heading("Change declarations"),
+        summary.hidden_field_heading("Download signed agreements"),
+      ] %}
+    {% else %}
+      {% set field_headings = [
+        "Name",
+        summary.hidden_field_heading("Users"),
+        summary.hidden_field_heading("Services"),
+      ] %}
+    {% endif %}
 
-      {% call(item) summary.list_table(
-        suppliers,
-        caption="Suppliers",
-        empty_message="No suppliers were found",
-        field_headings=field_headings,
-        field_headings_visible=True)
-      %}
-        {% call summary.row() %}
-          {{ summary.field_name(item.name) }}
-          {% if current_user.has_role('admin') %}
-            {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
-          {% endif %}
-          {% if current_user.has_role('admin-ccs-sourcing') %}
-            {{ summary.edit_link("G-Cloud 7 declaration", url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7")) }}
-            {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name="signed-framework-agreement")) }}
-          {% endif %}
-          {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-            {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
-            {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
-          {% endif %}
-        {% endcall %}
+    {% call(item) summary.list_table(
+      suppliers,
+      caption="Suppliers",
+      empty_message="No suppliers were found",
+      field_headings=field_headings,
+      field_headings_visible=True)
+    %}
+      {% call summary.row() %}
+        {{ summary.field_name(item.name) }}
+        {% if current_user.has_role('admin') %}
+          {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
+        {% endif %}
+        {% if current_user.has_role('admin-ccs-sourcing') %}
+          {{ summary.edit_link("G-Cloud 7 declaration", url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7")) }}
+          {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name="signed-framework-agreement")) }}
+        {% endif %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+          {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
+          {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
+        {% endif %}
       {% endcall %}
-    </div>
-</div>
-
+    {% endcall %}
+  </div>
 {% endblock %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -8,156 +8,152 @@
     Users – Digital Marketplace admin
 {% endblock %}
 
-{% block content %}
-{%
-    with items = [
-        {
-            "link": url_for('.index'),
-            "label": "Admin home"
-        },
-    ]
-%}
-{% include "toolkit/breadcrumb.html" %}
-{% endwith %}
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          },
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
 
-<div class="page-container">
+{% block main_content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+      {% for category, message in messages %}
+          {% if message == 'no_users' %}
+              {% set displayed_message = "Sorry, we couldn't find an account with that email address" %}
+          {% endif %}
+          {%
+          with
+              message = displayed_message,
+              type = "destructive" if category == 'error' else "success"
+          %}
+          {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+      {% endfor %}
+  {% endif %}
+  {% endwith %}
 
+  {% with heading = email_address if email_address %}
+  {% include "toolkit/page-heading.html" %}
+  {% endwith %}
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-        {% for category, message in messages %}
-            {% if message == 'no_users' %}
-                {% set displayed_message = "Sorry, we couldn't find an account with that email address" %}
-            {% endif %}
-            {%
-            with
-                message = displayed_message,
-                type = "destructive" if category == 'error' else "success"
-            %}
-            {% include "toolkit/notification-banner.html" %}
-            {% endwith %}
-        {% endfor %}
-    {% endif %}
-    {% endwith %}
+  {% call(item) summary.list_table(
+          users,
+          caption="Users",
+          empty_message="No users to show",
+          field_headings=[
+              'Name',
+              'Role',
+              'Supplier',
+              'Last login',
+              'Last password change',
+              'Locked',
+              summary.hidden_field_heading("Change status")
+          ],
+          field_headings_visible=True)
+      %}
+      {% call summary.row() %}
 
-    {% with heading = email_address if email_address %}
-    {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+      {{ summary.field_name(item.name) }}
 
-    {% call(item) summary.list_table(
-            users,
-            caption="Users",
-            empty_message="No users to show",
-            field_headings=[
-                'Name',
-                'Role',
-                'Supplier',
-                'Last login',
-                'Last password change',
-                'Locked',
-                summary.hidden_field_heading("Change status")
-            ],
-            field_headings_visible=True)
-        %}
-        {% call summary.row() %}
+      {{ summary.text(item.role) }}
 
-        {{ summary.field_name(item.name) }}
+      {% call summary.field() %}
+          {% if item.role == 'supplier' %}
+          <a href="{{ url_for('.find_supplier_users', supplier_id=item.supplier.supplierId) }}">{{ item.supplier.name }}</a>
+          {% endif %}
+      {% endcall %}
 
-        {{ summary.text(item.role) }}
+      {% call summary.field() %}
+          {% if item.loggedInAt %}
+              {{ item.loggedInAt|timeformat }}<br/>
+              {{ item.loggedInAt|shortdateformat }}
+          {% else %}
+              Never
+          {% endif %}
+      {% endcall %}
 
-        {% call summary.field() %}
-            {% if item.role == 'supplier' %}
-            <a href="{{ url_for('.find_supplier_users', supplier_id=item.supplier.supplierId) }}">{{ item.supplier.name }}</a>
-            {% endif %}
-        {% endcall %}
+      {% call summary.field() %}
+          {% if item.passwordChangedAt %}
+              {{ item.passwordChangedAt|timeformat }}<br/>
+              {{ item.passwordChangedAt|shortdateformat }}
+          {% else %}
+              Never
+          {% endif %}
+      {% endcall %}
 
-        {% call summary.field() %}
-            {% if item.loggedInAt %}
-                {{ item.loggedInAt|timeformat }}<br/>
-                {{ item.loggedInAt|shortdateformat }}
+      {% call summary.field() %}
+      {% if item.locked and current_user.has_role('admin') %}
+      <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+          {%
+              with
+              type = "secondary",
+              label = "Unlock"
+          %}
+          {% include "toolkit/button.html" %}
+          {% endwith %}
+      </form>
+      {% elif item.locked %}
+          Yes
+      {% else %}
+          No
+      {% endif %}
+      {% endcall %}
+
+      {% call summary.field() %}
+          {% if item.active %}
+            {% if current_user.has_role('admin') %}
+              <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                  <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+                  {%
+                      with
+                      type = "destructive",
+                      label = "Deactivate"
+                  %}
+                  {% include "toolkit/button.html" %}
+                  {% endwith %}
+              </form>
             {% else %}
-                Never
+              Active
             {% endif %}
-        {% endcall %}
-
-        {% call summary.field() %}
-            {% if item.passwordChangedAt %}
-                {{ item.passwordChangedAt|timeformat }}<br/>
-                {{ item.passwordChangedAt|shortdateformat }}
+          {% else %}
+            {% if current_user.has_role('admin') %}
+              <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                  <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+                  {%
+                      with
+                      type = "secondary",
+                      label = "Activate"
+                  %}
+                  {% include "toolkit/button.html" %}
+                  {% endwith %}
+              </form>
             {% else %}
-                Never
+              Deactivated
             {% endif %}
-        {% endcall %}
+          {% endif %}
+      {% endcall %}
 
-        {% call summary.field() %}
-        {% if item.locked and current_user.has_role('admin') %}
-        <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
-            {%
-                with
-                type = "secondary",
-                label = "Unlock"
-            %}
-            {% include "toolkit/button.html" %}
-            {% endwith %}
-        </form>
-        {% elif item.locked %}
-            Yes
-        {% else %}
-            No
-        {% endif %}
-        {% endcall %}
-
-        {% call summary.field() %}
-            {% if item.active %}
-              {% if current_user.has_role('admin') %}
-                <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                    <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
-                    {%
-                        with
-                        type = "destructive",
-                        label = "Deactivate"
-                    %}
-                    {% include "toolkit/button.html" %}
-                    {% endwith %}
-                </form>
-              {% else %}
-                Active
-              {% endif %}
-            {% else %}
-              {% if current_user.has_role('admin') %}
-                <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                    <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
-                    {%
-                        with
-                        type = "secondary",
-                        label = "Activate"
-                    %}
-                    {% include "toolkit/button.html" %}
-                    {% endwith %}
-                </form>
-              {% else %}
-                Deactivated
-              {% endif %}
-            {% endif %}
-        {% endcall %}
-
-        {% endcall %}
-        {% endcall %}
-    <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-      <label class="question-heading" for="email_address">Find users by email address</label>
-      <p class='hint'>
-        eg name@example.com
-      </p>
-      <input type="text" name="email_address" id="email_address" class="text-box" maxlength="200">
-      <input type="submit" value="Search" class="button-save">
-    </form>
-    </div>
-
-</div>
-
+      {% endcall %}
+      {% endcall %}
+  <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
+    <label class="question-heading" for="email_address">Find users by email address</label>
+    <p class='hint'>
+      eg name@example.com
+    </p>
+    <input type="text" name="email_address" id="email_address" class="text-box" maxlength="200">
+    <input type="submit" value="Search" class="button-save">
+  </form>
+  </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -193,7 +193,7 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         page_title = document.xpath(
-            '//div[@class="page-container"]//h1/text()')[0].strip()
+            '//h1/text()')[0].strip()
         self.assertEqual(expected_title, page_title)
 
         forms = document.xpath('//div[@class="page-container"]//form')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/110394970

> The admin app is the only one which uses a different layout system to generate its pages.
>
> For example, each page on the supplier and buyer apps wrap their content in a `<div>` with id of wrapper'. The admin app instead uses a `<div>` with class of `page-container`.
>
> This reduces the amount of shared CSS we can use on the admin app and will cause problems, the more modules we use from the toolkit.

This commit fixes this.