### PR TITLE
Import api-client 6.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.6.0#egg=digitalmarketplace-utils==21.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.2.0#egg=digitalmarketplace-apiclient==6.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.3#egg=digitalmarketplace-apiclient==6.3.3


### PR DESCRIPTION
There was an issue with requests to the api from iter methods changing
the http protocol from http to https. The update on the apiclient fixes
it.