### PR TITLE
Make index links explicit again

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -99,12 +99,12 @@
     {
         "body": "View G-Cloud 7 statistics",
         "link": "/admin/statistics/g-cloud-7",
-        "title": "G-Cloud 7"
+        "title": "G-Cloud 7 statistics"
     },
     {
         "body": "View Digital Outcomes and Specialists statistics",
         "link": "/admin/statistics/digital-outcomes-and-specialists",
-        "title": "Digital Outcomes and Specialists"
+        "title": "Digital Outcomes and Specialists statistics"
     }
 ]
 %}
@@ -122,7 +122,7 @@
       {
           "body": "G-Cloud 7 agreements",
           "link": "/admin/agreements/g-cloud-7",
-          "title": "G-Cloud 7"
+          "title": "G-Cloud 7 agreements"
       }
     ]
   %}
@@ -141,7 +141,7 @@
     {
         "body": "Manage Digital Outcomes and Specialists communications",
         "link": "/admin/communications/digital-outcomes-and-specialists",
-        "title": "Digital Outcomes and Specialists"
+        "title": "Digital Outcomes and Specialists communications"
     }
   ]
   %}


### PR DESCRIPTION
In an earlier commit I grouped together links on the admin index page and made the title's just the framework name. In hindsight this was a bad idea because it means that the links don't fully describe what they are going to. This is apparent in the functional tests.