### PR TITLE
Admin edit address and duns

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -49,7 +49,7 @@ def view(service_id):
         return redirect(url_for('.index'))
 
     service_data['priceString'] = format_service_price(service_data)
-    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service_data)
+    content = content_loader.get_manifest('g-cloud-6', 'edit_service_as_admin').filter(service_data)
 
     return render_template(
         "view_service.html",
@@ -99,7 +99,7 @@ def update_service_status(service_id):
 def edit(service_id, section):
     service_data = data_api_client.get_service(service_id)['services']
 
-    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service_data)
+    content = content_loader.get_manifest('g-cloud-6', 'edit_service_as_admin').filter(service_data)
 
     return render_template(
         "edit_section.html",
@@ -151,7 +151,7 @@ def compare(old_archived_service_id, new_archived_service_id):
     except (HTTPError, KeyError, ValueError):
         return abort(404)
 
-    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service_data)
+    content = content_loader.get_manifest('g-cloud-6', 'edit_service_as_admin').filter(service_data)
 
     # It's possible to have an empty array if none of the lines were changed.
     # TODO This possibility isn't actually handled.
@@ -186,7 +186,7 @@ def update(service_id, section_id):
         abort(404)
     service = service['services']
 
-    content = content_loader.get_builder('g-cloud-6', 'edit_service_as_admin').filter(service)
+    content = content_loader.get_manifest('g-cloud-6', 'edit_service_as_admin').filter(service)
     section = content.get_section(section_id)
     if section is None or not section.editable:
         abort(404)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -64,7 +64,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
             raise
         declaration = {}
 
-    content = content_loader.get_builder(framework_slug, 'declaration').filter(declaration)
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration)
 
     return render_template(
         "suppliers/view_declaration.html",
@@ -203,7 +203,7 @@ def edit_supplier_declaration_section(supplier_id, framework_slug, section_id):
             raise
         declaration = {}
 
-    content = content_loader.get_builder(framework_slug, 'declaration').filter(declaration)
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration)
     section = content.get_section(section_id)
     if section is None:
         abort(404)
@@ -232,7 +232,7 @@ def update_supplier_declaration_section(supplier_id, framework_slug, section_id)
             raise
         declaration = {}
 
-    content = content_loader.get_builder(framework_slug, 'declaration').filter(declaration)
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration)
     section = content.get_section(section_id)
     if section is None:
         abort(404)

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -145,3 +145,23 @@
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
 {%- endmacro %}
+
+{% macro multiquestion(question_content, service_data, errors, question_number=None, get_question=None) -%}
+<fieldset class="question" id="{{ question_content.id }}">
+  <legend>
+    <span class="visually-hidden">{{ question_content.name }}</span>
+  </legend>
+
+  <span class="question-heading">
+      <strong>{{ question_content.name }}</strong>
+  </span>
+
+  {% for child_question in question_content.questions %}
+    {% if errors and errors[child_question.id] %}
+      {{ text(child_question, service_data, errors) }}
+    {% else %}
+      {{ text(child_question, service_data, {}) }}
+    {% endif %}
+  {% endfor %}
+</fieldset>
+{%- endmacro %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -33,7 +33,7 @@
     </div>
   </div>
 
-  {% for section in content %}
+  {% for section in content.summary(declaration) %}
     {{ summary.heading(section.name) }}
     {{ summary.top_link("Edit", url_for('.edit_supplier_declaration_section', supplier_id=supplier.id, framework_slug=framework.slug, section_id=section.id)) }}
     {% call(item) summary.list_table(
@@ -47,7 +47,7 @@
     ) %}
       {% call summary.row() %}
         {{ summary.field_name(item.question) }}
-        {{ summary[item.type](declaration[item.id]) }}
+        {{ summary[item.type](item.value) }}
       {% endcall %}
     {% endcall %}
   {% endfor %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v15.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v1.1.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.1.2",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.0#egg=digitalmarketplace-content-loader==1.0.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@20.0.0#egg=digitalmarketplace-utils==20.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -463,7 +463,7 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
             def filter(*args):
                 return self.TestContent()
 
-        content_loader.get_builder.return_value = TestBuilder()
+        content_loader.get_manifest.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '20')
 
         # check title is there
@@ -506,6 +506,6 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
             def filter(*args):
                 return self.TestContent()
 
-        content_loader.get_builder.return_value = TestBuilder()
+        content_loader.get_manifest.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '50')
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Fixes this bug with declaration editing in the admin app: https://www.pivotaltracker.com/story/show/126406697

The first problem was that the frameworks version hadn't been bumped for an age, so the app didn't know about the DUNs number question at all and thought the address question was a text field when it has been split into a three-part multiquestion.

Once the new content was pulled in I needed to add a form macro for editing multiquestions.  This is simpler than the ones used in other apps, as we don't need to show question hints, etc. for admin editing.

Finally, the summary page wasn't quite doing things right in terms of the content loader - it was rendering questions from the content with values pulled directly from the declaration object without calling `.summary` which ties together questions with the answers given. Adding that call meant that the address multiquestion shows up OK in the summary page.

Summary table with address and DUNs number displayed
------------------------------------------------------------------
![screen shot 2016-08-03 at 17 38 16](https://cloud.githubusercontent.com/assets/6525554/17373682/397bf09a-59a1-11e6-9854-69e310adae52.png)

New form fields on the edit page
-------------------------------------
![screen shot 2016-08-03 at 17 38 25](https://cloud.githubusercontent.com/assets/6525554/17373818/d04aa6e2-59a1-11e6-8b7b-29e860856cd9.png)

![screen shot 2016-08-03 at 17 38 33](https://cloud.githubusercontent.com/assets/6525554/17373821/d3c6677a-59a1-11e6-81e0-9aef704ae1a3.png)

