### PR TITLE
Change to using the new dmcontent package

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from flask_wtf.csrf import CsrfProtect
 import dmapiclient
 from dmutils import init_app, flask_featureflags, formats
 from dmutils.user import User
-from dmutils.content_loader import ContentLoader
+from dmcontent.content_loader import ContentLoader
 
 from config import configs
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -3,7 +3,8 @@ from flask_login import login_required, current_user
 from datetime import datetime
 
 from dmapiclient import HTTPError
-from dmutils.formats import DATETIME_FORMAT, format_service_price
+from dmutils.formats import DATETIME_FORMAT
+from dmcontent.formats import format_service_price
 from dmutils.documents import upload_service_documents
 from dmutils.s3 import S3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@19.8.0#egg=digitalmarketplace-utils==19.8.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@19.8.0#egg=digitalmarketplace-utils==19.8.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ unicodecsv==0.14.1
 boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.8.0#egg=digitalmarketplace-utils==19.8.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@20.0.0#egg=digitalmarketplace-utils==20.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -190,7 +190,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             Activity for
         </p>
         <h1>
-        Friday 01 January 2010
+        Friday 1 January 2010
         </h1>
         """
 
@@ -407,7 +407,7 @@ class TestServiceStatusUpdates(LoggedInApplicationTest):
 
         page_contents = self._replace_whitespace(response.get_data(as_text=True))
 
-        self.assertIn('Friday01January2016', page_contents)
+        self.assertIn('Friday1January2016', page_contents)
         self.assertIn('1234567890', page_contents)
 
     def test_should_link_to_previous_and_next_days(self, data_api_client):

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -474,11 +474,11 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
 
         # check dates are right
         self.assertIn(
-            self.strip_all_whitespace('Monday 01 December 2014 at 10:55'),
+            self.strip_all_whitespace('Monday 1 December 2014 at 10:55'),
             self.strip_all_whitespace(response.get_data(as_text=True))
         )
         self.assertIn(
-            self.strip_all_whitespace('Tuesday 02 December 2014 at 10:55'),
+            self.strip_all_whitespace('Tuesday 2 December 2014 at 10:55'),
             self.strip_all_whitespace(response.get_data(as_text=True))
         )
 


### PR DESCRIPTION
The content loader has been extracted from dmutils to its own pacakge, `dmcontent`.

This pull request updates the admin-frontend to use the new package.

It updates the requirements to import the new package, as well as a new version of `dmutils` which no longer includes the moved content loader.

It also slightly updates three tests to drop leading 0s for dates, as version 20.0.0 of `dmutils` does not use them.