### PR TITLE
Make index links explicit again

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -98,12 +98,12 @@
       {
           "body": "View G-Cloud 7 statistics",
           "link": "/admin/statistics/g-cloud-7",
-          "title": "G-Cloud 7"
+          "title": "G-Cloud 7 statistics"
       },
       {
           "body": "View Digital Outcomes and Specialists statistics",
           "link": "/admin/statistics/digital-outcomes-and-specialists",
-          "title": "Digital Outcomes and Specialists"
+          "title": "Digital Outcomes and Specialists statistics"
       }
   ]
   %}
@@ -121,7 +121,7 @@
         {
             "body": "G-Cloud 7 agreements",
             "link": "/admin/agreements/g-cloud-7",
-            "title": "G-Cloud 7"
+            "title": "G-Cloud 7 agreements"
         }
       ]
     %}


### PR DESCRIPTION
In an earlier commit I grouped together links on the admin index page and made the title's just the framework name. In hindsight this was a bad idea because it means that the links don't fully describe what they are going to. This is apparent in the functional tests.

This is a copy of https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/158 which got clobbered by https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/157