### PR TITLE
Page for changes to service status

### DIFF
--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -44,7 +44,7 @@ def service_status_update_audits(day=None, page=1):
         day=day,
         day_as_datetime=day_as_datetime,
         previous_day=day_as_datetime - timedelta(1),
-        next_day=day_as_datetime + timedelta(1) if day_as_datetime < datetime.today() else None,
+        next_day=day_as_datetime + timedelta(1) if day_as_datetime + timedelta(1) < datetime.today() else None,
         previous_page=status_update_audit_events.get('links', {}).get('prev'),
         next_page=status_update_audit_events.get('links', {}).get('next'),
         page=page,

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -34,7 +34,8 @@ def service_status_update_audits(day=None, page=1):
     status_update_audit_events = data_api_client.find_audit_events(
         audit_type=AuditTypes.update_service_status,
         audit_date=day,
-        page=page
+        page=page,
+        latest_first=True
     )
 
     return render_template(

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -1,6 +1,8 @@
+import re
 from datetime import datetime
+from ordered_set import OrderedSet
 
-from flask import request, render_template, redirect, url_for
+from flask import request, render_template, redirect, url_for, abort
 from flask_login import login_required, current_user
 
 from dmapiclient.audit import AuditTypes
@@ -11,6 +13,66 @@ from .. import main
 from ..auth import role_required
 from ..forms import ServiceUpdateAuditEventsForm
 from . import get_template_data
+
+
+@main.route('/service-status-updates', methods=['GET'])
+@main.route('/service-status-updates/<day>', methods=['GET'])
+@login_required
+@role_required('admin', 'admin-ccs-category')
+def service_status_update_audits(day=None):
+
+    all_audit_events = data_api_client.find_audit_events(
+        audit_type=AuditTypes.update_service_status,
+    )['auditEvents']
+
+    days_with_events = list(OrderedSet(
+        [event['createdAt'][:10] for event in all_audit_events]
+    ))[::-1]
+
+    if day is None:
+        return redirect(url_for('.service_status_update_audits', day=days_with_events[0]))
+
+    try:
+        datetime.strptime(day, '%Y-%m-%d')
+    except ValueError as err:
+        abort(404)
+
+    previous_day = None
+    next_day = None
+    if day not in days_with_events:
+        day_index = -1
+    else:
+        day_index = days_with_events.index(day)
+
+        if day_index < len(days_with_events):
+            try:
+                previous_day = days_with_events[day_index + 1]
+            except IndexError:
+                pass
+
+        if day_index > 0:
+            try:
+                next_day = days_with_events[day_index - 1]
+            except IndexError:
+                pass
+
+    days_audit_events = data_api_client.find_audit_events(
+        audit_type=AuditTypes.update_service_status,
+        audit_date=day
+    )['auditEvents']
+
+    def day_to_datetime(day):
+        if not day:
+            return None
+        return '{}T00:00:00.000001Z'.format(day)
+
+    return render_template(
+        "service_status_update_audits.html",
+        audit_events=days_audit_events,
+        day=day_to_datetime(day),
+        previous_day=day_to_datetime(previous_day),
+        next_day=day_to_datetime(next_day),
+        **get_template_data())
 
 
 @main.route('/service-updates', methods=['GET'])

--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -10,7 +10,10 @@
       <ul id="proposition-links">
         {% if current_user.has_role('admin') or current_user.has_role('admin-ccs-category') %}
         <li>
-            <a href="{{ url_for('main.service_update_audits') }}">Service Updates</a>
+            <a href="{{ url_for('main.service_update_audits') }}">Service updates</a>
+        </li>
+        <li>
+            <a href="{{ url_for('main.service_status_update_audits') }}">Service status changes</a>
         </li>
         {% endif %}
         <li>

--- a/app/templates/service_status_update_audits.html
+++ b/app/templates/service_status_update_audits.html
@@ -46,7 +46,9 @@
         {{item.data.supplierName}}
       {% endcall %}
       {{ summary.text(item.user) }}
-      {{ summary.text(item.data.new_status) }}
+      {% call summary.field() %}
+        {{ 'Public' if item.data.new_status == 'published' else 'Unavailable' }}
+      {% endcall %}
       {% call summary.field() %}
         <a href="{{ '/services/g-cloud/{}'.format(item.data.serviceId) }}">{{ item.data.serviceId }}</a>
       {% endcall %}

--- a/app/templates/service_status_update_audits.html
+++ b/app/templates/service_status_update_audits.html
@@ -1,0 +1,74 @@
+{% import "toolkit/summary-table.html" as summary %}
+{% from 'macros/page_heading.html' import page_heading %}
+
+{% extends "_base_page.html" %}
+{% block page_title %}
+  Digital Marketplace admin
+{% endblock %}
+
+{% set csrf = csrf_token() %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      },
+      {
+        "label": "Audits",
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  {% with
+    heading="Service status changes",
+    smaller=True
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  {{summary.heading(day|dateformat)}}
+  {% call(item) summary.list_table(
+    audit_events,
+    caption=day|dateformat,
+    empty_message="No changes",
+    field_headings=[
+      'Supplier', 'User', 'Change', 'Service', 'At'
+    ],
+    field_headings_visible=True
+  ) %}
+    {% call summary.row() %}
+      {% call summary.field(first=True) %}
+        {{item.data.supplierName}}
+      {% endcall %}
+      {{ summary.text(item.user) }}
+      {{ summary.text(item.data.new_status) }}
+      {% call summary.field() %}
+        <a href="{{ '/services/g-cloud/{}'.format(item.data.serviceId) }}">{{ item.data.serviceId }}</a>
+      {% endcall %}
+      {{ summary.text(item.createdAt|timeformat) }}
+    {% endcall %}
+  {% endcall %}
+
+
+  {%
+    with
+    previous_page = {
+      "url": url_for(".service_status_update_audits", day=next_day[:10]),
+      "title": "Next day",
+      "label": next_day|dateformat
+    } if next_day else {},
+    next_page = {
+      "url": url_for(".service_status_update_audits", day=previous_day[:10]),
+      "title": "Previous day",
+      "label": previous_day|dateformat
+    } if previous_day else {}
+  %}
+    {% include "toolkit/previous-next-navigation.html" %}
+  {% endwith %}
+
+{% endblock %}

--- a/app/templates/service_status_update_audits.html
+++ b/app/templates/service_status_update_audits.html
@@ -31,10 +31,10 @@
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
-  {{summary.heading(day|dateformat)}}
+  {{summary.heading(day_as_datetime|dateformat)}}
   {% call(item) summary.list_table(
     audit_events,
-    caption=day|dateformat,
+    caption=day_as_datetime|dateformat,
     empty_message="No changes",
     field_headings=[
       'Supplier', 'User', 'Change', 'Service', 'At'
@@ -54,16 +54,23 @@
     {% endcall %}
   {% endcall %}
 
-
   {%
     with
     previous_page = {
-      "url": url_for(".service_status_update_audits", day=next_day[:10]),
+      "url": url_for(".service_status_update_audits", day=day, page=page-1),
+      "title": "Page {}".format(page - 1),
+      "label": "of {}".format(day_as_datetime|dateformat)
+    } if previous_page else {
+      "url": url_for(".service_status_update_audits", day=next_day.strftime('%Y-%m-%d')),
       "title": "Next day",
       "label": next_day|dateformat
     } if next_day else {},
     next_page = {
-      "url": url_for(".service_status_update_audits", day=previous_day[:10]),
+      "url": url_for(".service_status_update_audits", day=day, page=page+1),
+      "title": "Page {}".format(page + 1),
+      "label": "of {}".format(day_as_datetime|dateformat)
+    } if next_page else {
+      "url": url_for(".service_status_update_audits", day=previous_day.strftime('%Y-%m-%d')),
       "title": "Previous day",
       "label": previous_day|dateformat
     } if previous_day else {}

--- a/app/templates/service_status_update_audits.html
+++ b/app/templates/service_status_update_audits.html
@@ -47,7 +47,7 @@
       {% endcall %}
       {{ summary.text(item.user) }}
       {% call summary.field() %}
-        {{ 'Public' if item.data.new_status == 'published' else 'Unavailable' }}
+        {{ 'Live' if item.data.new_status == 'published' else 'Removed' }}
       {% endcall %}
       {% call summary.field() %}
         <a href="{{ '/services/g-cloud/{}'.format(item.data.serviceId) }}">{{ item.data.serviceId }}</a>


### PR DESCRIPTION
_Rebased on top of https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/164. Changed introduced in this PR: https://github.com/alphagov/digitalmarketplace-admin-frontend/compare/add-dmapiclient-package...service-status-updates_

***

~~This is kinda hacky but I want to see if it’s the right approach before cleaning it up.~~

Shows a page of audit events for change of service status. One page per day. Pagination to move to the next/previous days that have events.

I think this is easier to understand than the weird date input filter thing.

<img width="1019" alt="screen shot 2015-12-23 at 15 25 49" src="https://cloud.githubusercontent.com/assets/355079/11979334/641b196a-a98a-11e5-938a-a360a84d1181.png">

<img width="1044" alt="screen shot 2015-12-23 at 15 25 33" src="https://cloud.githubusercontent.com/assets/355079/11979333/64181418-a98a-11e5-81ee-3edf69f009cb.png">