### PR TITLE
Show briefs as open instead of live in csv

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -103,7 +103,7 @@ def download_buyers_and_briefs():
 
     for brief in briefs:
         for user in brief['users']:
-            brief_string = '{} - {}'.format(brief['title'], brief['status'])
+            brief_string = '{} - {}'.format(brief['title'], 'open' if brief['status'] == 'live' else brief['status'])
             buyers_dict[user['id']]['briefs'].append(brief_string)
 
     formatted_buyer_brief_rows = []

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -465,6 +465,33 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_two == [u'Topher', u'topher@gov.uk', u'01234567891', u'"Fri',
                              u' 05 Aug 2016 12:00:00 GMT"', u'This is a brief - draft']
 
+    def test_brief_status_is_output_as_open_instead_of_live(self, data_api_client):
+        data_api_client.find_users_iter.return_value = [
+            {
+                'id': 1,
+                "name": "Chris",
+                "emailAddress": "chris@gov.uk",
+                "phoneNumber": "01234567891",
+                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+            }
+        ]
+
+        data_api_client.find_briefs_iter.return_value = [
+            {
+                'title': 'This is a brief',
+                'status': 'live',
+                'users': [{
+                    'id': 1
+                }]
+            }
+        ]
+
+        response = self.client.get('/admin/users/download/buyers')
+        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
+        buyer = rows[1]
+
+        assert buyer[5] == u'This is a brief - open'
+
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
             {


### PR DESCRIPTION
Part of [this](https://www.pivotaltracker.com/story/show/124104161) story on Pivotal.

Briefs were being listed in the csv with their status as whatever their
status in the database is set at. To be more consistent with the rest of
the digitalmarketplace, if a brief's status is live it should be listed
as open in the csv.