### PR TITLE
[#113436157] Add 'Admin home' breadcrumb link to pages without it

### DIFF
--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -7,6 +7,19 @@
   {{ service_data['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
   {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -6,6 +6,19 @@
   Change {{ framework.name }} declaration
 {% endblock %}
 
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
   <div class="grid-row">
     <div class="service-title">

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -6,6 +6,19 @@
   Change {{ framework.name }} declaration
 {% endblock %}
 
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
   <div class="grid-row">
     <div class="service-title">


### PR DESCRIPTION
This pull request fixes a bug whereby a couple of pages didn't have breadcrumb links back to the Admin home page.

Spent a while thinking about a smarter way to do this, but couldn't figure it out without adding a bunch of logic to a "breadcrumb-building" template or some other form of indirection likely to age badly.  So copy+pasted it in.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/113436157)

