### PR TITLE
Fix the uploaded supplier pack file name

### DIFF
--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -16,7 +16,7 @@ def _get_path(framework_slug, path):
 
 
 def _get_itt_pack_path(framework_slug):
-    return '{0}/communications/{0}-itt-pack.zip'.format(framework_slug)
+    return '{0}/communications/{0}-supplier-pack.zip'.format(framework_slug)
 
 
 @main.route('/communications/<framework_slug>', methods=['GET'])


### PR DESCRIPTION
supplier-frontend expects the supplier pack file name to be
`<slug>-supplier-pack.zip`, which doesn't match the file name
generated by the admin app on upload.

https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/main/views/frameworks.py#L86