### PR TITLE
Add ability to find buyer contact details via brief ID

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,7 +3,7 @@ from flask import Blueprint
 
 main = Blueprint('main', __name__)
 
-from .views import login, agreements, communications, service_updates, services, suppliers, stats, users
+from .views import login, agreements, communications, service_updates, services, suppliers, stats, users, buyers
 from app.main import errors
 
 

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -5,6 +5,7 @@ from .. import main
 from ... import data_api_client
 from ..auth import role_required
 
+
 @main.route('/buyers', methods=['GET'])
 @login_required
 @role_required('admin')

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -20,7 +20,6 @@ def find_buyer_by_brief_id():
         return render_template(
             "view_buyers.html",
             users=list(),
-            title=None,
             brief_id=brief_id
         ), 404
 

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -9,25 +9,25 @@ from ..auth import role_required
 @main.route('/buyers', methods=['GET'])
 @login_required
 @role_required('admin')
-def find_buyer_by_brief_id():
-    brief_id = request.args.get('brief_id')
+def find_buyer_by_opportunity_id():
+    opportunity_id = request.args.get('opportunity_id')
 
     try:
-        brief = data_api_client.get_brief(brief_id).get('briefs')
+        opportunity = data_api_client.get_brief(opportunity_id).get('briefs')
 
     except:
-        flash('no_brief', 'error')
+        flash('no_opportunity', 'error')
         return render_template(
             "view_buyers.html",
             users=list(),
-            brief_id=brief_id
+            opportunity_id=opportunity_id
         ), 404
 
-    users = brief.get('users')
-    title = brief.get('title')
+    users = opportunity.get('users')
+    title = opportunity.get('title')
     return render_template(
         "view_buyers.html",
         users=users,
         title=title,
-        brief_id=brief_id
+        opportunity_id=opportunity_id
     )

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -1,17 +1,17 @@
-from flask import render_template
+from flask import render_template, request
 from flask_login import login_required
 
 from .. import main
 from ... import data_api_client
 from ..auth import role_required
 
-@main.route('/buyers/<string:brief_id>', methods=['GET'])
+@main.route('/buyers', methods=['GET'])
 @login_required
 @role_required('admin')
-def find_buyer_by_brief_id(brief_id):
-    brief = data_api_client.get_brief(brief_id)
+def find_buyer_by_brief_id():
+    brief = data_api_client.get_brief(request.args.get('brief_id'))
     if brief:
-        users = brief.get('users')
+        users = brief.get('briefs').get('users')
         return render_template(
             "view_buyers.html",
             users=users

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -9,25 +9,25 @@ from ..auth import role_required
 @main.route('/buyers', methods=['GET'])
 @login_required
 @role_required('admin')
-def find_buyer_by_opportunity_id():
-    opportunity_id = request.args.get('opportunity_id')
+def find_buyer_by_brief_id():
+    brief_id = request.args.get('brief_id')
 
     try:
-        opportunity = data_api_client.get_brief(opportunity_id).get('briefs')
+        brief = data_api_client.get_brief(brief_id).get('briefs')
 
     except:
-        flash('no_opportunity', 'error')
+        flash('no_brief', 'error')
         return render_template(
             "view_buyers.html",
             users=list(),
-            opportunity_id=opportunity_id
+            brief_id=brief_id
         ), 404
 
-    users = opportunity.get('users')
-    title = opportunity.get('title')
+    users = brief.get('users')
+    title = brief.get('title')
     return render_template(
         "view_buyers.html",
         users=users,
         title=title,
-        opportunity_id=opportunity_id
+        brief_id=brief_id
     )

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -1,4 +1,4 @@
-from flask import render_template, request
+from flask import render_template, request, flash
 from flask_login import login_required
 
 from .. import main
@@ -9,10 +9,25 @@ from ..auth import role_required
 @login_required
 @role_required('admin')
 def find_buyer_by_brief_id():
-    brief = data_api_client.get_brief(request.args.get('brief_id'))
-    if brief:
-        users = brief.get('briefs').get('users')
+    brief_id = request.args.get('brief_id')
+
+    try:
+        brief = data_api_client.get_brief(brief_id).get('briefs')
+
+    except:
+        flash('no_brief', 'error')
         return render_template(
             "view_buyers.html",
-            users=users
-        )
+            users=list(),
+            title=None,
+            brief_id=brief_id
+        ), 404
+
+    users = brief.get('users')
+    title = brief.get('title')
+    return render_template(
+        "view_buyers.html",
+        users=users,
+        title=title,
+        brief_id=brief_id
+    )

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -5,13 +5,13 @@ from .. import main
 from ... import data_api_client
 from ..auth import role_required
 
-@main.route('buyers/<string:brief_id>', methods=['GET'])
+@main.route('/buyers/<string:brief_id>', methods=['GET'])
 @login_required
 @role_required('admin')
-def find_buyer_by_brief_id():
+def find_buyer_by_brief_id(brief_id):
     brief = data_api_client.get_brief(brief_id)
     if brief:
-        users = data_api_client.get('users')
+        users = brief.get('users')
         return render_template(
             "view_buyers.html",
             users=users

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -1,0 +1,18 @@
+from flask import render_template
+from flask_login import login_required
+
+from .. import main
+from ... import data_api_client
+from ..auth import role_required
+
+@main.route('buyers/<string:brief_id>', methods=['GET'])
+@login_required
+@role_required('admin')
+def find_buyer_by_brief_id():
+    brief = data_api_client.get_brief(brief_id)
+    if brief:
+        users = data_api_client.get('users')
+        return render_template(
+            "view_buyers.html",
+            users=users
+        )

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -21,8 +21,8 @@ def process_login():
     if form.validate_on_submit():
         user_json = data_api_client.authenticate_user(
             form.email_address.data,
-            form.password.data,
-            supplier=False)
+            form.password.data
+            )
 
         if not any(user_has_role(user_json, role) for role in ['admin', 'admin-ccs-category', 'admin-ccs-sourcing']):
             message = "login.fail: Failed to log in: %s"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -72,12 +72,12 @@
                   <input type="submit" value="Search" class="button-save">
               </form>
 
-              <form action="{{ url_for('.find_buyer_by_opportunity_id') }}" method="get" class="question">
-                  <label class="question-heading" for="opportunity_id">Find buyer by opportunity ID</label>
+              <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+                  <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
                   <p class='hint'>
                     You can find this number at the end of the opportunities’ URL.
                   </p>
-                  <input type="text" name="opportunity_id" id="opportunuty_id" class="text-box">
+                  <input type="text" name="brief_id" id="brief_id" class="text-box">
                   <input type="submit" value="Search" class="button-save">
               </form>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -75,7 +75,7 @@
               <form action="{{ url_for('.find_buyer_by_opportunity_id') }}" method="get" class="question">
                   <label class="question-heading" for="opportunity_id">Find buyer by opportunity ID</label>
                   <p class='hint'>
-                    Opportunity IDs are digits
+                    You can find this number at the end of the opportunities’ URL.
                   </p>
                   <input type="text" name="opportunity_id" id="opportunuty_id" class="text-box">
                   <input type="submit" value="Search" class="button-save">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -73,7 +73,7 @@
               </form>
 
               <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-                  <label class="question-heading" for="email_address">Find buyer by brief ID</label>
+                  <label class="question-heading" for="brief_id">Find buyer by brief ID</label>
                   <p class='hint'>
                     Brief IDs are digits
                   </p>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -72,12 +72,12 @@
                   <input type="submit" value="Search" class="button-save">
               </form>
 
-              <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-                  <label class="question-heading" for="brief_id">Find buyer by brief ID</label>
+              <form action="{{ url_for('.find_buyer_by_opportunity_id') }}" method="get" class="question">
+                  <label class="question-heading" for="opportunity_id">Find buyer by opportunity ID</label>
                   <p class='hint'>
-                    Brief IDs are digits
+                    Opportunity IDs are digits
                   </p>
-                  <input type="text" name="brief_id" id="brief_id" class="text-box">
+                  <input type="text" name="opportunity_id" id="opportunuty_id" class="text-box">
                   <input type="submit" value="Search" class="button-save">
               </form>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -72,6 +72,15 @@
                   <input type="submit" value="Search" class="button-save">
               </form>
 
+              <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+                  <label class="question-heading" for="email_address">Find buyer by brief ID</label>
+                  <p class='hint'>
+                    Brief IDs are digits
+                  </p>
+                  <input type="text" name="brief_id" id="brief_id" class="text-box">
+                  <input type="submit" value="Search" class="button-save">
+              </form>
+
               {% endif %}
           </div>
       </div>

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -1,0 +1,85 @@
+{% import "toolkit/summary-table.html" as summary %}
+
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+    Buyers – Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          },
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+      {% for category, message in messages %}
+          {% if message == 'no_brief' %}
+              {% set displayed_message = "Sorry, we couldn't find a brief with the supplied ID: {}".format(brief_id) %}
+          {% endif %}
+          {%
+          with
+              message = displayed_message,
+              type = "destructive" if category == 'error' else "success"
+          %}
+          {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+      {% endfor %}
+  {% endif %}
+  {% endwith %}
+
+  {% with heading = brief_id + ' - ' + title if title %}
+  {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  {% call(item) summary.list_table(
+          users,
+          caption="Buyers",
+          empty_message="No buyers to show",
+          field_headings=[
+              'Name',
+              'Email',
+              'Phone number'
+          ],
+          field_headings_visible=True)
+      %}
+
+      {% call summary.row() %}
+
+        {{ summary.field_name(item.name) }}
+
+        {% call summary.field() %}
+          {{ item.emailAddress }}
+        {% endcall %}
+
+        {% call summary.field() %}
+          {{ item.phoneNumber }}
+        {% endcall %}
+
+
+      {% endcall %}
+
+  {% endcall %}
+
+  <br>
+
+  <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+      <label class="question-heading" for="email_address">Find buyer by brief ID</label>
+      <p class='hint'>
+        Brief IDs are digits
+      </p>
+      <input type="text" name="brief_id" id="brief_id" class="text-box">
+      <input type="submit" value="Search" class="button-save">
+  </form>
+  </div>
+
+{% endblock %}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -24,7 +24,7 @@
   {% if messages %}
       {% for category, message in messages %}
           {% if message == 'no_brief' %}
-              {% set displayed_message = "Sorry, we couldn't find a brief with the supplied ID: {}".format(brief_id) %}
+              {% set displayed_message = "Sorry, we couldn't find a brief with the ID: {}".format(brief_id) %}
           {% endif %}
           {%
           with

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -24,7 +24,7 @@
   {% if messages %}
       {% for category, message in messages %}
           {% if message == 'no_opportunity' %}
-              {% set displayed_message = "Sorry, we couldn't find an opportunity with the ID: {}".format(opportunity_id) %}
+              {% set displayed_message = "There are no opportunities with ID {}".format(opportunity_id) %}
           {% endif %}
           {%
           with

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -23,8 +23,8 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
       {% for category, message in messages %}
-          {% if message == 'no_brief' %}
-              {% set displayed_message = "Sorry, we couldn't find a brief with the ID: {}".format(brief_id) %}
+          {% if message == 'no_opportunity' %}
+              {% set displayed_message = "Sorry, we couldn't find an opportunity with the ID: {}".format(opportunity_id) %}
           {% endif %}
           {%
           with
@@ -37,7 +37,7 @@
   {% endif %}
   {% endwith %}
 
-  {% with heading = brief_id + ' - ' + title if title %}
+  {% with heading = opportunity_id + ' - ' + title if title %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
@@ -72,12 +72,12 @@
 
   <br>
 
-  <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-      <label class="question-heading" for="email_address">Find buyer by brief ID</label>
+  <form action="{{ url_for('.find_buyer_by_opportunity_id') }}" method="get" class="question">
+      <label class="question-heading" for="email_address">Find buyer by opportunity ID</label>
       <p class='hint'>
-        Brief IDs are digits
+        Opportunity IDs are digits
       </p>
-      <input type="text" name="brief_id" id="brief_id" class="text-box">
+      <input type="text" name="opportunity_id" id="opportunity_id" class="text-box">
       <input type="submit" value="Search" class="button-save">
   </form>
   </div>

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -23,8 +23,8 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
       {% for category, message in messages %}
-          {% if message == 'no_opportunity' %}
-              {% set displayed_message = "There are no opportunities with ID {}".format(opportunity_id) %}
+          {% if message == 'no_brief' %}
+              {% set displayed_message = "There are no opportunities with ID {}".format(brief_id) %}
           {% endif %}
           {%
           with
@@ -37,7 +37,7 @@
   {% endif %}
   {% endwith %}
 
-  {% with heading = opportunity_id + ' - ' + title if title %}
+  {% with heading = brief_id + ' - ' + title if title %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
@@ -72,12 +72,12 @@
 
   <br>
 
-  <form action="{{ url_for('.find_buyer_by_opportunity_id') }}" method="get" class="question">
-      <label class="question-heading" for="email_address">Find buyer by opportunity ID</label>
+  <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+      <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
       <p class='hint'>
-        Opportunity IDs are digits
+        You can find this number at the end of the opportunities’ URL.
       </p>
-      <input type="text" name="opportunity_id" id="opportunity_id" class="text-box">
+      <input type="text" name="brief_id" id="brief_id" class="text-box">
       <input type="submit" value="Search" class="button-save">
   </form>
   </div>

--- a/example_responses/brief_response.json
+++ b/example_responses/brief_response.json
@@ -1,0 +1,65 @@
+{
+  "briefs": {
+    "startDate": "31/12/2016",
+    "links": {
+        "framework": "http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "self": "http://localhost:5000/briefs/99"
+    },
+    "evaluationType": [
+      "Reference"
+    ],
+    "niceToHaveRequirements": [
+      "Do you like cats?",
+      "Is your cat named Eva?"
+    ],
+    "applicationsClosedAt": "2016-06-07T23:59:59.000000Z",
+    "essentialRequirements": [
+      "Can you do coding?",
+      "Can you do Python?"
+    ],
+    "updatedAt": "2016-05-24T16:44:17.133633Z",
+    "existingTeam": "Digital Marketplace team",
+    "specialistWork": "Work on the Digital Marketplace",
+    "id": 99,
+    "createdAt": "2016-05-24T16:44:17.106766Z",
+    "clarificationQuestionsAreClosed": true,
+    "frameworkFramework": "dos",
+    "clarificationQuestionsClosedAt": "2016-05-31T23:59:59.000000Z",
+    "lotSlug": "digital-specialists",
+    "clarificationQuestionsPublishedBy": "2016-06-06T23:59:59.000000Z",
+    "organisation": "Driver and Vehicle Licensing Agency",
+    "frameworkStatus": "live",
+    "lotName": "Digital specialists",
+    "location": "Scotland",
+    "lot": "digital-specialists",
+    "clarificationQuestions": [],
+    "specialistRole": "developer",
+    "users": [
+      {
+        "emailAddress": "test_buyer@gov.uk",
+        "name": "Test Buyer",
+        "phoneNumber": "02078481548",
+        "active": true,
+        "role": "buyer",
+        "id": 10348
+      }
+    ],
+    "priceWeighting": 20,
+    "contractLength": "1 day",
+    "culturalWeighting": 10,
+    "publishedAt": "2016-05-24T16:44:17.130998Z",
+    "status": "live",
+    "technicalWeighting": 70,
+    "culturalFitCriteria": [
+      "Cultural fit criteria 1",
+      "Cultural fit criteria 2"
+    ],
+    "title": "Individual Specialist-Buyer Requirements",
+    "frameworkSlug": "digital-outcomes-and-specialists",
+    "numberOfSuppliers": 5,
+    "summary": "Make a flappy bird clone except where the bird drives very safely",
+    "frameworkName": "Digital Outcomes and Specialists",
+    "workingArrangements": "Working from home",
+    "workplaceAddress": "Aviation House"
+  }
+}

--- a/example_responses/brief_response.json
+++ b/example_responses/brief_response.json
@@ -36,9 +36,9 @@
     "specialistRole": "developer",
     "users": [
       {
-        "emailAddress": "test_buyer@gov.uk",
+        "emailAddress": "test_buyer@example.com",
         "name": "Test Buyer",
-        "phoneNumber": "02078481548",
+        "phoneNumber": "02078888888",
         "active": true,
         "role": "buyer",
         "id": 10348

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@20.0.0#egg=digitalmarketplace-utils==20.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -1,0 +1,50 @@
+import mock
+from ...helpers import LoggedInApplicationTest
+from lxml import html
+
+
+@mock.patch('app.main.views.buyers.data_api_client')
+class TestBuyersView(LoggedInApplicationTest):
+
+    def test_should_be_a_404_if_no_brief_found(self, data_api_client):
+        data_api_client.get_brief.return_value = None
+        response = self.client.get('admin/buyers?brief_id=1')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_should_display_a_useful_message_if_no_brief_found(self, data_api_client):
+        data_api_client.get_brief.return_value = None
+        response = self.client.get('admin/buyers?brief_id=1')
+
+        document = html.fromstring(response.get_data(as_text=True))
+        banner_message = document.xpath('//p[@class="banner-message"]//text()')[0].strip()
+
+        self.assertEqual("Sorry, we couldn't find a brief with the supplied ID: 1", banner_message)
+
+    def test_table_should_show_a_useful_message_if_no_users(self, data_api_client):
+        data_api_client.get_brief.return_value = {
+            'briefs': {
+                'title': 'No users in here',
+                'users': list()
+            }
+        }
+        response = self.client.get('admin/buyers?brief_id=1')
+
+        document = html.fromstring(response.get_data(as_text=True))
+        table_content = document.xpath('//p[@class="summary-item-no-content"]//text()')[0].strip()
+
+        self.assertEqual("No buyers to show", table_content)
+
+    def test_should_show_buyers_contact_details(self, data_api_client):
+        brief = self.load_example_listing("brief_response")
+        data_api_client.get_brief.return_value = brief
+        response = self.client.get('/admin/buyers?brief_id=1')
+
+        document = html.fromstring(response.get_data(as_text=True))
+        name = document.xpath('//td[@class="summary-item-field-first"]//text()')[1].strip()
+        email = document.xpath('//td[@class="summary-item-field"]//text()')[1].strip()
+        phone = document.xpath('//td[@class="summary-item-field"]//text()')[4].strip()
+
+        self.assertEqual("Test Buyer", name)
+        self.assertEqual("test_buyer@gov.uk", email)
+        self.assertEqual("02078481548", phone)

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -6,20 +6,20 @@ from lxml import html
 @mock.patch('app.main.views.buyers.data_api_client')
 class TestBuyersView(LoggedInApplicationTest):
 
-    def test_should_be_a_404_if_no_brief_found(self, data_api_client):
+    def test_should_be_a_404_if_no_opportunity_found(self, data_api_client):
         data_api_client.get_brief.return_value = None
-        response = self.client.get('admin/buyers?brief_id=1')
+        response = self.client.get('admin/buyers?opportunity_id=1')
 
         self.assertEqual(response.status_code, 404)
 
-    def test_should_display_a_useful_message_if_no_brief_found(self, data_api_client):
+    def test_should_display_a_useful_message_if_no_opportunity_found(self, data_api_client):
         data_api_client.get_brief.return_value = None
-        response = self.client.get('admin/buyers?brief_id=1')
+        response = self.client.get('admin/buyers?opportunity_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
         banner_message = document.xpath('//p[@class="banner-message"]//text()')[0].strip()
 
-        self.assertEqual("Sorry, we couldn't find a brief with the ID: 1", banner_message)
+        self.assertEqual("Sorry, we couldn't find an opportunity with the ID: 1", banner_message)
 
     def test_table_should_show_a_useful_message_if_no_users(self, data_api_client):
         data_api_client.get_brief.return_value = {
@@ -28,7 +28,7 @@ class TestBuyersView(LoggedInApplicationTest):
                 'users': list()
             }
         }
-        response = self.client.get('admin/buyers?brief_id=1')
+        response = self.client.get('admin/buyers?opportunity_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
         table_content = document.xpath('//p[@class="summary-item-no-content"]//text()')[0].strip()
@@ -36,9 +36,9 @@ class TestBuyersView(LoggedInApplicationTest):
         self.assertEqual("No buyers to show", table_content)
 
     def test_should_show_buyers_contact_details(self, data_api_client):
-        brief = self.load_example_listing("brief_response")
-        data_api_client.get_brief.return_value = brief
-        response = self.client.get('/admin/buyers?brief_id=1')
+        opportunity = self.load_example_listing("brief_response")
+        data_api_client.get_brief.return_value = opportunity
+        response = self.client.get('/admin/buyers?opportunity_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
         name = document.xpath('//td[@class="summary-item-field-first"]//text()')[1].strip()

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -19,7 +19,7 @@ class TestBuyersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
         banner_message = document.xpath('//p[@class="banner-message"]//text()')[0].strip()
 
-        self.assertEqual("Sorry, we couldn't find a brief with the supplied ID: 1", banner_message)
+        self.assertEqual("Sorry, we couldn't find a brief with the ID: 1", banner_message)
 
     def test_table_should_show_a_useful_message_if_no_users(self, data_api_client):
         data_api_client.get_brief.return_value = {
@@ -46,5 +46,5 @@ class TestBuyersView(LoggedInApplicationTest):
         phone = document.xpath('//td[@class="summary-item-field"]//text()')[4].strip()
 
         self.assertEqual("Test Buyer", name)
-        self.assertEqual("test_buyer@gov.uk", email)
-        self.assertEqual("02078481548", phone)
+        self.assertEqual("test_buyer@example.com", email)
+        self.assertEqual("02078888888", phone)

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -19,7 +19,7 @@ class TestBuyersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
         banner_message = document.xpath('//p[@class="banner-message"]//text()')[0].strip()
 
-        self.assertEqual("Sorry, we couldn't find an opportunity with the ID: 1", banner_message)
+        self.assertEqual("There are no opportunities with ID 1", banner_message)
 
     def test_table_should_show_a_useful_message_if_no_users(self, data_api_client):
         data_api_client.get_brief.return_value = {

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -6,15 +6,15 @@ from lxml import html
 @mock.patch('app.main.views.buyers.data_api_client')
 class TestBuyersView(LoggedInApplicationTest):
 
-    def test_should_be_a_404_if_no_opportunity_found(self, data_api_client):
+    def test_should_be_a_404_if_no_brief_found(self, data_api_client):
         data_api_client.get_brief.return_value = None
-        response = self.client.get('admin/buyers?opportunity_id=1')
+        response = self.client.get('admin/buyers?brief_id=1')
 
         self.assertEqual(response.status_code, 404)
 
-    def test_should_display_a_useful_message_if_no_opportunity_found(self, data_api_client):
+    def test_should_display_a_useful_message_if_no_brief_found(self, data_api_client):
         data_api_client.get_brief.return_value = None
-        response = self.client.get('admin/buyers?opportunity_id=1')
+        response = self.client.get('admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
         banner_message = document.xpath('//p[@class="banner-message"]//text()')[0].strip()
@@ -28,7 +28,7 @@ class TestBuyersView(LoggedInApplicationTest):
                 'users': list()
             }
         }
-        response = self.client.get('admin/buyers?opportunity_id=1')
+        response = self.client.get('admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
         table_content = document.xpath('//p[@class="summary-item-no-content"]//text()')[0].strip()
@@ -36,9 +36,9 @@ class TestBuyersView(LoggedInApplicationTest):
         self.assertEqual("No buyers to show", table_content)
 
     def test_should_show_buyers_contact_details(self, data_api_client):
-        opportunity = self.load_example_listing("brief_response")
-        data_api_client.get_brief.return_value = opportunity
-        response = self.client.get('/admin/buyers?opportunity_id=1')
+        brief = self.load_example_listing("brief_response")
+        data_api_client.get_brief.return_value = brief
+        response = self.client.get('/admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
         name = document.xpath('//td[@class="summary-item-field-first"]//text()')[1].strip()

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -57,7 +57,7 @@ class TestLogin(BaseApplicationTest):
             'email_address': '  valid@email.com  ',
             'password': '1234567890'
         })
-        data_api_client.authenticate_user.assert_called_with('valid@email.com', '1234567890', supplier=False)
+        data_api_client.authenticate_user.assert_called_with('valid@email.com', '1234567890')
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_not_strip_whitespace_surrounding_login_password_field(self, data_api_client):
@@ -66,7 +66,7 @@ class TestLogin(BaseApplicationTest):
             'email_address': 'valid@email.com',
             'password': '  1234567890  '
         })
-        data_api_client.authenticate_user.assert_called_with('valid@email.com', '  1234567890  ', supplier=False)
+        data_api_client.authenticate_user.assert_called_with('valid@email.com', '  1234567890  ')
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_ok_next_url_redirects_on_login(self, data_api_client):


### PR DESCRIPTION
For [this] (https://www.pivotaltracker.com/story/show/119738871) story on Pivotal.

This PR adds a new form to the index page of the admin app which allows an admin to find the contact details for the users listed with a brief, by searching by the brief ID.

It upgrades the required version of the api_client to 3.7.0, which seemed to only break a couple of tests.

Screenshots of new form and search results below.

Form
-
<img width="660" alt="screen shot 2016-06-07 at 14 33 59" src="https://cloud.githubusercontent.com/assets/13836290/15859467/302eea58-2cbd-11e6-9267-8af9678b3e12.png">

Successful search
-
<img width="1440" alt="screen shot 2016-06-07 at 14 34 47" src="https://cloud.githubusercontent.com/assets/13836290/15859485/3bcb4a6e-2cbd-11e6-8a63-d321e095a543.png">

Unsuccessful search
-
<img width="1440" alt="screen shot 2016-06-07 at 14 37 13" src="https://cloud.githubusercontent.com/assets/13836290/15859517/5ec9066e-2cbd-11e6-904b-6b927a1410a1.png">
