### PR TITLE
Don't allow viewing supplier declaration for open frameworks

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -45,6 +45,8 @@ def edit_supplier_name(supplier_id):
 def view_supplier_declaration(supplier_id, framework_slug):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if framework['status'] not in ['pending', 'standstill', 'live']:
+        abort(403)
     try:
         declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
     except APIError as e:
@@ -92,6 +94,8 @@ def download_agreement_file(supplier_id, framework_slug, document_name):
 def edit_supplier_declaration_section(supplier_id, framework_slug, section_id):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if framework['status'] not in ['pending', 'standstill', 'live']:
+        abort(403)
     try:
         declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
     except APIError as e:
@@ -119,6 +123,8 @@ def edit_supplier_declaration_section(supplier_id, framework_slug, section_id):
 def update_supplier_declaration_section(supplier_id, framework_slug, section_id):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if framework['status'] not in ['pending', 'standstill', 'live']:
+        abort(403)
     try:
         declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
     except APIError as e:

--- a/example_responses/framework_response.json
+++ b/example_responses/framework_response.json
@@ -1,5 +1,6 @@
 {
   "frameworks": {
+    "status": "standstill",
     "slug": "g-cloud-7",
     "name": "G-Cloud 7"
   }

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -676,6 +676,15 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         data = document.cssselect('.summary-item-row td.summary-item-field')
         eq_(data[0].text_content().strip(), "Yes")
 
+    def test_should_403_if_framework_is_open(self, data_api_client):
+        data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
+        data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
+        data_api_client.get_framework.return_value['frameworks']['status'] = 'open'
+        data_api_client.get_supplier_declaration.return_value = self.load_example_listing('declaration_response')
+
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/digital-outcomes-and-specialists')
+        eq_(response.status_code, 403)
+
 
 @mock.patch('app.main.views.suppliers.data_api_client')
 class TestEditingASupplierDeclaration(LoggedInApplicationTest):


### PR DESCRIPTION
Supplier declarations shouldn't be viewed by anyone while the
framework is open for submissions.