### PR TITLE
Remove supplier name from agreement paths

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -3,6 +3,7 @@ from flask_login import login_required
 from dateutil.parser import parse as parse_date
 
 from dmutils.formats import datetimeformat
+from dmutils.documents import SIGNED_AGREEMENT_PREFIX
 
 from .. import main
 from ..auth import role_required
@@ -27,5 +28,6 @@ def list_agreements(framework_slug):
         'view_agreements.html',
         framework=framework,
         supplier_frameworks=supplier_frameworks,
+        signed_agreement_prefix=SIGNED_AGREEMENT_PREFIX,
         **get_template_data()
     )

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -12,7 +12,7 @@ from dmapiclient.audit import AuditTypes
 from dmutils.email import send_email, generate_token, MandrillException
 from dmutils.documents import (
     get_signed_url, get_agreement_document_path, file_is_pdf,
-    COUNTERSIGNED_AGREEMENT_FILENAME
+    SIGNED_AGREEMENT_PREFIX, COUNTERSIGNED_AGREEMENT_FILENAME,
 )
 from dmutils import s3
 from dmutils.formats import datetimeformat
@@ -27,6 +27,7 @@ def find_suppliers():
     return render_template(
         "view_suppliers.html",
         suppliers=suppliers['suppliers'],
+        signed_agreement_prefix=SIGNED_AGREEMENT_PREFIX,
         **get_template_data()
     )
 

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -41,7 +41,7 @@
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}
     {% elif category == 'remove_countersigned_agreement' %}
-    <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug, document_name="countersigned-framework-agreement") }}'>
+    <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug) }}'>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <div class="banner-destructive-with-action">
       <p class="banner-message">
@@ -85,9 +85,9 @@
       {{ summary.field_name("{} countersigned agreement".format(framework.name)) }}
       {{ summary.text(countersigned_agreement.last_modified) }}
       {% call summary.field(wide=True) %}
-        <a href="{{ url_for('.download_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug, document_name='countersigned-framework-agreement') }}" download>Download agreement</a>
+        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug, document_name=countersigned_agreement_filename) }}" download>Download agreement</a>
       {% endcall %}
-      {{ summary.remove_link("Remove", url_for('.remove_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug, document_name='countersigned-framework-agreement') ) }}
+      {{ summary.remove_link("Remove", url_for('.remove_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug) ) }}
     {% endcall %}
   {% endcall %}
 

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -39,7 +39,7 @@
       {{ summary.field_name(supplier_framework.supplierName) }}
       {{ summary.field_name(supplier_framework.agreementReturnedAt) }}
       {% call summary.field(wide=True) %}
-        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name="signed-framework-agreement") }}" download>Download agreement</a>
+        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name=signed_agreement_prefix) }}" download>Download agreement</a>
       {% endcall %}
     {% endcall %}
   {% endcall %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -62,7 +62,7 @@
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">G-Cloud 7 declaration</a></div>
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Digital Outcomes and Specialists declaration</a></div>
           {% endcall %}
-          {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name="signed-framework-agreement")) }}
+          {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix)) }}
           {{ summary.edit_link("Upload G-Cloud 7 countersigned agreement", url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7")) }}
         {% endif %}
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}

--- a/config.py
+++ b/config.py
@@ -75,7 +75,7 @@ class Test(Config):
     INVITE_EMAIL_SALT = 'SALT'
     DM_MANDRILL_API_KEY = "MANDRILL"
     DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
-    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-agreements-dev-dev'
+    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-documents-dev-dev'
 
 
 class Development(Config):
@@ -83,7 +83,7 @@ class Development(Config):
     SESSION_COOKIE_SECURE = False
     AUTHENTICATION = True
     DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
-    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-agreements-dev-dev'
+    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-documents-dev-dev'
 
 
 class Live(Config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,3 @@ boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@16.1.0#egg=digitalmarketplace-utils==16.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0
-
-# Required for SNI to work in requests
-pyOpenSSL==0.14
-ndg-httpsclient==0.3.3
-pyasn1==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@16.1.0#egg=digitalmarketplace-utils==16.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@17.0.0#egg=digitalmarketplace-utils==17.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -956,7 +956,7 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
     def test_should_remove_countersigned_agreement(self, s3, data_api_client):
-        s3.S3.return_value.delete_key.return_value = {'Key': 'digitalmarketplace-agreements-dev-dev'
+        s3.S3.return_value.delete_key.return_value = {'Key': 'digitalmarketplace-documents-dev-dev'
                                                       ',g-cloud-7/agreements/93495/93495-'
                                                       'countersigned-framework-agreement.pdf'}
         response = self.client.post('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7')
@@ -964,7 +964,7 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
 
     def test_admin_should_not_be_able_to_remove_countersigned_agreement(self, s3, data_api_client):
         self.user_role = 'admin'
-        s3.S3.return_value.delete_key.return_value = {'Key': 'digitalmarketplace-agreements-dev-dev'
+        s3.S3.return_value.delete_key.return_value = {'Key': 'digitalmarketplace-documents-dev-dev'
                                                       ',g-cloud-7/agreements/93495/93495-'
                                                       'countersigned-framework-agreement.pdf'}
         response = self.client.post('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -773,7 +773,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
 class TestDownloadAgreementFile(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
-    def test_admin_user_should_not_be_able_to_download(self, s3, data_api_client):
+    def test_category_admin_user_should_not_be_able_to_download(self, s3, data_api_client):
         self.user_role = 'admin-ccs-category'
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
@@ -795,39 +795,39 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
             'frameworkInterest': {'declaration': {'SQ1-1a': 'Supplier name'}}
         }
         s3.S3.return_value.list.return_value = [
-            {'path': 'g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf'}
+            {'path': 'g-cloud-7/agreements/1234/1234-foo.pdf'}
         ]
         s3.S3.return_value.get_signed_url.return_value = None
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo')
 
-        s3.S3.return_value.list.assert_called_with(prefix='g-cloud-7/agreements/1234/Supplier_name-1234-foo')
-        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf')
+        s3.S3.return_value.list.assert_called_with(prefix='g-cloud-7/agreements/1234/1234-foo')
+        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-foo.pdf')
         eq_(response.status_code, 404)
 
     def test_should_select_most_recent_matching_file(self, s3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = {
-            'frameworkInterest': {'declaration': {'SQ1-1a': 'Supplier name'}}
+            'frameworkInterest': {'declaration': {'key': 'value'}}
         }
         s3.S3.return_value.list.return_value = [
             {'path': 'foo.jpg'},
-            {'path': 'g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf'}
+            {'path': 'g-cloud-7/agreements/1234/1234-foo.pdf'}
         ]
         s3.S3.return_value.get_signed_url.return_value = 'http://foo/blah?extra'
 
         self.app.config['DM_ASSETS_URL'] = 'https://example'
 
-        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo')
+        self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo')
 
-        s3.S3.return_value.list.assert_called_with(prefix='g-cloud-7/agreements/1234/Supplier_name-1234-foo')
-        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf')
+        s3.S3.return_value.list.assert_called_with(prefix='g-cloud-7/agreements/1234/1234-foo')
+        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-foo.pdf')
 
     def test_should_redirect(self, s3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = {
-            'frameworkInterest': {'declaration': {'SQ1-1a': 'Supplier name'}}
+            'frameworkInterest': {'declaration': {'key': 'Supplier name'}}
         }
         s3.S3.return_value.list.return_value = [
-            {'path': 'g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf'}
+            {'path': 'g-cloud-7/agreements/1234/1234-foo.pdf'}
         ]
         s3.S3.return_value.get_signed_url.return_value = 'http://foo/blah?extra'
 
@@ -835,10 +835,33 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo')
 
-        s3.S3.return_value.list.assert_called_with(prefix='g-cloud-7/agreements/1234/Supplier_name-1234-foo')
-        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/Supplier_name-1234-foo.pdf')
+        s3.S3.return_value.list.assert_called_with(prefix='g-cloud-7/agreements/1234/1234-foo')
+        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-foo.pdf')
         eq_(response.status_code, 302)
         eq_(response.location, 'https://example/blah?extra')
+
+    def test_admin_should_be_able_to_download_countersigned_agreement(self, s3, data_api_client):
+        data_api_client.get_supplier_framework_info.return_value = {
+            'frameworkInterest': {'declaration': {'key': 'value'}}
+        }
+        s3.S3.return_value.list.return_value = [
+            {'path': 'g-cloud-7/agreements/1234/1234-countersigned-framework-agreement.pdf'}
+        ]
+        s3.S3.return_value.get_signed_url.return_value = 'http://foo/blah?extra'
+
+        self.app.config['DM_ASSETS_URL'] = 'https://example'
+
+        response = self.client.get(
+            '/admin/suppliers/1234/agreements/g-cloud-7/countersigned-framework-agreement.pdf'
+        )
+
+        s3.S3.return_value.list.assert_called_with(
+            prefix='g-cloud-7/agreements/1234/1234-countersigned-framework-agreement.pdf'
+        )
+        s3.S3.return_value.get_signed_url.assert_called_with(
+            'g-cloud-7/agreements/1234/1234-countersigned-framework-agreement.pdf'
+        )
+        eq_(response.status_code, 302)
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -925,44 +948,6 @@ class TestUploadCountersignedAgreementFile(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
         self.assertEqual(response.status_code, 200)
-
-
-@mock.patch('app.main.views.suppliers.data_api_client')
-@mock.patch('app.main.views.suppliers.s3')
-class TestDownloadCountersignedAgreementFile(LoggedInApplicationTest):
-    user_role = 'admin-ccs-sourcing'
-
-    def test_admin_user_should_not_be_able_to_download(self, s3, data_api_client):
-        self.user_role = 'admin'
-        s3.S3.return_value.get_key.return_value = {
-            'size': '7050',
-            'path': u'g-cloud-7/agreements/93495/93495-countersigned-framework-agreement.pdf',
-            'ext': u'pdf',
-            'last_modified': u'2016-01-15T12:58:08.000000Z',
-            'filename': u'93495-countersigned-framework-agreement'
-        }
-
-        response = self.client.get('/admin/suppliers/1234/countersigned-agreements-download/g-cloud-7')
-
-        eq_(response.status_code, 403)
-
-    def test_admin_user_should_be_able_to_download(self, s3, data_api_client):
-        s3.S3.return_value.get_key.return_value = {
-            'size': '7050',
-            'path': u'g-cloud-7/agreements/93495/93495-countersigned-framework-agreement.pdf',
-            'ext': u'pdf',
-            'last_modified': u'2016-01-15T12:58:08.000000Z',
-            'filename': u'93495-countersigned-framework-agreement'
-        }
-
-        response = self.client.get('/admin/suppliers/1234/countersigned-agreements-download/g-cloud-7')
-
-        eq_(response.status_code, 302)
-
-    def test_if_agreement_is_not_available_abort(self, s3, data_api_client):
-        s3.S3.return_value.get_key.return_value = []
-        response = self.client.get('/admin/suppliers/1234/countersigned-agreements-download/g-cloud-7')
-        eq_(response.status_code, 404)
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')


### PR DESCRIPTION
Updates utils to use new agreement path helpers.
Removes a separate endpoint for downloading countersigned agreements:
now that the paths for signed and countersigned agreements have the
same structure there's no need for a separate view function.