### PR TITLE
Let admins download a list of users (and information about their applications) from the admin portal

### DIFF
--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from flask import request, render_template, redirect, url_for, abort
+from flask import request, render_template, redirect, url_for
 from flask_login import login_required, current_user
 
 from dmutils.audit import AuditTypes

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,5 +1,4 @@
-from flask import render_template, request, redirect, url_for, flash, \
-    current_app, abort
+from flask import render_template, request, redirect, url_for, flash, current_app, abort
 from flask_login import login_required, current_user
 from datetime import datetime
 

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 
-from flask import render_template, abort, request
-from flask_login import login_required, current_user, flash
+from flask import render_template, request
+from flask_login import login_required
 
-from dmutils.apiclient import HTTPError
 from dmutils.audit import AuditTypes
 from dmutils.formats import DATETIME_FORMAT
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -35,65 +35,77 @@ def find_user_by_email_address():
             **get_template_data()), 404
 
 
-@main.route('/users/export', methods=['GET', 'POST'])
+@main.route('/users/export', methods=['GET'])
+@login_required
+@role_required('admin')
+def export_users_form():
+    return _export_users()
+
+
+@main.route('/users/export', methods=['POST'])
 @login_required
 @role_required('admin')
 def export_users():
     bad_statuses = ['coming', 'expired']
+    framework = None
+
+    framework_slug = request.form.get('framework_slug')
+    if framework_slug:
+        framework = data_api_client.get_framework(framework_slug).get('frameworks')
+        if framework:
+            framework = framework if framework.get('status') not in bad_statuses else None
+
+    if not framework:
+        return _export_users(errors=[{
+            "input_name": "framework_slug",
+            "question": "Please select a framework"
+        }])
+
+    supplier_rows = data_api_client.export_users(framework_slug).get('users', [])
+    supplier_headers = [
+        "user_email",
+        "user_name",
+        "supplier_id",
+        "declaration_status",
+        "application_status",
+        "application_result",
+        "framework_agreement"
+    ]
+    # insert header column
+    supplier_rows.insert(0, {header: header for header in supplier_headers})
+
+    def iter_csv(rows):
+
+        class Line(object):
+            def __init__(self):
+                self._line = None
+
+            def write(self, line):
+                self._line = line
+
+            def read(self):
+                return self._line
+
+        line = Line()
+        writer = unicodecsv.writer(line)
+        for row in rows:
+            writer.writerow([row.get(header, '') for header in supplier_headers])
+            yield line.read()
+
+    return Response(
+        iter_csv(supplier_rows),
+        mimetype='text/csv',
+        headers={
+            "Content-Disposition": "attachment;filename=users-{}.csv".format(framework_slug),
+            "Content-Type": "text/csv; header=present"
+        }
+    )
+
+
+def _export_users(errors=None):
+    bad_statuses = ['coming', 'expired']
     frameworks = [f for f in data_api_client.find_frameworks()['frameworks'] if f['status'] not in bad_statuses]
-    # if frameworks is empty, framework options will be empty
     framework_options = [{'value': f['slug'], 'label': f['name']} for f in sorted(frameworks, key=lambda f: f['name'])]
-    errors = []
-
-    if framework_options and request.method == 'POST':
-
-        framework_slug = request.form.get('framework_slug')
-        if not framework_slug or framework_slug not in [f['slug'] for f in frameworks]:
-            errors = [{
-                "input_name": "framework_slug",
-                "question": "Please select a framework"
-            }]
-
-        else:
-            supplier_rows = data_api_client.export_users(framework_slug).get('users', [])
-            supplier_headers = [
-                "user_email",
-                "user_name",
-                "supplier_id",
-                "declaration_status",
-                "application_status",
-                "application_result",
-                "framework_agreement"
-            ]
-            # insert header column
-            supplier_rows.insert(0, {header: header for header in supplier_headers})
-
-            def iter_csv(rows):
-
-                class Line(object):
-                    def __init__(self):
-                        self._line = None
-
-                    def write(self, line):
-                        self._line = line
-
-                    def read(self):
-                        return self._line
-
-                line = Line()
-                writer = unicodecsv.writer(line)
-                for row in rows:
-                    writer.writerow([row.get(header, '') for header in supplier_headers])
-                    yield line.read()
-
-            return Response(
-                iter_csv(supplier_rows),
-                mimetype='text/csv',
-                headers={
-                    "Content-Disposition": "attachment;filename=users-{}.csv".format(framework_slug),
-                    "Content-Type": "text/csv; header=present"
-                }
-            )
 
     return render_template(
         "export.html",

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,5 +1,5 @@
-from flask import render_template, request
-from flask_login import login_required, current_user, flash
+from flask import render_template, request, Response
+from flask_login import login_required, flash
 
 from .. import main
 from . import get_template_data

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -31,3 +31,58 @@ def find_user_by_email_address():
             users=list(),
             email_address=None,
             **get_template_data()), 404
+
+
+@main.route('/users/export', methods=['GET', 'POST'])
+@login_required
+@role_required('admin')
+def export_users():
+    bad_statuses = ['coming', 'expired']
+    frameworks = [f for f in data_api_client.find_frameworks()['frameworks'] if f['status'] not in bad_statuses]
+    framework_options = [{'value': f['slug'], 'label': f['name']} for f in sorted(frameworks, key=lambda f: f['name'])]
+    errors = []
+
+    if request.method == 'POST':
+
+        framework_slug = request.form.get('framework_slug')
+
+        if not framework_slug or framework_slug not in [f['slug'] for f in frameworks]:
+            errors = [{
+                "input_name": "framework_slug",
+                "question": "Please select a framework"
+            }]
+
+        else:
+            supplier_rows = data_api_client.export_users(framework_slug).get('users', [])
+            supplier_headers = [
+                "user_email",
+                "user_name",
+                "supplier_id",
+                "declaration_status",
+                "application_status",
+                "application_result",
+                "framework_agreement"
+            ]
+            # insert header column
+            supplier_rows.insert(0, {header: header for header in supplier_headers})
+
+            def generate():
+                for row in supplier_rows:
+                    row = ["{}".format(row.get(header, '')) for header in supplier_headers]
+                    yield '{}{}'.format(','.join(row), '\r\n')
+
+            return Response(
+                generate(),
+                mimetype='text/csv',
+                headers={
+                    "Content-Disposition": "attachment;filename=users-{}.csv".format(framework_slug),
+                    "Content-Type": "text/csv; header=present"
+                }
+            )
+
+    return render_template(
+        "export.html",
+        framework_options=framework_options,
+        errors=errors,
+        **get_template_data()
+    )

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -39,13 +39,13 @@ def find_user_by_email_address():
 def export_users():
     bad_statuses = ['coming', 'expired']
     frameworks = [f for f in data_api_client.find_frameworks()['frameworks'] if f['status'] not in bad_statuses]
+    # if frameworks is empty, framework options will be empty
     framework_options = [{'value': f['slug'], 'label': f['name']} for f in sorted(frameworks, key=lambda f: f['name'])]
     errors = []
 
-    if request.method == 'POST':
+    if framework_options and request.method == 'POST':
 
         framework_slug = request.form.get('framework_slug')
-
         if not framework_slug or framework_slug not in [f['slug'] for f in frameworks]:
             errors = [{
                 "input_name": "framework_slug",

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -85,4 +85,4 @@ def export_users():
         framework_options=framework_options,
         errors=errors,
         **get_template_data()
-    )
+    ), 200 if not errors else 400

--- a/app/templates/export.html
+++ b/app/templates/export.html
@@ -1,0 +1,46 @@
+{% from 'macros/page_heading.html' import page_heading %}
+
+{% extends "_base_page.html" %}
+{% block page_title %}
+  Digital Marketplace admin
+{% endblock %}
+
+{% block main_content %}
+  {%
+    with heading = "Export users"
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  {% if errors %}
+    {%
+      with
+      errors = errors,
+      lede = "Not answering isn't very helpful",
+      description = "Please do it right this time"
+    %}
+      {% include "toolkit/forms/validation.html" %}
+    {% endwith %}
+  {% endif %}
+
+  <form method="post" class="question">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    {%
+      with
+      question = "Please select a framework",
+      type = "radio",
+      name = "framework_slug",
+      options = framework_options
+    %}
+      {% include "toolkit/forms/selection-buttons.html" %}
+    {% endwith %}
+    {%
+      with
+      type = "save",
+      label = "Run me off a CSV"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+  </form>
+
+{% endblock %}

--- a/app/templates/export.html
+++ b/app/templates/export.html
@@ -7,7 +7,7 @@
 
 {% block main_content %}
   {%
-    with heading = "Export users"
+    with heading = "Export user list"
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/export.html
+++ b/app/templates/export.html
@@ -24,15 +24,14 @@
 
   {% if not framework_options %}
     <p>No valid frameworks were found.</p>
-    <p>A framework must be open, pending or live in order to export its users.</p>
+    <p>A framework must be open, pending or live to export its users.</p>
   {% else %}
 
     {% if errors %}
       {%
         with
         errors = errors,
-        lede = "Not answering isn't very helpful",
-        description = "Please do it right this time"
+        lede = "A list of users can't be generated unless you select a valid framework"
       %}
         {% include "toolkit/forms/validation.html" %}
       {% endwith %}
@@ -52,7 +51,7 @@
       {%
         with
         type = "save",
-        label = "Run me off a CSV"
+        label = "Download users"
       %}
         {% include "toolkit/button.html" %}
       {% endwith %}

--- a/app/templates/export.html
+++ b/app/templates/export.html
@@ -1,8 +1,18 @@
 {% from 'macros/page_heading.html' import page_heading %}
 
 {% extends "_base_page.html" %}
-{% block page_title %}
-  Digital Marketplace admin
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
 {% endblock %}
 
 {% block main_content %}
@@ -12,35 +22,41 @@
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
-  {% if errors %}
-    {%
-      with
-      errors = errors,
-      lede = "Not answering isn't very helpful",
-      description = "Please do it right this time"
-    %}
-      {% include "toolkit/forms/validation.html" %}
-    {% endwith %}
-  {% endif %}
+  {% if not framework_options %}
+    <p>No valid frameworks were found.</p>
+    <p>A framework must be open, pending or live in order to export its users.</p>
+  {% else %}
 
-  <form method="post" class="question">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    {%
-      with
-      question = "Please select a framework",
-      type = "radio",
-      name = "framework_slug",
-      options = framework_options
-    %}
-      {% include "toolkit/forms/selection-buttons.html" %}
-    {% endwith %}
-    {%
-      with
-      type = "save",
-      label = "Run me off a CSV"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
-  </form>
+    {% if errors %}
+      {%
+        with
+        errors = errors,
+        lede = "Not answering isn't very helpful",
+        description = "Please do it right this time"
+      %}
+        {% include "toolkit/forms/validation.html" %}
+      {% endwith %}
+    {% endif %}
+
+    <form method="post" class="question">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      {%
+        with
+        question = "Please select a framework",
+        type = "radio",
+        name = "framework_slug",
+        options = framework_options
+      %}
+        {% include "toolkit/forms/selection-buttons.html" %}
+      {% endwith %}
+      {%
+        with
+        type = "save",
+        label = "Run me off a CSV"
+      %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+    </form>
+  {% endif %}{# /if not frameworks_options #}
 
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -141,6 +141,11 @@
           "body": "Manage Digital Outcomes and Specialists communications",
           "link": "/admin/communications/digital-outcomes-and-specialists",
           "title": "Digital Outcomes and Specialists communications"
+      },
+      {
+          "body": "Download a list of users for frameworks that are open, pending or live",
+          "link": url_for(".export_users"),
+          "title": "Export user list"
       }
     ]
     %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ werkzeug==0.10.4
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@15.10.0#egg=digitalmarketplace-utils==15.10.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.12.0#egg=digitalmarketplace-utils==15.12.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pbkdf2==1.3
 python-dateutil==2.4.2
 six==1.9.0
 werkzeug==0.10.4
+unicodecsv==0.14.1
 
 boto==2.36.0
 

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -5,6 +5,7 @@ except ImportError:
     from urllib.parse import urlsplit
     from io import BytesIO as StringIO
 import mock
+import copy
 from lxml import html
 from ...helpers import LoggedInApplicationTest
 
@@ -221,7 +222,7 @@ class TestUsersExport(LoggedInApplicationTest):
 
     def _return_post_user_export_response(self, data_api_client, frameworks, users, framework_slug=None):
         # collection of users is modified in the route
-        data_api_client.export_users.return_value = {"users": users.copy()}
+        data_api_client.export_users.return_value = {"users": copy.copy(users)}
         data_api_client.find_frameworks.return_value = {"frameworks": frameworks}
 
         if framework_slug is None:

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -169,3 +169,159 @@ class TestUsersView(LoggedInApplicationTest):
         self.assertEquals('/admin/suppliers/users/999/deactivate', deactivate_link.attrib['action'])
         self.assertEquals('Deactivate', deactivate_button)
         self.assertEquals('/admin/users?email_address=test.user%40sme.com', return_link.attrib['value'])
+
+
+@mock.patch('app.main.views.users.data_api_client')
+class TestUsersExport(LoggedInApplicationTest):
+    _bad_statuses = ['coming', 'expired']
+
+    _valid_framework = {
+        'name': 'G-Cloud 7',
+        'slug': 'g-cloud-7',
+        'status': 'live'
+    }
+
+    _invalid_framework = {
+        'name': 'G-Cloud 8',
+        'slug': 'g-cloud-8',
+        'status': 'coming'
+    }
+
+    def _return_get_user_export_response(self, data_api_client, frameworks):
+        data_api_client.find_frameworks.return_value = {"frameworks": frameworks}
+        return self.client.get('/admin/users/export')
+
+    def _assert_things_about_frameworks(self, response, frameworks):
+
+        def _assert_things_about_valid_frameworks(options, frameworks):
+            valid_frameworks = [
+                framework for framework in frameworks if framework['status'] not in self._bad_statuses]
+
+            assert len(options) == len(valid_frameworks)
+            for framework in valid_frameworks:
+                assert framework['slug'] in [option.xpath('input')[0].attrib['value'] for option in options]
+                assert framework['name'] in ["".join(option.xpath('text()')).strip() for option in options]
+
+        def _assert_things_about_invalid_frameworks(options, frameworks):
+            invalid_frameworks = [
+                framework for framework in frameworks if framework['status'] in self._bad_statuses]
+
+            for framework in invalid_frameworks:
+                assert framework['slug'] not in [option.xpath('input')[0].attrib['value'] for option in options]
+                assert framework['name'] not in ["".join(option.xpath('text()')).strip() for option in options]
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        options = document.xpath(
+            '//fieldset[@id="framework_slug"]/label')
+
+        assert response.status_code == 200
+        _assert_things_about_valid_frameworks(options, frameworks)
+        _assert_things_about_invalid_frameworks(options, frameworks)
+
+    def _return_post_user_export_response(self, data_api_client, frameworks, users, framework_slug=None):
+        # collection of users is modified in the route
+        data_api_client.export_users.return_value = {"users": users.copy()}
+        data_api_client.find_frameworks.return_value = {"frameworks": frameworks}
+
+        if framework_slug is None:
+            framework_slug = frameworks[0]['slug']
+
+        return self.client.post(
+            '/admin/users/export',
+            data={'framework_slug': framework_slug}
+        )
+
+    def _assert_things_about_user_export(self, response, users):
+
+        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
+
+        assert len(rows) == len(users) + 1
+
+        if users:
+            common_header_values = set(users[0].keys()) & set(rows[0])
+            assert len(common_header_values) == len(list(users[0].keys())) == len(rows[0])
+
+            for index, user in enumerate(users):
+                common_user_values = set(map(str, user.values())) & set(rows[index+1])
+                assert len(common_user_values) == len(list(user.values())) == len(rows[index+1])
+
+    ##########################################################################
+
+    def test_get_form_with_valid_framework(self, data_api_client):
+        frameworks = [self._valid_framework]
+        response = self._return_get_user_export_response(data_api_client, frameworks)
+        self._assert_things_about_frameworks(response, frameworks)
+
+    def test_get_form_with_invalid_framework(self, data_api_client):
+        frameworks = [self._invalid_framework]
+        response = self._return_get_user_export_response(data_api_client, frameworks)
+        assert self.strip_all_whitespace("No valid frameworks were found.") in \
+            self.strip_all_whitespace(response.get_data(as_text=True))
+        self._assert_things_about_frameworks(response, frameworks)
+
+    def test_get_form_with_valid_and_framework(self, data_api_client):
+        frameworks = [self._valid_framework, self._invalid_framework]
+        response = self._return_get_user_export_response(data_api_client, frameworks)
+        self._assert_things_about_frameworks(response, frameworks)
+
+    def test_post_user_export_with_no_users(self, data_api_client):
+        frameworks = [self._valid_framework]
+        users = []
+
+        response = self._return_post_user_export_response(data_api_client, frameworks, users)
+        self._assert_things_about_user_export(response, users)
+
+    def test_post_user_export_with_one_user(self, data_api_client):
+        frameworks = [self._valid_framework]
+        users = [{
+            "application_result": "fail",
+            "application_status": "no_application",
+            "declaration_status": "unstarted",
+            "framework_agreement": False,
+            "supplier_id": 1,
+            "user_email": "test.user@sme.com",
+            "user_name": "Tess User"
+        }]
+
+        response = self._return_post_user_export_response(data_api_client, frameworks, users)
+        self._assert_things_about_user_export(response, users)
+
+    def test_post_user_export_with_two_users(self, data_api_client):
+        frameworks = [self._valid_framework]
+        users = [{
+            "application_result": "fail",
+            "application_status": "no_application",
+            "declaration_status": "unstarted",
+            "framework_agreement": False,
+            "supplier_id": 1,
+            "user_email": "test.user@sme.com",
+            "user_name": "Tess User"
+        }, {
+            "application_result": "pass",
+            "application_status": "application",
+            "declaration_status": "complete",
+            "framework_agreement": True,
+            "supplier_id": 2,
+            "user_email": "paul@paul.paul",
+            "user_name": "Paul"
+        }]
+
+        response = self._return_post_user_export_response(data_api_client, frameworks, users)
+        self._assert_things_about_user_export(response, users)
+
+    def test_cannot_post_user_export_with_no_framework(self, data_api_client):
+        frameworks = [self._valid_framework]
+        framework_slug = ''
+        users = []
+        response = self._return_post_user_export_response(data_api_client, frameworks, users, framework_slug)
+        assert self.strip_all_whitespace("A list of users cannot be generated unless you select a valid framework") in \
+            self.strip_all_whitespace(response.get_data(as_text=True))
+
+    def test_cannot_post_user_export_with_bad_framework_slug(self, data_api_client):
+        frameworks = [self._valid_framework]
+        framework_slug = 'all-the-frameworks-in-the-uk'
+        users = []
+        response = self._return_post_user_export_response(data_api_client, frameworks, users, framework_slug)
+        assert self.strip_all_whitespace("A list of users cannot be generated unless you select a valid framework") in \
+            self.strip_all_whitespace(response.get_data(as_text=True))

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -323,7 +323,7 @@ class TestUsersExport(LoggedInApplicationTest):
         users = []
         response = self._return_post_user_export_response(data_api_client, frameworks, users, framework_slug)
         assert response.status_code == 400
-        assert self.strip_all_whitespace("A list of users cannot be generated unless you select a valid framework") in \
+        assert self.strip_all_whitespace("A list of users can&#39;t be generated unless you select a valid framework") in \
             self.strip_all_whitespace(response.get_data(as_text=True))
 
     def test_cannot_post_user_export_with_bad_framework_slug(self, data_api_client):
@@ -332,5 +332,5 @@ class TestUsersExport(LoggedInApplicationTest):
         users = []
         response = self._return_post_user_export_response(data_api_client, frameworks, users, framework_slug)
         assert response.status_code == 400
-        assert self.strip_all_whitespace("A list of users cannot be generated unless you select a valid framework") in \
+        assert self.strip_all_whitespace("A list of users can&#39;t be generated unless you select a valid framework") in \
             self.strip_all_whitespace(response.get_data(as_text=True))

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -251,6 +251,7 @@ class TestUsersExport(LoggedInApplicationTest):
     def test_get_form_with_valid_framework(self, data_api_client):
         frameworks = [self._valid_framework]
         response = self._return_get_user_export_response(data_api_client, frameworks)
+        assert response.status_code == 200
         self._assert_things_about_frameworks(response, frameworks)
 
     def test_get_form_with_invalid_framework(self, data_api_client):
@@ -258,11 +259,13 @@ class TestUsersExport(LoggedInApplicationTest):
         response = self._return_get_user_export_response(data_api_client, frameworks)
         assert self.strip_all_whitespace("No valid frameworks were found.") in \
             self.strip_all_whitespace(response.get_data(as_text=True))
+        assert response.status_code == 200
         self._assert_things_about_frameworks(response, frameworks)
 
     def test_get_form_with_valid_and_framework(self, data_api_client):
         frameworks = [self._valid_framework, self._invalid_framework]
         response = self._return_get_user_export_response(data_api_client, frameworks)
+        assert response.status_code == 200
         self._assert_things_about_frameworks(response, frameworks)
 
     def test_post_user_export_with_no_users(self, data_api_client):
@@ -270,6 +273,7 @@ class TestUsersExport(LoggedInApplicationTest):
         users = []
 
         response = self._return_post_user_export_response(data_api_client, frameworks, users)
+        assert response.status_code == 200
         self._assert_things_about_user_export(response, users)
 
     def test_post_user_export_with_one_user(self, data_api_client):
@@ -285,6 +289,7 @@ class TestUsersExport(LoggedInApplicationTest):
         }]
 
         response = self._return_post_user_export_response(data_api_client, frameworks, users)
+        assert response.status_code == 200
         self._assert_things_about_user_export(response, users)
 
     def test_post_user_export_with_two_users(self, data_api_client):
@@ -308,6 +313,7 @@ class TestUsersExport(LoggedInApplicationTest):
         }]
 
         response = self._return_post_user_export_response(data_api_client, frameworks, users)
+        assert response.status_code == 200
         self._assert_things_about_user_export(response, users)
 
     def test_cannot_post_user_export_with_no_framework(self, data_api_client):
@@ -315,6 +321,7 @@ class TestUsersExport(LoggedInApplicationTest):
         framework_slug = ''
         users = []
         response = self._return_post_user_export_response(data_api_client, frameworks, users, framework_slug)
+        assert response.status_code == 400
         assert self.strip_all_whitespace("A list of users cannot be generated unless you select a valid framework") in \
             self.strip_all_whitespace(response.get_data(as_text=True))
 
@@ -323,5 +330,6 @@ class TestUsersExport(LoggedInApplicationTest):
         framework_slug = 'all-the-frameworks-in-the-uk'
         users = []
         response = self._return_post_user_export_response(data_api_client, frameworks, users, framework_slug)
+        assert response.status_code == 400
         assert self.strip_all_whitespace("A list of users cannot be generated unless you select a valid framework") in \
             self.strip_all_whitespace(response.get_data(as_text=True))

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+from __future__ import unicode_literals
+
 try:
     from urlparse import urlsplit
     from StringIO import StringIO
@@ -6,6 +9,7 @@ except ImportError:
     from io import BytesIO as StringIO
 import mock
 import copy
+import six
 from lxml import html
 from ...helpers import LoggedInApplicationTest
 
@@ -240,12 +244,10 @@ class TestUsersExport(LoggedInApplicationTest):
         assert len(rows) == len(users) + 1
 
         if users:
-            common_header_values = set(users[0].keys()) & set(rows[0])
-            assert len(common_header_values) == len(list(users[0].keys())) == len(rows[0])
+            assert sorted(list(users[0].keys())) == sorted(rows[0])
 
             for index, user in enumerate(users):
-                common_user_values = set(map(str, user.values())) & set(rows[index+1])
-                assert len(common_user_values) == len(list(user.values())) == len(rows[index+1])
+                assert sorted([six.text_type(val) for val in user.values()]) == sorted(rows[index+1])
 
     ##########################################################################
 
@@ -296,21 +298,21 @@ class TestUsersExport(LoggedInApplicationTest):
     def test_post_user_export_with_two_users(self, data_api_client):
         frameworks = [self._valid_framework]
         users = [{
-            "application_result": "fail",
-            "application_status": "no_application",
-            "declaration_status": "unstarted",
+            "application_result": 'fail',
+            "application_status": '汉字$@!%^%&^*%&^	 	 	',
+            "declaration_status": 'chữ Nôm',
             "framework_agreement": False,
             "supplier_id": 1,
-            "user_email": "test.user@sme.com",
-            "user_name": "Tess User"
+            "user_email": 'test.user@sme.com',
+            "user_name": 'Tess User'
         }, {
-            "application_result": "pass",
-            "application_status": "application",
-            "declaration_status": "complete",
-            "framework_agreement": True,
+            "application_result": 'pass',
+            "application_status": 'application',
+            "declaration_status": 'complete',
+            "framework_agreement": False,
             "supplier_id": 2,
-            "user_email": "paul@paul.paul",
-            "user_name": "Paul"
+            "user_email": 'paul@paul.paul',
+            "user_name": 'Paul'
         }]
 
         response = self._return_post_user_export_response(data_api_client, frameworks, users)


### PR DESCRIPTION
This pull request hooks into the [API method that returns a list of users](https://github.com/alphagov/digitalmarketplace-api/pull/312) and their status in relation to a given framework.  This way Digital Marketplace admins can generate lists of users on the fly and send emails to those who should get them (for example, when clarification questions are uploaded).

If no users exist for a given framework, a CSV containing only a header file is returned.
If no frameworks with a valid status exist (*highly* unlikely), then nothing can be downloaded.

#### Notes

- I've only given it to the admin role.  Do we want other roles to be able to access it?
- Is there a better way to export CSVs?  I've just done what I saw on [StackOverflow](http://stackoverflow.com/questions/32608265/streaming-a-generated-csv-with-flask). ([CSV Lint](http://csvlint.io/) likes it, for what it's worth.)

***

### Admin portal link

![screen shot 2015-12-24 at 10 44 30](https://cloud.githubusercontent.com/assets/2454380/11995364/68ef12bc-aa47-11e5-9555-037a4a2af16e.png)

### Export user list
![screen shot 2015-12-24 at 10 45 06](https://cloud.githubusercontent.com/assets/2454380/11995378/9df0dc48-aa47-11e5-9a5a-89533f866a51.png)

### No framework selected
![screen shot 2015-12-24 at 10 45 17](https://cloud.githubusercontent.com/assets/2454380/11995377/9b14f54a-aa47-11e5-9568-73ae22495837.png)

### No frameworks are valid
![screen shot 2015-12-24 at 10 46 33](https://cloud.githubusercontent.com/assets/2454380/11995371/80aea656-aa47-11e5-86fd-3c93ddbff6cf.png)