### PR TITLE
Admin can extract buyer contact details and their briefs

### DIFF
--- a/app/main/helpers/csv_generator.py
+++ b/app/main/helpers/csv_generator.py
@@ -1,0 +1,22 @@
+import unicodecsv
+
+
+def iter_csv(rows, headers):
+
+    class Line(object):
+        def __init__(self):
+            self._line = None
+
+        def write(self, line):
+            self._line = line
+
+        def read(self):
+            return self._line
+
+    rows.insert(0, {header: header for header in headers})
+
+    line = Line()
+    writer = unicodecsv.writer(line)
+    for row in rows:
+        writer.writerow([row.get(header, '') for header in headers])
+        yield line.read()

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from flask import render_template, request, Response
 from flask_login import login_required, flash
+from datetime import datetime
 from ..helpers import csv_generator
 
 from .. import main
@@ -88,12 +89,12 @@ def download_buyers_and_briefs():
         "buyer_created",
         "briefs"
     ]
-
+    timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%S')
     return Response(
         csv_generator.iter_csv(buyer_rows, buyer_headings),
         mimetype='text/csv',
         headers={
-            "Content-Disposition": "attachment;filename=buyers.csv",
+            "Content-Disposition": "attachment;filename=buyers_{}.csv".format(timestamp),
             "Content-Type": "text/csv; header=present"
         }
     )

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 from flask import render_template, request, Response
 from flask_login import login_required, flash
+from ..helpers import csv_generator
 
-import unicodecsv
 from .. import main
 from ... import data_api_client
 from ..auth import role_required
@@ -65,29 +65,9 @@ def download_users(framework_slug):
         "application_result",
         "framework_agreement"
     ]
-    # insert header column
-    supplier_rows.insert(0, {header: header for header in supplier_headers})
-
-    def iter_csv(rows):
-
-        class Line(object):
-            def __init__(self):
-                self._line = None
-
-            def write(self, line):
-                self._line = line
-
-            def read(self):
-                return self._line
-
-        line = Line()
-        writer = unicodecsv.writer(line)
-        for row in rows:
-            writer.writerow([row.get(header, '') for header in supplier_headers])
-            yield line.read()
 
     return Response(
-        iter_csv(supplier_rows),
+        csv_generator.iter_csv(supplier_rows, supplier_headers),
         mimetype='text/csv',
         headers={
             "Content-Disposition": "attachment;filename=users-{}.csv".format(framework_slug),
@@ -109,28 +89,8 @@ def download_buyers_and_briefs():
         "briefs"
     ]
 
-    buyer_rows.insert(0, {header: header for header in buyer_headings})
-
-    def iter_csv(rows):
-
-        class Line(object):
-            def __init__(self):
-                self._line = None
-
-            def write(self, line):
-                self._line = line
-
-            def read(self):
-                return self._line
-
-        line = Line()
-        writer = unicodecsv.writer(line)
-        for row in rows:
-            writer.writerow([row.get(header, '') for header in buyer_headings])
-            yield line.read()
-
     return Response(
-        iter_csv(buyer_rows),
+        csv_generator.iter_csv(buyer_rows, buyer_headings),
         mimetype='text/csv',
         headers={
             "Content-Disposition": "attachment;filename=buyers.csv",

--- a/app/templates/download_users.html
+++ b/app/templates/download_users.html
@@ -37,7 +37,13 @@
 
   {% endif %}{# /if not frameworks_options #}
 
-    <p class='question-heading'>Please select a framework</p>
+    {%
+      with
+      smaller = true,
+      heading = "Suppliers"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
     {% for framework in framework_options %}
       {%
         with
@@ -51,6 +57,24 @@
         {% include "toolkit/browse-list.html" %}
       {% endwith %}
     {% endfor %}
+    {%
+      with
+      smaller = true,
+      heading = "Buyers"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    {%
+      with
+      items = [
+        {
+            "title": 'All frameworks',
+            "link": url_for('.download_buyers_and_briefs')
+        }
+      ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
 
 
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@20.0.0#egg=digitalmarketplace-utils==20.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.1.0#egg=digitalmarketplace-apiclient==6.1.0

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import unicode_literals
+from datetime import datetime
 
 import mock
 import copy
@@ -315,3 +316,14 @@ class TestBuyersExport(LoggedInApplicationTest):
         response = self.client.get('/admin/users/download/buyers')
 
         assert response.mimetype == 'text/csv'
+
+    def test_filename_includes_a_timestamp(self, data_api_client):
+        with mock.patch('app.main.views.users.datetime') as mock_date:
+            mock_date.utcnow.return_value = datetime(2016, 8, 5, 16, 0, 0)
+            data_api_client.export_buyers_with_briefs.return_value = {
+                "buyers": [{}]
+            }
+
+            response = self.client.get('/admin/users/download/buyers')
+            
+            assert response.headers[1][1] == 'attachment;filename=buyers_20160805T160000.csv'


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/124104161) story on Pivotal.

Admin's need to be able to extract a list of buyers with their contact details and their briefs.

This PR adds a link to the download user list page which hooks up to a new endpoint on the api. Api PR is [here](https://github.com/alphagov/digitalmarketplace-api/pull/430) and apiclient PR is [here](https://github.com/alphagov/digitalmarketplace-apiclient/pull/32)

Apiclient PR will need merging for tests to go green.

![download_buyer_csv](https://cloud.githubusercontent.com/assets/13836290/17441126/89a06510-5b27-11e6-8f60-d0ae0e736ba3.gif)
