### PR TITLE
[#121428243] Allow CCS Sourcing to edit G-Cloud 8 declarations

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -23,6 +23,7 @@ content_loader = ContentLoader('app/content')
 content_loader.load_manifest('g-cloud-6', 'services', 'edit_service_as_admin')
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
+content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')
 
 from app.main.helpers.service import parse_document_upload_time
 

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -33,7 +33,8 @@
       {% set field_headings = [
         "Name",
         "G-Cloud 7",
-        "Digital Outcomes and Specialists",
+        "Digital Outcomes<br />and Specialists"|safe,
+        "G-Cloud 8",
       ] %}
     {% else %}
       {% set field_headings = [
@@ -58,15 +59,18 @@
         {% if current_user.has_role('admin-ccs-sourcing') %}
           {% call summary.field() %}
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">Edit declaration</a></div>
-            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=agreement_prefix) }}">Download agreement</a></div>
-            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix) }}">Download signed agreement</a></div>
-            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Upload countersigned agreement</a></div>
+            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=agreement_prefix) }}">Agreement</a></div>
+            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix) }}">Signed agreement</a></div>
+            <div>⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Countersigned agreement</a></div>
           {% endcall %}
           {% call summary.field() %}
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Edit declaration</a></div>
-            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=agreement_prefix) }}" >Download agreement</a></div>
-            <div><a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=signed_agreement_prefix) }}">Download signed agreement</a></div>
-            <div><a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Upload countersigned agreement</a></div>
+            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=agreement_prefix) }}" >Agreement</a></div>
+            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=signed_agreement_prefix) }}">Signed agreement</a></div>
+            <div>⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Countersigned agreement</a></div>
+          {% endcall %}
+          {% call summary.field() %}
+            <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-8") }}">Edit declaration</a></div>
           {% endcall %}
         {% endif %}
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pep8]
-exclude = ./venv,./bower_components,./node_modules
+exclude = ./venv*,./bower_components,./node_modules
 max-line-length=120
 
 [pytest]
-norecursedirs = venv app/content bower_components node_modules
+norecursedirs = venv* app/content bower_components node_modules


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/121428243

This is strictly a temporary fix because the new countersigning process for G-Cloud 8 will require a major re-work of this part of the admin app.

The changes here will allow CCS Sourcing to do the work they need to (ie make changes to G8 declarations where suppliers change their minds) while we build that countersigning flow out. 

The changes here ~~will probably~~ require updates to the functional tests - ~~pull-request to follow for that~~ - see:
 - [ ] https://github.com/alphagov/digitalmarketplace-functional-tests/pull/206

## Before
![screen shot 2016-06-23 at 11 00 21](https://cloud.githubusercontent.com/assets/6525554/16300464/fa95882a-3937-11e6-839b-29ddfd634a8e.png)

## After
![screen shot 2016-06-23 at 11 29 39](https://cloud.githubusercontent.com/assets/6525554/16300469/ff736d94-3937-11e6-8616-166cc96def51.png)
