### PR TITLE
Give sourcing a link to download agreements

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -11,7 +11,7 @@ from dmapiclient.audit import AuditTypes
 from dmutils.email import send_email, generate_token, MandrillException
 from dmutils.documents import (
     get_signed_url, get_agreement_document_path, file_is_pdf,
-    SIGNED_AGREEMENT_PREFIX, COUNTERSIGNED_AGREEMENT_FILENAME,
+    AGREEMENT_FILENAME, SIGNED_AGREEMENT_PREFIX, COUNTERSIGNED_AGREEMENT_FILENAME,
 )
 from dmutils import s3
 from dmutils.formats import datetimeformat
@@ -26,7 +26,8 @@ def find_suppliers():
     return render_template(
         "view_suppliers.html",
         suppliers=suppliers['suppliers'],
-        signed_agreement_prefix=SIGNED_AGREEMENT_PREFIX
+        signed_agreement_prefix=SIGNED_AGREEMENT_PREFIX,
+        agreement_prefix=AGREEMENT_FILENAME
     )
 
 

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -32,8 +32,8 @@
     {% elif current_user.has_role("admin-ccs-sourcing") %}
       {% set field_headings = [
         "Name",
-        summary.hidden_field_heading("Change declarations"),
-        summary.hidden_field_heading("Download signed agreements"),
+        "G-Cloud 7",
+        "Digital Outcomes and Specialists",
       ] %}
     {% else %}
       {% set field_headings = [
@@ -57,16 +57,16 @@
         {% endif %}
         {% if current_user.has_role('admin-ccs-sourcing') %}
           {% call summary.field() %}
-            <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">G-Cloud 7 declaration</a></div>
-            <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Digital Outcomes and Specialists declaration</a></div>
+            <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">Edit declaration</a></div>
+            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=agreement_prefix) }}">Download agreement</a></div>
+            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix) }}">Download signed agreement</a></div>
+            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Upload countersigned agreement</a></div>
           {% endcall %}
           {% call summary.field() %}
-            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix) }}">Download G-Cloud 7 agreement</a></div>
-            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=signed_agreement_prefix) }}">Download Digital Outcomes and Specialists agreement</a></div>
-          {% endcall %}
-          {% call summary.field() %}
-            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Upload G-Cloud 7 countersigned agreement</a></div>
-            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Upload Digital Outcomes and Specialists countersigned agreement</a></div>
+            <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Edit declaration</a></div>
+            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=agreement_prefix) }}" >Download agreement</a></div>
+            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=signed_agreement_prefix) }}">Download signed agreement</a></div>
+            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Upload countersigned agreement</a></div>
           {% endcall %}
         {% endif %}
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}


### PR DESCRIPTION
The CCS sourcing team currently have links to download signed and countersigned agreements. This change adds links to download the plain unsigned agreement as well.

This commit also changes the layout. It's a little less clear but it does make the layout less cluttered.

## Before
![screen shot 2016-03-09 at 08 48 03](https://cloud.githubusercontent.com/assets/14287/13629881/e30d5bd6-e5d3-11e5-9cb2-52d0f1561cb3.png)

## After
![screen shot 2016-03-09 at 08 48 23](https://cloud.githubusercontent.com/assets/14287/13629886/e7eb43b6-e5d3-11e5-98b1-e63500d52260.png)
