### PR TITLE
Add DOS agreement links

### DIFF
--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -60,8 +60,14 @@
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">G-Cloud 7 declaration</a></div>
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Digital Outcomes and Specialists declaration</a></div>
           {% endcall %}
-          {{ summary.edit_link("Download G-Cloud 7 agreement", url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix)) }}
-          {{ summary.edit_link("Upload G-Cloud 7 countersigned agreement", url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7")) }}
+          {% call summary.field() %}
+            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix) }}">Download G-Cloud 7 agreement</a></div>
+            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=signed_agreement_prefix) }}">Download Digital Outcomes and Specialists agreement</a></div>
+          {% endcall %}
+          {% call summary.field() %}
+            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Upload G-Cloud 7 countersigned agreement</a></div>
+            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Upload Digital Outcomes and Specialists countersigned agreement</a></div>
+          {% endcall %}
         {% endif %}
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
           {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}


### PR DESCRIPTION
Add links to download DOS agreements and upload countersigned DOS agreements. This is not an ideal solution at all and looks really cramped, however, it is quick.

## Before
![screen shot 2016-02-29 at 13 40 30](https://cloud.githubusercontent.com/assets/14287/13396001/0cc41f3c-deea-11e5-8966-1b6b5c814c2a.png)

## After
![screen shot 2016-02-29 at 13 36 04](https://cloud.githubusercontent.com/assets/14287/13395988/f863074c-dee9-11e5-9fe2-4881a6842dce.png)
