### PR TITLE
[#128842227]view_signed_agreement: show lots supplier has applied for

### DIFF
--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -53,13 +53,12 @@ Countersign {{ framework.name }} agreement for {{ supplier.name }}
             {% endwith %}
         </div>
 
-        <!-- 
         <h2>Appointment is to</h2>
         <ul class="padding-bottom-small">
-            <li>Add lot names here</li>
-            <li>(<a href="https://www.pivotaltracker.com/story/show/128842227">see this story</a>)</li>
+          {% for lot_slug, lot_name in lot_slugs_names.items() %}
+            <li>{{ lot_name }}</li>
+          {% endfor %}
         </ul>
-        -->
         
         <h2>Signed by</h2>
         <p class="padding-bottom-small">


### PR DESCRIPTION
This is waiting on a decision about what `status` `Service`s to take into account when aggregating for the lots (see `TODO` comment in code).

Don't imagine we should be counting `DraftService`s too should we?