### PR TITLE
Duns number lookup, csv uploads and more

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -32,6 +32,9 @@ $path: "/admin/static/images/";
 @import "patterns/service-id";
 @import "patterns/pricing";
 
+// Blocks shared between multiple selectors
+@import "shared_placeholders/_temporary-messages.scss";
+
 // Layout of specific views
 @import "views/view_service";
 @import "views/edit_section";

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -7,7 +7,7 @@ from ..auth import role_required
 from ... import data_api_client
 
 from dmutils import s3
-from dmutils.documents import file_is_pdf, file_is_zip
+from dmutils.documents import file_is_pdf, file_is_zip, file_is_csv
 
 
 def _get_path(framework_slug, path):
@@ -47,8 +47,8 @@ def upload_communication(framework_slug):
 
     if request.files.get('communication'):
         the_file = request.files['communication']
-        if not file_is_pdf(the_file):
-            errors['communication'] = 'not_pdf'
+        if not (file_is_pdf(the_file) or file_is_csv(the_file)):
+            errors['communication'] = 'not_pdf_or_csv'
 
         if 'communication' not in errors.keys():
             filename = _get_path(framework_slug, 'updates/communications') + '/' + the_file.filename

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -21,7 +21,10 @@ from dmutils.formats import datetimeformat
 @login_required
 @role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
 def find_suppliers():
-    suppliers = data_api_client.find_suppliers(prefix=request.args.get("supplier_name_prefix"))
+    suppliers = data_api_client.find_suppliers(
+        prefix=request.args.get("supplier_name_prefix"),
+        duns_number=request.args.get("supplier_duns_number")
+    )
 
     return render_template(
         "view_suppliers.html",

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -10,7 +10,7 @@ from ..auth import role_required
 
 @main.route('/users', methods=['GET'])
 @login_required
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin')
 def find_user_by_email_address():
     template = "view_users.html"
     users = None

--- a/app/templates/download_users.html
+++ b/app/templates/download_users.html
@@ -15,7 +15,7 @@
 
 {% block main_content %}
   {%
-    with heading = "Download user list"
+    with heading = "Download user lists"
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,24 +41,6 @@
                   <input type="text" name="service_id" id="service_id" class="text-box">
                   <input type="submit" value="Search" class="button-save">
               </form>
-
-              <form action="{{ url_for('.find_supplier_services') }}" method="get" class="question">
-                  <label class="question-heading" for="supplier_id_for_services">Find services by supplier ID</label>
-                  <p class='hint'>
-                    eg 54321
-                  </p>
-                  <input type="text" name="supplier_id" id="supplier_id_for_services" class="text-box">
-                  <input type="submit" value="Search" class="button-save">
-              </form>
-
-              <form action="{{ url_for('.find_supplier_users') }}" method="get" class="question">
-                  <label class="question-heading" for="supplier_id_for_users">Find users by supplier ID</label>
-                  <p class='hint'>
-                    eg 54321
-                  </p>
-                  <input type="text" name="supplier_id" id="supplier_id_for_users" class="text-box">
-                  <input type="submit" value="Search" class="button-save">
-              </form>
               {% endif %}
 
               <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
@@ -67,6 +49,15 @@
                   eg searching for c would give all suppliers starting with c
                 </p>
                 <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
+                <input type="submit" value="Search" class="button-save">
+              </form>
+
+              <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
+                <label class="question-heading" for="supplier_duns_number">Find suppliers by DUNS number</label>
+                <p class="hint">
+                  DUNS numbers are usually 9 digits long, eg 234554321
+                </p>
+                <input type="text" name="supplier_duns_number" id="supplier_duns_number" class="text-box">
                 <input type="submit" value="Search" class="button-save">
               </form>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -85,14 +85,9 @@
   {% endwith %}
   {% with items = [
       {
-          "body": "View G-Cloud 7 statistics",
-          "link": "/admin/statistics/g-cloud-7",
-          "title": "G-Cloud 7 statistics"
-      },
-      {
-          "body": "View Digital Outcomes and Specialists statistics",
-          "link": "/admin/statistics/digital-outcomes-and-specialists",
-          "title": "Digital Outcomes and Specialists statistics"
+          "body": "View G-Cloud 8 statistics",
+          "link": "/admin/statistics/g-cloud-8",
+          "title": "G-Cloud 8 statistics"
       }
   ]
   %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -137,6 +137,11 @@
           "title": "Digital Outcomes and Specialists communications"
       },
       {
+        "body": "Manage G-Cloud 8 communications",
+        "link": "/admin/communications/g-cloud-8",
+        "title": "G-Cloud 8 communications"
+      },
+      {
           "body": "Download a list of users for frameworks that are open, pending or live",
           "link": url_for(".list_frameworks_with_users"),
           "title": "Download user list"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -139,7 +139,7 @@
       {
           "body": "Download a list of users for frameworks that are open, pending or live",
           "link": url_for(".list_frameworks_with_users"),
-          "title": "Download user list"
+          "title": "Download user lists"
       }
     ]
     %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -17,40 +17,35 @@
 
 {% block main_content %}
   {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-  {% for category, message in messages %}
-  {% if category == 'upload_communication' %}
-    <div class="banner-success-without-action">
-      <p class="banner-message">
-      {% if message == 'itt_pack' %}
-        ITT pack was uploaded.
-      {% elif message == 'clarification' %}
-        New clarification was uploaded.
-      {% elif message == 'communication' %}
-        New communication was uploaded.
+      {% if messages %}
+          {% for category, message in messages %}
+              {% if category == 'upload_communication' %}
+                <div class="banner-success-without-action">
+                  <p class="banner-message">
+                  {% if message == 'itt_pack' %}
+                    ITT pack was uploaded.
+                  {% elif message == 'clarification' %}
+                    New clarification was uploaded.
+                  {% elif message == 'communication' %}
+                    New communication was uploaded.
+                  {% endif %}
+                  </p>
+                </div>
+              {% else %}
+                <div class="banner-destructive-without-action">
+                    <p class="banner-message">
+                    {% if category == 'not_pdf_or_csv' and message == 'communication' %}
+                        Communication file is not a PDF or CSV.
+                    {% elif category == 'not_pdf' and message == 'clarification' %}
+                        Clarification file is not a PDF.
+                    {% elif category == 'not_zip' and message == 'itt_pack' %}
+                        ITT pack is not a zip file.
+                    {% endif %}
+                  </p>
+                </div>
+              {% endif %}
+          {% endfor %}
       {% endif %}
-      </p>
-    </div>
-  {% elif category == 'not_pdf' %}
-    <div class="banner-destructive-without-action">
-      <p class="banner-message">
-        {% if message == 'communication' %}
-        Communication file is not a PDF.
-        {% elif message == 'clarification' %}
-        Clarification file is not a PDF.
-        {% endif %}
-      </p>
-    </div>
-  {% elif category == 'not_zip' and message == 'itt_pack' %}
-    <div class="banner-destructive-without-action">
-      <p class="banner-message">
-        ITT pack is not a zip file.
-      </p>
-    </div>
-  {% endif %}
-
-  {% endfor %}
-  {% endif %}
   {% endwith %}
 
   {% with heading = "Upload {} communications".format(framework.name) %}
@@ -61,7 +56,7 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     {% with
        question="Communication",
-       hint="This must be PDF",
+       hint="This must be PDF or CSV",
        name="communication",
        value="Last modified {}".format(communication.last_modified),
        error=communication_error

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v14.0.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.12.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.20.0",
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.1.0",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.0#egg=digitalmarketplace-utils==19.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.8.0#egg=digitalmarketplace-utils==19.8.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -173,12 +173,13 @@ class TestServiceEdit(LoggedInApplicationTest):
             '/admin/services/1/edit/features-and-benefits'
         )
         self.assertEquals(200, response.status_code)
+        stripped_page = self.strip_all_whitespace(response.data)
         self.assertIn(
-            b'id="input-serviceFeatures-0" class="text-box" value="bar"',
-            response.data)
+            b'id="input-serviceFeatures-0"class="text-box"value="bar"',
+            stripped_page)
         self.assertIn(
-            b'id="input-serviceFeatures-1" class="text-box" value=""',
-            response.data)
+            b'id="input-serviceFeatures-1"class="text-box"value=""',
+            stripped_page)
         response = self.client.post(
             '/admin/services/1/edit/features-and-benefits',
             data={
@@ -204,8 +205,8 @@ class TestServiceEdit(LoggedInApplicationTest):
 
         self.assertEquals(200, response.status_code)
         self.assertIn(
-            b'id="input-serviceFeatures-0" class="text-box" value=""',
-            response.data)
+            b'id="input-serviceFeatures-0"class="text-box"value=""',
+            self.strip_all_whitespace(response.data))
 
     @mock.patch('app.main.views.services.data_api_client')
     @mock.patch('app.main.views.services.upload_service_documents')

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -173,12 +173,12 @@ class TestServiceEdit(LoggedInApplicationTest):
             '/admin/services/1/edit/features-and-benefits'
         )
         self.assertEquals(200, response.status_code)
-        stripped_page = self.strip_all_whitespace(response.data)
+        stripped_page = self.strip_all_whitespace(response.get_data(as_text=True))
         self.assertIn(
-            b'id="input-serviceFeatures-0"class="text-box"value="bar"',
+            'id="input-serviceFeatures-0"class="text-box"value="bar"',
             stripped_page)
         self.assertIn(
-            b'id="input-serviceFeatures-1"class="text-box"value=""',
+            'id="input-serviceFeatures-1"class="text-box"value=""',
             stripped_page)
         response = self.client.post(
             '/admin/services/1/edit/features-and-benefits',
@@ -205,8 +205,8 @@ class TestServiceEdit(LoggedInApplicationTest):
 
         self.assertEquals(200, response.status_code)
         self.assertIn(
-            b'id="input-serviceFeatures-0"class="text-box"value=""',
-            self.strip_all_whitespace(response.data))
+            'id="input-serviceFeatures-0"class="text-box"value=""',
+            self.strip_all_whitespace(response.get_data(as_text=True)))
 
     @mock.patch('app.main.views.services.data_api_client')
     @mock.patch('app.main.views.services.upload_service_documents')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -40,7 +40,13 @@ class TestSuppliersListView(LoggedInApplicationTest):
         data_api_client.find_suppliers.side_effect = HTTPError(Response(404))
         self.client.get("/admin/suppliers?supplier_name_prefix=foo")
 
-        data_api_client.find_suppliers.assert_called_once_with(prefix="foo")
+        data_api_client.find_suppliers.assert_called_once_with(prefix="foo", duns_number=None)
+
+    def test_should_search_by_duns_number(self, data_api_client):
+        data_api_client.find_suppliers.side_effect = HTTPError(Response(404))
+        self.client.get("/admin/suppliers?supplier_duns_number=987654321")
+
+        data_api_client.find_suppliers.assert_called_once_with(prefix=None, duns_number="987654321")
 
 
 class TestSupplierUsersView(LoggedInApplicationTest):


### PR DESCRIPTION
Completes this story (DUNS number lookup): https://www.pivotaltracker.com/story/show/118179967
And this one (Communications links and CSV upload): https://www.pivotaltracker.com/story/show/118178617

Now also has a cheeky bugfix fro this: https://www.pivotaltracker.com/story/show/114000913

These changes will break the functional tests.  I'm working on updating the tests at the moment so we can ship the test changes at the same time as this.

DUNS number lookup:
![screen shot 2016-04-28 at 16 03 02](https://cloud.githubusercontent.com/assets/6525554/14890499/d384fc2e-0d5a-11e6-8731-bfb55b75867e.png)

Communications link and upload page:
![screen shot 2016-04-28 at 15 57 42](https://cloud.githubusercontent.com/assets/6525554/14890458/a2e5b7d4-0d5a-11e6-86f0-142ddc7e941c.png)

![screen shot 2016-04-28 at 15 57 25](https://cloud.githubusercontent.com/assets/6525554/14890463/a63886c8-0d5a-11e6-871c-2c8d5a50e7bd.png)
