### PR TITLE
Allow admin to move users between supplier accounts

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -60,3 +60,10 @@ class EmailAddressForm(Form):
         DataRequired(message="Email can not be empty"),
         Email(message="Please enter a valid email address")
     ])
+
+
+class MoveUserForm(Form):
+    user_to_move_email_address = StripWhitespaceStringField('Move an existing user to this supplier', validators=[
+        DataRequired(message="Email can not be empty"),
+        Email(message="Please enter a valid email address")
+    ])

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -63,8 +63,9 @@
               'Name',
               'Email address',
               'Last login',
-              'Last password change',
-              'Locked'
+              'Pwd changed',
+              'Locked',
+              summary.hidden_field_heading("") if current_user.has_role('admin') else "Status"
           ],
           field_headings_visible=True)
       %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -38,16 +38,18 @@
   {% elif category == 'success' %}
     <div class="banner-success-without-action">
   {% endif %}
+        <p class="banner-message">
   {% if message == 'user_invited' %}
-  <p class="banner-message">
       User invited
-  </p>
   {% elif message == 'user_not_invited' %}
-  <p class="banner-message">
       Not Invited
-  </p>
+  {% elif message == 'user_moved' %}
+      User moved to this supplier
+  {% elif message == 'user_not_moved' %}
+      User not moved to this supplier - please check you entered the address of an existing supplier user
   {% endif %}
-        </div>
+        </p>
+    </div>
   {% endfor %}
   {% endif %}
   {% endwith %}
@@ -142,23 +144,6 @@
         {% endif %}
       {% endif %}
       {% endcall %}
-
-      {% call summary.field() %}
-      {% if current_user.has_role('admin') %}
-      <form action="{{ url_for('.remove_from_supplier', user_id=item.id) }}" method="post">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          <input type="hidden" name="supplier_id" value="{{ item.supplier.supplierId }}"/>
-          {%
-              with
-              type = "secondary",
-              label = "Remove from supplier"
-          %}
-          {% include "toolkit/button.html" %}
-          {% endwith %}
-      </form>
-      {% endif %}
-      {% endcall %}
-
       {% endcall %}
       {% endcall %}
   </div>
@@ -176,7 +161,7 @@
                       <div class="question">
                           {{ form.email_address.label(class="question-heading-with-hint") }}
                           <p class="hint">
-                              Enter the email address you of the user you wish to add
+                              Enter the email address you of the person you wish to invite
                           </p>
                           {% if form.email_address.errors %}
                           <p class="validation-message" id="error-email-address-textbox">
@@ -193,5 +178,34 @@
           </div>
       </form>
   </div>
+
+    <div class='page-section'>
+        <form action="{{ url_for('.move_user_to_new_supplier', supplier_id=supplier.id) }}" method="post">
+            <div class="grid-row">
+                <div class="column-two-thirds">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    {% if form2.user_to_move_email_address.errors %}
+                    <div class="validation-wrapper">
+                        {% endif %}
+                        <div class="question">
+                            {{ form2.user_to_move_email_address.label(class="question-heading-with-hint") }}
+                            <p class="hint">
+                                Enter the email address you of the existing user you wish to move to this supplier
+                            </p>
+                            {% if form2.user_to_move_email_address.errors %}
+                            <p class="validation-message" id="error-email-address-textbox">
+                                {% for error in form2.user_to_move_email_address.errors %}{{ error }}{% endfor %}
+                            </p>
+                            {% endif %}
+                            {{ form2.user_to_move_email_address(class="text-box", autocomplete="off") }}
+                        </div>
+                        {% if form2.user_to_move_email_address.errors %}
+                    </div>
+                    {% endif %}
+                    <button class="button-save">Move user to this supplier</button>
+                </div>
+            </div>
+        </form>
+    </div>
   {% endif %}
 {% endblock %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -156,22 +156,22 @@
           <div class="grid-row">
               <div class="column-two-thirds">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  {% if form.email_address.errors %}
+                  {% if invite_form.email_address.errors %}
                   <div class="validation-wrapper">
                       {% endif %}
                       <div class="question">
-                          {{ form.email_address.label(class="question-heading-with-hint") }}
+                          {{ invite_form.email_address.label(class="question-heading-with-hint") }}
                           <p class="hint">
-                              Enter the email address you of the person you wish to invite
+                              Enter the email address of the person you wish to invite
                           </p>
-                          {% if form.email_address.errors %}
+                          {% if invite_form.email_address.errors %}
                           <p class="validation-message" id="error-email-address-textbox">
-                              {% for error in form.email_address.errors %}{{ error }}{% endfor %}
+                              {% for error in invite_form.email_address.errors %}{{ error }}{% endfor %}
                           </p>
                           {% endif %}
-                          {{ form.email_address(class="text-box", autocomplete="off") }}
+                          {{ invite_form.email_address(class="text-box", autocomplete="off") }}
                       </div>
-                      {% if form.email_address.errors %}
+                      {% if invite_form.email_address.errors %}
                   </div>
                   {% endif %}
                  <button class="button-save">Send invitation</button>
@@ -185,22 +185,22 @@
             <div class="grid-row">
                 <div class="column-two-thirds">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                    {% if form2.user_to_move_email_address.errors %}
+                    {% if move_user_form.user_to_move_email_address.errors %}
                     <div class="validation-wrapper">
                         {% endif %}
                         <div class="question">
-                            {{ form2.user_to_move_email_address.label(class="question-heading-with-hint") }}
+                            {{ move_user_form.user_to_move_email_address.label(class="question-heading-with-hint") }}
                             <p class="hint">
-                                Enter the email address you of the existing user you wish to move to this supplier
+                                Enter the email address of the existing user you wish to move to this supplier
                             </p>
-                            {% if form2.user_to_move_email_address.errors %}
+                            {% if move_user_form.user_to_move_email_address.errors %}
                             <p class="validation-message" id="error-email-address-textbox">
-                                {% for error in form2.user_to_move_email_address.errors %}{{ error }}{% endfor %}
+                                {% for error in move_user_form.user_to_move_email_address.errors %}{{ error }}{% endfor %}
                             </p>
                             {% endif %}
-                            {{ form2.user_to_move_email_address(class="text-box", autocomplete="off") }}
+                            {{ move_user_form.user_to_move_email_address(class="text-box", autocomplete="off") }}
                         </div>
-                        {% if form2.user_to_move_email_address.errors %}
+                        {% if move_user_form.user_to_move_email_address.errors %}
                     </div>
                     {% endif %}
                     <button class="button-save">Move user to this supplier</button>

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -149,12 +149,12 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         )
 
         self.assertIn(
-            '<input type="submit" class="button-secondary"  value="Remove from supplier" />',
+            '<button class="button-save">Move user to this supplier</button>',
             response.get_data(as_text=True)
         )
 
         self.assertIn(
-            '<form action="/admin/suppliers/users/999/remove-from-supplier" method="post">',
+            '<form action="/admin/suppliers/1234/move-existing-user" method="post">',
             response.get_data(as_text=True)
         )
 
@@ -238,16 +238,19 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
-    def test_should_call_api_to_remove_user_from_supplier(self, data_api_client):
+    def test_should_call_api_to_move_user_to_another_supplier(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
+        data_api_client.get_user.return_value = self.load_example_listing("user_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
 
         response = self.client.post(
-            '/admin/suppliers/users/999/remove-from-supplier',
-            data={'supplier_id': 1000}
+            '/admin/suppliers/1000/move-existing-user',
+            data={'user_to_move_email_address': 'test.user@sme.com'}
         )
 
-        data_api_client.update_user.assert_called_with(999, role='buyer', updater="test@example.com")
+        data_api_client.update_user.assert_called_with(
+            999, role='supplier', supplier_id=1000, active=True, updater="test@example.com"
+        )
 
         self.assertEquals(302, response.status_code)
         self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/119279671

Currently the "Remove user from supplier" button doesn't work, because before we had actual buyer accounts users were ported to a "buyer" role, which now fails unless the user happened to have an email address that is allowed for our buyer accounts, and anyway is not the expected behaviour any more.

This removes the broken "Remove from supplier" button, and instead adds a form field that allows an admin user to move existing supplier users from one supplier to another.

:sparkles:  Demo'd to Nicole and she likes it. :sparkles:

~~It's probably going to break the functional tests though - fix for those coming soon.~~
Functional test fix should be merged just *before* this: 
 - [ ] https://github.com/alphagov/digitalmarketplace-functional-tests/pull/195

![screen shot 2016-05-10 at 17 51 46](https://cloud.githubusercontent.com/assets/6525554/15155313/d32000e8-16d9-11e6-9f36-45b2f4f1eaa9.png)
