### PR TITLE
Break long emails

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -77,3 +77,7 @@ $path: "/admin/static/images/";
     font-weight: bold;
   }
 }
+
+.break-email {
+  word-break: break-all;
+}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -68,7 +68,11 @@ Countersign {{ framework.name }} agreement for {{ supplier.name }}
 
         <h2>Uploaded by</h2>
         <p class="padding-bottom-small">
-            {{ supplier_framework.agreementDetails.uploaderUserName }}, {{ supplier_framework.agreementDetails.uploaderUserEmail }}
+            {{ supplier_framework.agreementDetails.uploaderUserName }}
+            <br>
+            <span class="break-email">
+                {{ supplier_framework.agreementDetails.uploaderUserEmail }}
+            </span>
             <br>
             {{ supplier_framework.agreementReturnedAt|datetimeformat }}
         </p>

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1073,7 +1073,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         assert len(document.xpath('//p[contains(text(), "Ace Developer")]')) == 1
         # Uploader details
         assert len(document.xpath('//p[contains(text(), "Uploader Name")]')) == 1
-        assert len(document.xpath('//p[contains(text(), "uploader@email.com")]')) == 1
+        assert len(document.xpath('//span[contains(text(), "uploader@email.com")]')) == 1
 
     def test_should_embed_for_pdf_file(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')


### PR DESCRIPTION
This is an issue raised by @andrewchong when testing the page.  I'm not sure which looks worse to be honest, but at least we can see it here for discussion and put it in if we like the broken version more.

## Before
![screen shot 2016-08-26 at 15 13 05](https://cloud.githubusercontent.com/assets/6525554/18008554/850a06a8-6ba0-11e6-9c6b-b78b98de5c1d.png)

## After
![screen shot 2016-08-26 at 15 14 57](https://cloud.githubusercontent.com/assets/6525554/18008562/8a7a5188-6ba0-11e6-856f-1a75f572785b.png)

