### PR TITLE
Fix buyer app service links

### DIFF
--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -42,7 +42,7 @@
     field_headings_visible=True
   ) %}
     {% call summary.row() %}
-      {{ summary.service_link(item.serviceName, '/service/' + item.id|string) }}
+      {{ summary.service_link(item.serviceName, '/' + item.frameworkFramework + '/services/' + item.id|string) }}
       {{ summary.text(item.id) }}
       {{ summary.text(item.frameworkName) }}
       {{ summary.text(item.lotName) }}

--- a/example_responses/framework_response.json
+++ b/example_responses/framework_response.json
@@ -2,6 +2,7 @@
   "frameworks": {
     "status": "standstill",
     "slug": "g-cloud-7",
-    "name": "G-Cloud 7"
+    "name": "G-Cloud 7",
+    "framework": "g-cloud"
   }
 }

--- a/example_responses/services_response.json
+++ b/example_responses/services_response.json
@@ -72,6 +72,7 @@
         "value": true
       },
       "frameworkName": "G-Cloud 6",
+      "frameworkFramework": "g-cloud",
       "freeOption": false,
       "governanceFramework": {
         "assurance": "Independent validation of assertion",

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -301,7 +301,7 @@ class TestSupplierServicesView(LoggedInApplicationTest):
             response.get_data(as_text=True)
         )
         self.assertIn(
-            '<a href="/service/5687123785023488">',
+            '<a href="/g-cloud/services/5687123785023488">',
             response.get_data(as_text=True)
         )
         self.assertIn(


### PR DESCRIPTION
The previous path was deprecated and has recently been removed from the buyer app.

:sparkles: This has been tested locally with the functional tests :sparkles: 