### PR TITLE
[#129915689]download_buyers_and_briefs: redesign to output rows of buyer-brief combinations instead of briefs aggregated to buyer rows…

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -100,12 +100,16 @@ def download_buyers_and_briefs():
         for user in brief["users"]:
             users[user["id"]]["briefs"].append(brief)
 
+    # not using DATETIME_FORMAT as we'll be using this in a filename and don't want any odd characters
     timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%S')
+
+    # "verbatim" fields have the same column heading as the dict key they're retrieved from
     user_verbatim_fields = (
         "name",
         "emailAddress",
         "phoneNumber",
     )
+    # "generated" fields have a column heading "label" and callable to generate the field value given a user(/brief)
     user_generated_fields = OrderedDict((
         (
             "createdAtDate",
@@ -148,7 +152,8 @@ def download_buyers_and_briefs():
                 (brief.get(field_name, "") for field_name in brief_verbatim_fields),
                 (func(brief) for func in itervalues(brief_generated_fields)),
             ))
-            for user, brief in chain.from_iterable(
+            for user, brief in chain.from_iterable(  # using from_iterable to flatten an iterable of iterables (of
+                                                     # (user, brief) pairs) into a single iterable
                 (
                     (user, brief) for brief in
                     (user["briefs"] or ({},))   # if user has an empty seq of briefs add a single fake blank

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,8 +1,14 @@
 from __future__ import unicode_literals
+
+from itertools import chain
+from collections import OrderedDict
+
 from flask import render_template, request, Response
 from flask_login import login_required, flash
 from datetime import datetime
 from dmutils import csv_generator
+from six import itervalues, iterkeys
+from unicodecsv import DictWriter
 
 from .. import main
 from ... import data_api_client
@@ -87,42 +93,66 @@ def download_users(framework_slug):
 @login_required
 @role_required('admin')
 def download_buyers_and_briefs():
-    buyers = (user for user in data_api_client.find_users_iter(role='buyer'))
-    briefs = (brief for brief in data_api_client.find_briefs_iter(with_users=True))
-    buyer_headings = [
+    users = {user["id"]: dict(user, briefs=[]) for user in data_api_client.find_users_iter(role="buyer")}
+
+    # join users with briefs (a "hash join")
+    for brief in data_api_client.find_briefs_iter(with_users=True):
+        for user in brief["users"]:
+            users[user["id"]]["briefs"].append(brief)
+
+    timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%S')
+    user_verbatim_fields = (
         "name",
         "emailAddress",
         "phoneNumber",
         "createdAt",
-        "briefs"
-    ]
+    )
+    # no user_generated_fields as of yet
+    brief_verbatim_fields = (
+        "title",
+    )
+    brief_generated_fields = OrderedDict((
+        (
+            "status",
+            lambda brief: "open" if brief.get("status") == "live" else brief.get("status", ""),
+        ),
+        (
+            "applicationsClosedAtIfClosed",
+            lambda brief: brief.get("applicationsClosedAt", "") if brief.get("status") == "closed" else "",
+        ),
+    ))
 
-    buyers_dict = {}
-    for buyer in buyers:
-        buyer['briefs'] = []
-        buyers_dict[buyer['id']] = buyer
-
-    for brief in briefs:
-        for user in brief['users']:
-            brief_string = '{} - {} - {}'.format(
-                brief['title'],
-                brief.get('location'),
-                'open' if brief['status'] == 'live' else brief['status'],
+    rows_iter = chain(
+        (
+            # header row
+            tuple(chain(
+                ("user.{}".format(field_name) for field_name in user_verbatim_fields),
+                # no user_generated_fields as of yet
+                ("brief.{}".format(field_name) for field_name in brief_verbatim_fields),
+                ("brief.{}".format(field_name) for field_name in iterkeys(brief_generated_fields)),
+            )),
+        ),
+        (
+            # data rows
+            tuple(chain(
+                (user.get(field_name, "") for field_name in user_verbatim_fields),
+                # no user_generated_fields as of yet
+                (brief.get(field_name, "") for field_name in brief_verbatim_fields),
+                (func(brief) for func in itervalues(brief_generated_fields)),
+            ))
+            for user, brief in chain.from_iterable(
+                (
+                    (user, brief) for brief in
+                    (user["briefs"] or ({},))   # if user has an empty seq of briefs add a single fake blank
+                                                # one ("outer join" behaviour)
+                )
+                for user in sorted(itervalues(users), key=lambda user: user["name"])
             )
-            buyers_dict[user['id']]['briefs'].append(brief_string)
-
-    formatted_buyer_brief_rows = []
-    for id_num, buyer_with_briefs in buyers_dict.items():
-        buyer_with_briefs['briefs'] = '; '.join(buyer_with_briefs['briefs'])
-        formatted_buyer_brief_rows.append([buyer_with_briefs.get(header, '') for header in buyer_headings])
-
-    formatted_buyer_brief_rows.sort(key=lambda x: x[0])
-    formatted_buyer_brief_rows.insert(0, buyer_headings)
-
-    timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%S')
+        ),
+    )
 
     return Response(
-        csv_generator.iter_csv(formatted_buyer_brief_rows),
+        csv_generator.iter_csv(rows_iter),
         mimetype='text/csv',
         headers={
             "Content-Disposition": "attachment;filename=buyers_{}.csv".format(timestamp),

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -115,6 +115,7 @@ def download_buyers_and_briefs():
     brief_verbatim_fields = (
         "title",
         "location",
+        "lotSlug",
     )
     brief_generated_fields = OrderedDict((
         (

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -110,6 +110,7 @@ def download_buyers_and_briefs():
     # no user_generated_fields as of yet
     brief_verbatim_fields = (
         "title",
+        "location",
     )
     brief_generated_fields = OrderedDict((
         (

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -113,6 +113,7 @@ def download_buyers_and_briefs():
         ),
     ))
     brief_verbatim_fields = (
+        "id",
         "title",
         "location",
         "lotSlug",

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -298,7 +298,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT",
+                "createdAt": "2016-08-04T12:00:00.000000Z",
             }
         ]
 
@@ -328,7 +328,7 @@ class TestBuyersExport(LoggedInApplicationTest):
             u'brief.title', u'brief.location', u'brief.status', u'brief.applicationsClosedAtIfClosed',
         ]
         assert buyer == [
-            u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
+            u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
             u'This is a brief', u'Wales', u'draft', u'',
         ]
 
@@ -339,7 +339,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-04T12:00:00.000000Z"
             },
         ]
 
@@ -370,11 +370,11 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
                 u'This is a brief', u'Wales', u'draft', u'',
             ],
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
                 u'This is a second brief', u'', u'draft', u'',
             ],
         ]
@@ -386,7 +386,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-04T12:00:00.000000Z",
             }
         ]
 
@@ -399,7 +399,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
                 u'', u'', u'', u'',
             ],
         ]
@@ -411,15 +411,15 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-04T12:00:00.000000Z",
             },
             {
                 'id': 2,
                 "name": "Topher",
                 "emailAddress": "topher@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Fri, 05 Aug 2016 12:00:00 GMT"
-            }
+                "createdAt": "2016-08-05T12:00:00.000000Z",
+            },
         ]
 
         data_api_client.find_briefs_iter.return_value = [
@@ -449,11 +449,11 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
                 u'This is a brief', u'London', u'draft', u'',
             ],
             [
-                u'Topher', u'topher@gov.uk', u'01234567891', u'"Fri', u' 05 Aug 2016 12:00:00 GMT"',
+                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05T12:00:00.000000Z',
                 u'This is a second brief', u'Wales', u'draft', u'',
             ],
         ]
@@ -465,15 +465,15 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-04T12:00:00.000000Z",
             },
             {
                 'id': 2,
                 "name": "Topher",
                 "emailAddress": "topher@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Fri, 05 Aug 2016 12:00:00 GMT"
-            }
+                "createdAt": "2016-08-05T12:00:00.000000Z",
+            },
         ]
 
         data_api_client.find_briefs_iter.return_value = [
@@ -501,11 +501,11 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
                 u'This is a brief', u'Wales', u'draft', u'',
             ],
             [
-                u'Topher', u'topher@gov.uk', u'01234567891', u'"Fri', u' 05 Aug 2016 12:00:00 GMT"',
+                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05T12:00:00.000000Z',
                 u'This is a brief', u'Wales', u'draft', u'',
             ],
         ]
@@ -517,7 +517,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-04T12:00:00.000000Z",
             }
         ]
 
@@ -539,7 +539,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[5:8] == [u'This is a brief', u'London', u'open']
+        assert buyer[4:7] == [u'This is a brief', u'London', u'open']
 
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -548,29 +548,29 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Zebedee",
                 "emailAddress": "zebedee@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-04T12:00:00.000000Z",
             },
             {
                 'id': 2,
                 "name": "Dougal",
                 "emailAddress": "dougal@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Fri, 05 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-05T12:00:00.000000Z",
             },
             {
                 'id': 3,
                 "name": "Brian",
                 "emailAddress": "brian@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Sat, 06 Aug 2016 12:00:00 GMT"
+                "createdAt": "2016-08-06T12:00:00.000000Z",
             },
             {
                 'id': 4,
                 "name": "Florence",
                 "emailAddress": "florence@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Sun, 07 Aug 2016 12:00:00 GMT"
-            }
+                "createdAt": "2016-08-07T12:00:00.000000Z",
+            },
         ]
 
         response = self.client.get('/admin/users/download/buyers')
@@ -588,8 +588,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
-            }
+                "createdAt": "2016-08-04T12:00:00.000000Z",
+            },
         ]
 
         data_api_client.find_briefs_iter.return_value = [
@@ -615,8 +615,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                     "name": "Chris",
                     "emailAddress": "chris@gov.uk",
                     "phoneNumber": "01234567891",
-                    "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
-                }
+                    "createdAt": "2016-08-04T12:00:00.000000Z",
+                },
             ]
 
             data_api_client.find_briefs_iter.return_value = [

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -310,6 +310,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                     'id': 1
                 }],
                 "location": "Wales",
+                "lotSlug": "magic-roundabout",
             }
         ]
 
@@ -324,12 +325,20 @@ class TestBuyersExport(LoggedInApplicationTest):
         buyer = rows[1]
 
         assert header == [
-            u'user.name', u'user.emailAddress', u'user.phoneNumber', u'user.createdAtDate',
-            u'brief.title', u'brief.location', u'brief.status', u'brief.applicationsClosedAtDateIfClosed',
+            u'user.name',
+            u'user.emailAddress',
+            u'user.phoneNumber',
+            u'user.createdAtDate',
+
+            u'brief.title',
+            u'brief.location',
+            u'brief.lotSlug',
+            u'brief.status',
+            u'brief.applicationsClosedAtDateIfClosed',
         ]
         assert buyer == [
             u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-            u'This is a brief', u'Wales', u'draft', u'',
+            u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
         ]
 
     def test_response_has_two_lines_for_buyer_if_multiple_briefs(self, data_api_client):
@@ -350,14 +359,16 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'location': 'Wales',
                 'users': [{
                     'id': 1
-                }]
+                }],
+                'lotSlug': 'magic-roundabout',
             },
             {
                 'title': 'This is a second brief',
                 'status': 'draft',
                 'users': [{
                     'id': 1
-                }]
+                }],
+                'lotSlug': 'manege-enchante',
             },
         ]
 
@@ -371,11 +382,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a brief', u'Wales', u'draft', u'',
+                u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
             ],
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a second brief', u'', u'draft', u'',
+                u'This is a second brief', u'', u'manege-enchante', u'draft', u'',
             ],
         ]
 
@@ -400,7 +411,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'', u'', u'', u'',
+                u'', u'', u'', u'', u'',
             ],
         ]
 
@@ -429,7 +440,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'status': 'draft',
                 'users': [{
                     'id': 1
-                }]
+                }],
+                'lotSlug': 'magic-roundabout',
             },
             {
                 'title': 'This is a second brief',
@@ -437,7 +449,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'status': 'draft',
                 'users': [{
                     'id': 2
-                }]
+                }],
+                'lotSlug': 'manege-enchante',
             }
         ]
 
@@ -450,11 +463,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a brief', u'London', u'draft', u'',
+                u'This is a brief', u'London', u'magic-roundabout', u'draft', u'',
             ],
             [
                 u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
-                u'This is a second brief', u'Wales', u'draft', u'',
+                u'This is a second brief', u'Wales', u'manege-enchante', u'draft', u'',
             ],
         ]
 
@@ -488,7 +501,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                     {
                         'id': 2
                     }
-                ]
+                ],
+                'lotSlug': 'magic-roundabout',
             }
         ]
 
@@ -502,11 +516,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a brief', u'Wales', u'draft', u'',
+                u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
             ],
             [
                 u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
-                u'This is a brief', u'Wales', u'draft', u'',
+                u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
             ],
         ]
 
@@ -530,6 +544,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                     'id': 1
                 }],
                 "applicationsClosedAt": "2016-09-05T12:00:00.000000Z",
+                'lotSlug': 'magic-roundabout',
             }
         ]
 
@@ -540,7 +555,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[4:] == [u"This is a brief", u"London", u"open", u"", ]
+        assert buyer[4:] == [u"This is a brief", u"London", u'magic-roundabout', u"open", u"", ]
 
     def test_brief_applications_closed_at_is_output_if_status_closed(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -562,6 +577,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                     'id': 1
                 }],
                 "applicationsClosedAt": "2016-09-05T12:00:00.000000Z",
+                'lotSlug': 'magic-roundabout',
             }
         ]
 
@@ -572,7 +588,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[4:] == [u"This is a brief", u"London", u"closed", u"2016-09-05", ]
+        assert buyer[4:] == [u"This is a brief", u"London", u'magic-roundabout', u"closed", u"2016-09-05", ]
 
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -631,7 +647,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'status': 'draft',
                 'users': [{
                     'id': 1
-                }]
+                }],
+                'lotSlug': 'magic-roundabout',
             }
         ]
 
@@ -658,7 +675,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                     'status': 'draft',
                     'users': [{
                         'id': 1
-                    }]
+                    }],
+                    'lotSlug': 'magic-roundabout',
                 }
             ]
 

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -528,7 +528,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'status': 'live',
                 'users': [{
                     'id': 1
-                }]
+                }],
+                "applicationsClosedAt": "2016-09-05T12:00:00.000000Z",
             }
         ]
 
@@ -539,7 +540,39 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[4:7] == [u'This is a brief', u'London', u'open']
+        assert buyer[4:] == [u"This is a brief", u"London", u"open", u"",]
+
+    def test_brief_applications_closed_at_is_output_if_status_closed(self, data_api_client):
+        data_api_client.find_users_iter.return_value = [
+            {
+                'id': 1,
+                "name": "Chris",
+                "emailAddress": "chris@gov.uk",
+                "phoneNumber": "01234567891",
+                "createdAt": "2016-08-04T12:00:00.000000Z",
+            }
+        ]
+
+        data_api_client.find_briefs_iter.return_value = [
+            {
+                'title': 'This is a brief',
+                'location': 'London',
+                'status': 'closed',
+                'users': [{
+                    'id': 1
+                }],
+                "applicationsClosedAt": "2016-09-05T12:00:00.000000Z",
+            }
+        ]
+
+        response = self.client.get('/admin/users/download/buyers')
+
+        assert response.status_code == 200
+
+        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
+        buyer = rows[1]
+
+        assert buyer[4:] == [u"This is a brief", u"London", u"closed", u"2016-09-05",]
 
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -324,11 +324,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         buyer = rows[1]
 
         assert header == [
-            u'user.name', u'user.emailAddress', u'user.phoneNumber', u'user.createdAt',
-            u'brief.title', u'brief.location', u'brief.status', u'brief.applicationsClosedAtIfClosed',
+            u'user.name', u'user.emailAddress', u'user.phoneNumber', u'user.createdAtDate',
+            u'brief.title', u'brief.location', u'brief.status', u'brief.applicationsClosedAtDateIfClosed',
         ]
         assert buyer == [
-            u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
+            u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
             u'This is a brief', u'Wales', u'draft', u'',
         ]
 
@@ -370,11 +370,11 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
                 u'This is a brief', u'Wales', u'draft', u'',
             ],
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
                 u'This is a second brief', u'', u'draft', u'',
             ],
         ]
@@ -399,7 +399,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
                 u'', u'', u'', u'',
             ],
         ]
@@ -449,11 +449,11 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
                 u'This is a brief', u'London', u'draft', u'',
             ],
             [
-                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05T12:00:00.000000Z',
+                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
                 u'This is a second brief', u'Wales', u'draft', u'',
             ],
         ]
@@ -501,11 +501,11 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert buyer_briefs == [
             [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04T12:00:00.000000Z',
+                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
                 u'This is a brief', u'Wales', u'draft', u'',
             ],
             [
-                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05T12:00:00.000000Z',
+                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
                 u'This is a brief', u'Wales', u'draft', u'',
             ],
         ]

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -298,7 +298,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT"
+                "createdAt": "Thu, 04 Aug 2016 12:00:00 GMT",
             }
         ]
 
@@ -308,7 +308,8 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'status': 'draft',
                 'users': [{
                     'id': 1
-                }]
+                }],
+                "location": "Wales",
             }
         ]
 
@@ -324,11 +325,11 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         assert header == [
             u'user.name', u'user.emailAddress', u'user.phoneNumber', u'user.createdAt',
-            u'brief.title', u'brief.status', u'brief.applicationsClosedAtIfClosed',
+            u'brief.title', u'brief.location', u'brief.status', u'brief.applicationsClosedAtIfClosed',
         ]
         assert buyer == [
             u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
-            u'This is a brief', u'draft', u'',
+            u'This is a brief', u'Wales', u'draft', u'',
         ]
 
     def test_response_has_two_lines_for_buyer_if_multiple_briefs(self, data_api_client):
@@ -370,11 +371,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
-                u'This is a brief', u'draft', u'',
+                u'This is a brief', u'Wales', u'draft', u'',
             ],
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
-                u'This is a second brief', u'draft', u'',
+                u'This is a second brief', u'', u'draft', u'',
             ],
         ]
 
@@ -399,7 +400,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
-                u'', u'', u'',
+                u'', u'', u'', u'',
             ],
         ]
 
@@ -449,11 +450,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
-                u'This is a brief', u'draft', u'',
+                u'This is a brief', u'London', u'draft', u'',
             ],
             [
                 u'Topher', u'topher@gov.uk', u'01234567891', u'"Fri', u' 05 Aug 2016 12:00:00 GMT"',
-                u'This is a second brief', u'draft', u'',
+                u'This is a second brief', u'Wales', u'draft', u'',
             ],
         ]
 
@@ -501,11 +502,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'"Thu', u' 04 Aug 2016 12:00:00 GMT"',
-                u'This is a brief', u'draft', u'',
+                u'This is a brief', u'Wales', u'draft', u'',
             ],
             [
                 u'Topher', u'topher@gov.uk', u'01234567891', u'"Fri', u' 05 Aug 2016 12:00:00 GMT"',
-                u'This is a brief', u'draft', u'',
+                u'This is a brief', u'Wales', u'draft', u'',
             ],
         ]
 
@@ -538,7 +539,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[5:7] == [u'This is a brief', u'open']
+        assert buyer[5:8] == [u'This is a brief', u'London', u'open']
 
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -304,6 +304,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         data_api_client.find_briefs_iter.return_value = [
             {
+                'id': 321,
                 'title': 'This is a brief',
                 'status': 'draft',
                 'users': [{
@@ -330,6 +331,7 @@ class TestBuyersExport(LoggedInApplicationTest):
             u'user.phoneNumber',
             u'user.createdAtDate',
 
+            u'brief.id',
             u'brief.title',
             u'brief.location',
             u'brief.lotSlug',
@@ -338,7 +340,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         ]
         assert buyer == [
             u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-            u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
+            u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
         ]
 
     def test_response_has_two_lines_for_buyer_if_multiple_briefs(self, data_api_client):
@@ -348,12 +350,13 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "name": "Chris",
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z"
+                "createdAt": "2016-08-04T12:00:00.000000Z",
             },
         ]
 
         data_api_client.find_briefs_iter.return_value = [
             {
+                'id': 321,
                 'title': 'This is a brief',
                 'status': 'draft',
                 'location': 'Wales',
@@ -363,6 +366,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'lotSlug': 'magic-roundabout',
             },
             {
+                'id': 432,
                 'title': 'This is a second brief',
                 'status': 'draft',
                 'users': [{
@@ -382,11 +386,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
+                u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
             ],
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a second brief', u'', u'manege-enchante', u'draft', u'',
+                u'432', u'This is a second brief', u'', u'manege-enchante', u'draft', u'',
             ],
         ]
 
@@ -411,7 +415,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'', u'', u'', u'', u'',
+                u'', u'', u'', u'', u'', u'',
             ],
         ]
 
@@ -435,6 +439,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         data_api_client.find_briefs_iter.return_value = [
             {
+                'id': 321,
                 'title': 'This is a brief',
                 'location': 'London',
                 'status': 'draft',
@@ -444,6 +449,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 'lotSlug': 'magic-roundabout',
             },
             {
+                'id': 432,
                 'title': 'This is a second brief',
                 'location': 'Wales',
                 'status': 'draft',
@@ -463,11 +469,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a brief', u'London', u'magic-roundabout', u'draft', u'',
+                u'321', u'This is a brief', u'London', u'magic-roundabout', u'draft', u'',
             ],
             [
                 u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
-                u'This is a second brief', u'Wales', u'manege-enchante', u'draft', u'',
+                u'432', u'This is a second brief', u'Wales', u'manege-enchante', u'draft', u'',
             ],
         ]
 
@@ -491,6 +497,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         data_api_client.find_briefs_iter.return_value = [
             {
+                'id': 321,
                 'title': 'This is a brief',
                 'status': 'draft',
                 'location': 'Wales',
@@ -516,11 +523,11 @@ class TestBuyersExport(LoggedInApplicationTest):
         assert buyer_briefs == [
             [
                 u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
+                u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
             ],
             [
                 u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
-                u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
+                u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
             ],
         ]
 
@@ -537,6 +544,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         data_api_client.find_briefs_iter.return_value = [
             {
+                'id': 321,
                 'title': 'This is a brief',
                 'location': 'London',
                 'status': 'live',
@@ -555,7 +563,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[4:] == [u"This is a brief", u"London", u'magic-roundabout', u"open", u"", ]
+        assert buyer[4:] == [u"321", u"This is a brief", u"London", u'magic-roundabout', u"open", u"", ]
 
     def test_brief_applications_closed_at_is_output_if_status_closed(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -570,6 +578,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         data_api_client.find_briefs_iter.return_value = [
             {
+                'id': 321,
                 'title': 'This is a brief',
                 'location': 'London',
                 'status': 'closed',
@@ -588,7 +597,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[4:] == [u"This is a brief", u"London", u'magic-roundabout', u"closed", u"2016-09-05", ]
+        assert buyer[4:] == [u"321", u"This is a brief", u"London", u'magic-roundabout', u"closed", u"2016-09-05", ]
 
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -643,6 +652,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         data_api_client.find_briefs_iter.return_value = [
             {
+                'id': 321,
                 'title': 'This is a brief',
                 'status': 'draft',
                 'users': [{
@@ -671,6 +681,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
             data_api_client.find_briefs_iter.return_value = [
                 {
+                    'id': 321,
                     'title': 'This is a brief',
                     'status': 'draft',
                     'users': [{

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -540,7 +540,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[4:] == [u"This is a brief", u"London", u"open", u"",]
+        assert buyer[4:] == [u"This is a brief", u"London", u"open", u"", ]
 
     def test_brief_applications_closed_at_is_output_if_status_closed(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -572,7 +572,7 @@ class TestBuyersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
         buyer = rows[1]
 
-        assert buyer[4:] == [u"This is a brief", u"London", u"closed", u"2016-09-05",]
+        assert buyer[4:] == [u"This is a brief", u"London", u"closed", u"2016-09-05", ]
 
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/129915689

Tried to implement this in a nice declarative, functional way.

Ended up using a standard `Writer` in the end instead of a `DictWriter` as I decided the overhead of creating & merging all the intermediate dicts wasn't worth it.