### PR TITLE
Always use https:// protocol for bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.13.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v15.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.1.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v1.1.0",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }


### PR DESCRIPTION
git:// is unauthenticated (and we don't pin with commit SHA) so https:// should be preferred.

Since we're downloading from GitHub we need to add `.git` to access the Git endpoint over HTTPS.

This is a duplicate of the following pull requests
- [#367 on the buyer app](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/367)
- [#515 on the supplier app](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/515)