### PR TITLE
Upload countersigned agreements

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,5 +1,6 @@
 from flask import render_template, request, redirect, url_for, abort, current_app
 from flask_login import login_required, current_user, flash
+from dateutil.parser import parse as parse_date
 
 from .. import main
 from . import get_template_data
@@ -9,8 +10,10 @@ from ..auth import role_required
 from dmapiclient import HTTPError, APIError
 from dmapiclient.audit import AuditTypes
 from dmutils.email import send_email, generate_token, MandrillException
-from dmutils.documents import get_signed_url, get_agreement_document_path
+from dmutils.documents import get_signed_url, get_agreement_document_path, file_is_pdf, \
+    get_countersigned_agreement_document_path
 from dmutils import s3
+from dmutils.formats import datetimeformat
 
 
 @main.route('/suppliers', methods=['GET'])
@@ -84,6 +87,112 @@ def download_agreement_file(supplier_id, framework_slug, document_name):
         abort(404)
 
     return redirect(url)
+
+
+@main.route('/suppliers/<supplier_id>/countersigned-agreements/<framework_slug>',
+            methods=['GET'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def list_countersigned_agreement_file(supplier_id, framework_slug):
+    supplier = data_api_client.get_supplier(supplier_id)['suppliers']
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    path = get_countersigned_agreement_document_path(framework_slug, supplier_id)
+    countersigned_agreement_document = agreements_bucket.get_key(path)
+    if countersigned_agreement_document:
+        countersigned_agreement = countersigned_agreement_document
+        countersigned_agreement['last_modified'] = datetimeformat(parse_date(
+            countersigned_agreement['last_modified']))
+        countersigned_agreement = [countersigned_agreement]
+    else:
+        countersigned_agreement = []
+
+    return render_template(
+        "suppliers/upload_countersigned_agreement.html",
+        supplier=supplier,
+        framework=framework,
+        countersigned_agreement=countersigned_agreement,
+        **get_template_data())
+
+
+@main.route('/suppliers/<supplier_id>/countersigned-agreements/<framework_slug>', methods=['POST'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def upload_countersigned_agreement_file(supplier_id, framework_slug):
+    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    errors = {}
+
+    if request.files.get('countersigned_agreement'):
+        the_file = request.files['countersigned_agreement']
+        if not file_is_pdf(the_file):
+            errors['countersigned_agreement'] = 'not_pdf'
+
+        if 'countersigned_agreement' not in errors.keys():
+            filename = get_countersigned_agreement_document_path(framework_slug, supplier_id)
+            agreements_bucket.save(filename, the_file)
+
+            data_api_client.create_audit_event(
+                audit_type=AuditTypes.upload_countersigned_agreement,
+                user=current_user.email_address,
+                object_type='suppliers',
+                object_id=supplier_id,
+                data={'upload_countersigned_agreement': filename})
+
+            flash('countersigned_agreement', 'upload_countersigned_agreement')
+
+    if len(errors) > 0:
+        for category, message in errors.items():
+            flash(category, message)
+
+    return redirect(url_for(
+        '.list_countersigned_agreement_file',
+        supplier_id=supplier_id,
+        framework_slug=framework_slug)
+    )
+
+
+@main.route('/suppliers/<supplier_id>/countersigned-agreements-download/<framework_slug>',
+            methods=['GET'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def download_countersigned_agreement_file(supplier_id, framework_slug):
+    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    path = get_countersigned_agreement_document_path(framework_slug, supplier_id)
+    countersigned_agreement_document = agreements_bucket.get_key(path)
+    if not len(countersigned_agreement_document):
+        abort(404)
+    url = get_signed_url(agreements_bucket, countersigned_agreement_document, current_app.config['DM_ASSETS_URL'])
+    if not url:
+        abort(404)
+    return redirect(url)
+
+
+@main.route('/suppliers/<supplier_id>/countersigned-agreements-remove/<framework_slug>',
+            methods=['GET', 'POST'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def remove_countersigned_agreement_file(supplier_id, framework_slug):
+    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    document = get_countersigned_agreement_document_path(framework_slug, supplier_id)
+
+    if request.method == 'GET':
+        flash('countersigned_agreement', 'remove_countersigned_agreement')
+
+    if request.method == 'POST':
+        agreements_bucket.delete_key(document)
+
+        data_api_client.create_audit_event(
+            audit_type=AuditTypes.delete_countersigned_agreement,
+            user=current_user.email_address,
+            object_type='suppliers',
+            object_id=supplier_id,
+            data={'upload_countersigned_agreement': document})
+
+    return redirect(url_for(
+        '.list_countersigned_agreement_file',
+        supplier_id=supplier_id,
+        framework_slug=framework_slug)
+    )
 
 
 @main.route(

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -1,0 +1,113 @@
+{% import 'macros/toolkit_forms.html' as forms %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+  Upload {{ framework.name }} countersigned agreement
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  {% for category, message in messages %}
+  {% if category == 'upload_countersigned_agreement' %}
+    {%
+      with
+      message = "Countersigned agreement file was uploaded",
+      type = "success"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  {% elif category == 'not_pdf' %}
+    {%
+      with
+      message = "Countersigned agreement file is not a PDF",
+      type = "destructive"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+    {% elif category == 'remove_countersigned_agreement' %}
+    <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug, document_name="countersigned-framework-agreement") }}'>
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <div class="banner-destructive-with-action">
+      <p class="banner-message">
+        Do you want to remove the countersigned agreement?
+      </p>
+      <button class="button-destructive banner-action" type="submit">Yes</button>
+    </div>
+  {% endif %}
+
+  {% endfor %}
+  {% endif %}
+  {% endwith %}
+
+  <div class="grid-row">
+    <div class="service-title">
+      {%
+        with
+        context = supplier.name,
+        heading = "Upload a " + framework.name + " countersigned agreement",
+        smaller = True
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+    </div>
+  </div>
+
+  {% set field_headings = [
+    "Countersigned agreement",
+    "Date uploaded",
+    summary.hidden_field_heading("Download countersigned agreement"),
+    summary.hidden_field_heading("Remove countersigned agreement"),
+  ] %}
+  {% call(countersigned_agreement) summary.list_table(
+    countersigned_agreement,
+    caption="Uploaded {} framework agreements".format(framework.name),
+    empty_message="No agreements have been uploaded",
+    field_headings=field_headings,
+    field_headings_visible=True)
+  %}
+    {% call summary.row() %}
+      {{ summary.field_name("{} countersigned agreement".format(framework.name)) }}
+      {{ summary.text(countersigned_agreement.last_modified) }}
+      {% call summary.field(wide=True) %}
+        <a href="{{ url_for('.download_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug, document_name='countersigned-framework-agreement') }}" download>Download agreement</a>
+      {% endcall %}
+      {{ summary.remove_link("Remove", url_for('.remove_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug, document_name='countersigned-framework-agreement') ) }}
+    {% endcall %}
+  {% endcall %}
+
+  <form method="post" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  {%
+      with
+      question = "Please upload a countersigned agreement",
+      name = "countersigned_agreement",
+      hint = "This must be a pdf"
+    %}
+      {% include "toolkit/forms/upload.html" %}
+    {% endwith %}
+    {%
+      with
+      type = "save",
+      label = "Upload file"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+  </form>
+
+{% endblock %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -63,6 +63,7 @@
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Digital Outcomes and Specialists declaration</a></div>
           {% endcall %}
           {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name="signed-framework-agreement")) }}
+          {{ summary.edit_link("Upload G-Cloud 7 countersigned agreement", url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7")) }}
         {% endif %}
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
           {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}

--- a/config.py
+++ b/config.py
@@ -75,6 +75,7 @@ class Test(Config):
     INVITE_EMAIL_SALT = 'SALT'
     DM_MANDRILL_API_KEY = "MANDRILL"
     DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
+    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-agreements-dev-dev'
 
 
 class Development(Config):
@@ -82,6 +83,7 @@ class Development(Config):
     SESSION_COOKIE_SECURE = False
     AUTHENTICATION = True
     DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
+    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-agreements-dev-dev'
 
 
 class Live(Config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@16.0.0#egg=digitalmarketplace-utils==16.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.1.0#egg=digitalmarketplace-apiclient==1.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@16.1.0#egg=digitalmarketplace-utils==16.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1,3 +1,4 @@
+import io
 try:
     from urlparse import urlsplit
     from StringIO import StringIO
@@ -838,3 +839,164 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
         s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf')
         eq_(response.status_code, 302)
         eq_(response.location, 'https://example/blah?extra')
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.s3')
+class TestListCountersignedAgreementFile(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_should_not_be_visible_to_admin_users(self, s3, data_api_client):
+        self.user_role = 'admin'
+
+        response = self.client.get('/admin/suppliers/1234/countersigned-agreements/g-cloud-7')
+
+        eq_(response.status_code, 403)
+
+    def test_should_be_visible_to_admin_sourcing_users(self, s3, data_api_client):
+        s3.S3.return_value.get_key.return_value = {
+            'size': '7050',
+            'path': u'g-cloud-7/agreements/93495/93495-countersigned-framework-agreement.pdf',
+            'ext': u'pdf',
+            'last_modified': u'2016-01-15T12:58:08.000000Z',
+            'filename': u'93495-countersigned-framework-agreement'
+        }
+        response = self.client.get('/admin/suppliers/1234/countersigned-agreements/g-cloud-7')
+        eq_(response.status_code, 200)
+
+    def test_should_display_no_documents_if_no_documents_listed(self, s3, data_api_client):
+        s3.S3.return_value.get_key.return_value = []
+        response = self.client.get('/admin/suppliers/1234/countersigned-agreements/g-cloud-7')
+        self.assertIn(
+            'No agreements have been uploaded',
+            response.get_data(as_text=True)
+        )
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.s3')
+class TestUploadCountersignedAgreementFile(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_countersigned_agreement_displays_error_for_wrong_format(self, s3, data_api_client):
+        s3.S3.return_value.get_key.return_value = {
+            'size': '7050',
+            'path': u'g-cloud-7/agreements/93495/93495-countersigned-framework-agreement.pdf',
+            'ext': u'pdf',
+            'last_modified': u'2016-01-15T12:58:08.000000Z',
+            'filename': u'93495-countersigned-framework-agreement'
+        }
+        response = self.client.post('/admin/suppliers/1234/countersigned-agreements/g-cloud-7',
+                                    data=dict(
+                                        countersigned_agreement=(io.BytesIO(b"this is a test"),
+                                                                 'test.odt'), ), follow_redirects=True)
+
+        self.assertIn(
+            'This must be a pdf',
+            response.get_data(as_text=True)
+        )
+        eq_(response.status_code, 200)
+
+    def test_should_create_audit_event(self, s3, data_api_client):
+        s3.S3.return_value.get_key.return_value = {
+            'size': '7050',
+            'path': u'g-cloud-7/agreements/1234/1234-countersigned-framework-agreement.pdf',
+            'ext': u'pdf',
+            'last_modified': u'2016-01-15T12:58:08.000000Z',
+            'filename': u'1234-countersigned-framework-agreement'
+        }
+
+        response = self.client.post('/admin/suppliers/1234/countersigned-agreements/g-cloud-7',
+                                    data=dict(
+                                        countersigned_agreement=(io.BytesIO(b"this is a test"),
+                                                                 'countersigned_agreement.pdf'),
+                                    ), follow_redirects=True)
+
+        data_api_client.create_audit_event.assert_called_once_with(
+            audit_type=AuditTypes.upload_countersigned_agreement,
+            user='test@example.com',
+            object_type='suppliers',
+            object_id=u'1234',
+            data={'upload_countersigned_agreement': 'g-cloud-7/agreements/1234/1234-countersigned-'
+                  'framework-agreement.pdf'})
+
+        self.assertIn(
+            'Countersigned agreement file was uploaded',
+            response.get_data(as_text=True)
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.s3')
+class TestDownloadCountersignedAgreementFile(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_admin_user_should_not_be_able_to_download(self, s3, data_api_client):
+        self.user_role = 'admin'
+        s3.S3.return_value.get_key.return_value = {
+            'size': '7050',
+            'path': u'g-cloud-7/agreements/93495/93495-countersigned-framework-agreement.pdf',
+            'ext': u'pdf',
+            'last_modified': u'2016-01-15T12:58:08.000000Z',
+            'filename': u'93495-countersigned-framework-agreement'
+        }
+
+        response = self.client.get('/admin/suppliers/1234/countersigned-agreements-download/g-cloud-7')
+
+        eq_(response.status_code, 403)
+
+    def test_admin_user_should_be_able_to_download(self, s3, data_api_client):
+        s3.S3.return_value.get_key.return_value = {
+            'size': '7050',
+            'path': u'g-cloud-7/agreements/93495/93495-countersigned-framework-agreement.pdf',
+            'ext': u'pdf',
+            'last_modified': u'2016-01-15T12:58:08.000000Z',
+            'filename': u'93495-countersigned-framework-agreement'
+        }
+
+        response = self.client.get('/admin/suppliers/1234/countersigned-agreements-download/g-cloud-7')
+
+        eq_(response.status_code, 302)
+
+    def test_if_agreement_is_not_available_abort(self, s3, data_api_client):
+        s3.S3.return_value.get_key.return_value = []
+        response = self.client.get('/admin/suppliers/1234/countersigned-agreements-download/g-cloud-7')
+        eq_(response.status_code, 404)
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.s3')
+class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_should_remove_countersigned_agreement(self, s3, data_api_client):
+        s3.S3.return_value.delete_key.return_value = {'Key': 'digitalmarketplace-agreements-dev-dev'
+                                                      ',g-cloud-7/agreements/93495/93495-'
+                                                      'countersigned-framework-agreement.pdf'}
+        response = self.client.post('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7')
+        eq_(response.status_code, 302)
+
+    def test_admin_should_not_be_able_to_remove_countersigned_agreement(self, s3, data_api_client):
+        self.user_role = 'admin'
+        s3.S3.return_value.delete_key.return_value = {'Key': 'digitalmarketplace-agreements-dev-dev'
+                                                      ',g-cloud-7/agreements/93495/93495-'
+                                                      'countersigned-framework-agreement.pdf'}
+        response = self.client.post('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7')
+        eq_(response.status_code, 403)
+
+    def test_should_display_remove_countersigned_agreement_message(self, s3, data_api_client):
+        s3.S3.return_value.get_key.return_value = {
+            'size': '7050',
+            'path': u'g-cloud-7/agreements/93495/93495-countersigned-framework-agreement.pdf',
+            'ext': u'pdf',
+            'last_modified': u'2016-01-15T12:58:08.000000Z',
+            'filename': u'93495-countersigned-framework-agreement'
+        }
+        response = self.client.get('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7',
+                                   follow_redirects=True)
+        self.assertIn(
+            'Do you want to remove the countersigned agreement?',
+            response.get_data(as_text=True)
+        )
+        eq_(response.status_code, 200)


### PR DESCRIPTION
Add configuration for agreements buckets.  List latest countersigned agreement, and add ability to upload or remove countersigned agreement.

Version bump for digitalmarketplace-apiclient.

Countersigned agreement
<img width="1044" alt="screen shot 2016-01-21 at 16 50 45" src="https://cloud.githubusercontent.com/assets/11633362/12487534/87565674-c05f-11e5-8ba2-e380291734a9.png">

Successful upload 
<img width="1024" alt="screen shot 2016-01-21 at 16 54 48" src="https://cloud.githubusercontent.com/assets/11633362/12487594/be62c65c-c05f-11e5-85f8-2393708c95ab.png">

Unsuccessful upload
<img width="1042" alt="screen shot 2016-01-21 at 16 56 09" src="https://cloud.githubusercontent.com/assets/11633362/12487645/f227345a-c05f-11e5-901a-e90f5ff3915c.png">

Confirmation screen for file deletion
<img width="1017" alt="screen shot 2016-01-21 at 16 58 01" src="https://cloud.githubusercontent.com/assets/11633362/12487714/44408958-c060-11e5-9783-0d9a9487bb0e.png">

No agreements have been uploaded
<img width="969" alt="screen shot 2016-01-21 at 16 59 27" src="https://cloud.githubusercontent.com/assets/11633362/12487748/73767d68-c060-11e5-9723-63bea777d7aa.png">

