### PR TITLE
Change supplier link following user search

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -21,14 +21,17 @@ from dmutils.formats import datetimeformat
 @login_required
 @role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
 def find_suppliers():
-    suppliers = data_api_client.find_suppliers(
-        prefix=request.args.get("supplier_name_prefix"),
-        duns_number=request.args.get("supplier_duns_number")
-    )
+    if request.args.get("supplier_id"):
+        suppliers = [data_api_client.get_supplier(request.args.get("supplier_id"))['suppliers']]
+    else:
+        suppliers = data_api_client.find_suppliers(
+            prefix=request.args.get("supplier_name_prefix"),
+            duns_number=request.args.get("supplier_duns_number")
+        )['suppliers']
 
     return render_template(
         "view_suppliers.html",
-        suppliers=suppliers['suppliers'],
+        suppliers=suppliers,
         signed_agreement_prefix=SIGNED_AGREEMENT_PREFIX,
         agreement_prefix=AGREEMENT_FILENAME
     )

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -64,7 +64,7 @@
 
       {% call summary.field() %}
           {% if item.role == 'supplier' %}
-          <a href="{{ url_for('.find_supplier_users', supplier_id=item.supplier.supplierId) }}">{{ item.supplier.name }}</a>
+          <a href="{{ url_for('.find_suppliers', supplier_id=item.supplier.supplierId) }}">{{ item.supplier.name }}</a>
           {% endif %}
       {% endcall %}
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -48,6 +48,12 @@ class TestSuppliersListView(LoggedInApplicationTest):
 
         data_api_client.find_suppliers.assert_called_once_with(prefix=None, duns_number="987654321")
 
+    def test_should_find_by_supplier_id(self, data_api_client):
+        data_api_client.get_supplier.side_effect = HTTPError(Response(404))
+        self.client.get("/admin/suppliers?supplier_id=12345")
+
+        data_api_client.get_supplier.assert_called_once_with("12345")
+
 
 class TestSupplierUsersView(LoggedInApplicationTest):
 

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -129,7 +129,7 @@ class TestUsersView(LoggedInApplicationTest):
 
         supplier_link = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/a')[0]
-        self.assertEquals('/admin/suppliers/users?supplier_id=1000', supplier_link.attrib['href'])
+        self.assertEquals('/admin/suppliers?supplier_id=1000', supplier_link.attrib['href'])
 
     def test_should_show_unlock_button(self, data_api_client):
         buyer = self.load_example_listing("user_response")


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/118839501

When searching for a user by email address it is more convenient for admin users to go to a page where they can access both services and user accounts for that supplier. (Currently the link takes them to the page with users for the supplier.)

I have demo'd this to Nicole and it made her happy :)