### PR TITLE
Add link to DOS agreements page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -119,9 +119,14 @@
     {% endwith %}
     {% with items = [
         {
-            "body": "G-Cloud 7 agreements",
+            "body": "Download G-Cloud 7 agreements",
             "link": "/admin/agreements/g-cloud-7",
             "title": "G-Cloud 7 agreements"
+        },
+        {
+            "body": "Download Digital Outcomes and Specialists agreements",
+            "link": "/admin/agreements/digital-outcomes-and-specialists",
+            "title": "Digital Outcomes and Specialists agreements"
         }
       ]
     %}


### PR DESCRIPTION
The page already exists and can be viewed for any framework so the simplest possible solution is to just add a link to the admin home page.

## Before
![screen shot 2016-02-05 at 14 58 41](https://cloud.githubusercontent.com/assets/14287/12849739/2a35871a-cc19-11e5-9eee-9cff934de79d.png)

## After
![screen shot 2016-02-05 at 14 58 56](https://cloud.githubusercontent.com/assets/14287/12849748/33513b96-cc19-11e5-94a2-da5efa5a6bdd.png)
