### PR TITLE
Add buttons to set framework agreements as 'on hold' or 'countersigned'

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -79,7 +79,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>', methods=['GET'])
 @login_required
-@role_required('admin-ccs-sourcing')
+@role_required('admin', 'admin-ccs-sourcing')
 def view_signed_agreement(supplier_id, framework_slug):
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
@@ -116,6 +116,38 @@ def view_signed_agreement(supplier_id, framework_slug):
         lot_slugs_names=lot_slugs_names,
         agreement_url=url,
         agreement_ext=agreement_documents[-1]['ext']
+    )
+
+
+@main.route('/suppliers/agreements/<agreement_id>/on-hold', methods=['POST'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def put_signed_agreement_on_hold(agreement_id):
+    data_api_client.put_signed_agreement_on_hold(agreement_id, current_user.email_address)
+
+    organisation = request.args['organisation']
+    flash('The agreement for {} was put on hold.'.format(organisation), 'message')
+
+    return redirect(url_for(
+        '.list_agreements',
+        framework_slug='g-cloud-8')
+    )
+
+
+@main.route('/suppliers/agreements/<agreement_id>/approve', methods=['POST'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def approve_agreement_for_countersignature(agreement_id):
+    data_api_client.approve_agreement_for_countersignature(agreement_id,
+                                                           current_user.email_address,
+                                                           current_user.id)
+
+    organisation = request.args['organisation']
+    flash('A confirmation was sent to {}.'.format(organisation), 'message')
+
+    return redirect(url_for(
+        '.list_agreements',
+        framework_slug='g-cloud-8')
     )
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -125,7 +125,7 @@ def view_signed_agreement(supplier_id, framework_slug):
 def put_signed_agreement_on_hold(agreement_id):
     data_api_client.put_signed_agreement_on_hold(agreement_id, current_user.email_address)
 
-    organisation = request.args['organisation']
+    organisation = request.form['nameOfOrganisation']
     flash('The agreement for {} was put on hold.'.format(organisation), 'message')
 
     return redirect(url_for(
@@ -141,9 +141,9 @@ def approve_agreement_for_countersignature(agreement_id):
     data_api_client.approve_agreement_for_countersignature(agreement_id,
                                                            current_user.email_address,
                                                            current_user.id)
-
-    organisation = request.args['organisation']
-    flash('A confirmation was sent to {}.'.format(organisation), 'message')
+    organisation = request.form['nameOfOrganisation']
+    flash('The agreement for {} was approved. They will receive a countersigned version soon.'
+          .format(organisation), 'message')
 
     return redirect(url_for(
         '.list_agreements',

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -3,7 +3,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-Countersign {{ framework.name }} agreement for {{ supplier.name }}
+Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }}
 {% endblock %}
 
 {% block breadcrumb %}
@@ -24,86 +24,115 @@ Countersign {{ framework.name }} agreement for {{ supplier.name }}
 {% endblock %}
 
 {% block main_content %}
-<div class='grid-row'>
 
-    <div class="column-one-third">
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
         {%
-            with
-            heading = supplier.name,
-            smaller = True
+          with
+          message = message,
+          type = "success"
         %}
-        {% include "toolkit/page-heading.html" %}
+          {% include "toolkit/notification-banner.html" %}
         {% endwith %}
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
 
-        <h2>Registered address</h2>
-        <ul class="padding-bottom-small">
-            <li>{{ supplier_framework.declaration.registeredAddressBuilding }}</li>
-            <li>{{ supplier_framework.declaration.registeredAddressTown }}</li>
-            <li>{{ supplier_framework.declaration.registeredAddressPostcode }}</li>
-        </ul>
-        
-        <h2>Company number</h2>
-        <div class="padding-bottom-small">
-            {%
-            with
-                text = supplier_framework.declaration.companyRegistrationNumber,
-                link = "https://beta.companieshouse.gov.uk/company/%s" | format(supplier_framework.declaration.companyRegistrationNumber)
-            %}
-            {% include "toolkit/external-link.html" %}
-            {% endwith %}
-        </div>
 
-        <h2>Appointment is to</h2>
-        <ul class="padding-bottom-small">
-          {% for lot_slug, lot_name in lot_slugs_names.items() %}
-            <li>{{ lot_name }}</li>
-          {% endfor %}
-        </ul>
-        
-        <h2>Signed by</h2>
+<div class='grid-row'>
+  <div class="column-one-third">
+      {%
+          with
+          heading = supplier_framework.declaration.nameOfOrganisation,
+          smaller = True
+      %}
+      {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+
+      <h2>Registered address</h2>
+      <ul class="padding-bottom-small">
+          <li>{{ supplier_framework.declaration.registeredAddressBuilding }}</li>
+          <li>{{ supplier_framework.declaration.registeredAddressTown }}</li>
+          <li>{{ supplier_framework.declaration.registeredAddressPostcode }}</li>
+      </ul>
+
+      <h2>Company number</h2>
+      <div class="padding-bottom-small">
+          {%
+          with
+              text = supplier_framework.declaration.companyRegistrationNumber,
+              link = "https://beta.companieshouse.gov.uk/company/%s" | format(supplier_framework.declaration.companyRegistrationNumber),
+              target = _blank
+          %}
+          {% include "toolkit/external-link.html" %}
+          {% endwith %}
+      </div>
+
+      <h2>Appointment is to</h2>
+      <ul class="padding-bottom-small">
+        {% for lot_slug, lot_name in lot_slugs_names.items() %}
+          <li>{{ lot_name }}</li>
+        {% endfor %}
+      </ul>
+
+      <h2>Signed by</h2>
+      <p class="padding-bottom-small">
+          {{ supplier_framework.agreementDetails.signerName}}, {{ supplier_framework.agreementDetails.signerRole }}
+      </p>
+
+      <h2>Uploaded by</h2>
+      <p class="padding-bottom-small">
+          {{ supplier_framework.agreementDetails.uploaderUserName }}
+          <br>
+          <span class="break-email">
+              {{ supplier_framework.agreementDetails.uploaderUserEmail }}
+          </span>
+          <br>
+          {{ supplier_framework.agreementReturnedAt|datetimeformat }}
+      </p>
+
+      {% if supplier_framework.agreementStatus in ['approved', 'countersigned'] %}
+        <h2>Accepted by</h2>
         <p class="padding-bottom-small">
-            {{ supplier_framework.agreementDetails.signerName}}, {{ supplier_framework.agreementDetails.signerRole }}
+          {{ supplier_framework.countersignedDetails.approvedByUserName }}
+          <br>
+          {{ supplier_framework.countersignedAt|datetimeformat }}
         </p>
 
-        <h2>Uploaded by</h2>
-        <p class="padding-bottom-small">
-            {{ supplier_framework.agreementDetails.uploaderUserName }}
-            <br>
-            <span class="break-email">
-                {{ supplier_framework.agreementDetails.uploaderUserEmail }}
-            </span>
-            <br>
-            {{ supplier_framework.agreementReturnedAt|datetimeformat }}
-        </p>
-
-        <!-- 
-        <form action="{# url_for('.countersign_agreement', etc) #}">
+      {% elif current_user.role == 'admin-ccs-sourcing' %}
+        <form action="{{ url_for('.approve_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, organisation=supplier_framework.declaration.nameOfOrganisation) }}" method="post">
+          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
             {%
               with
               type = "save",
               label = "Accept and continue"
             %}
-                {% include "toolkit/button.html" %}
-            {% endwith %}
-        </form>
-
-        <form action="{# url_for('.put_agreement_on_hold', etc) #}">
-            {%
-              with
-              type = "secondary",
-              label = "Put on hold and continue"
-            %}
               {% include "toolkit/button.html" %}
             {% endwith %}
         </form>
-        -->
-    </div>
-
-    <div class="column-two-thirds">
-        {% if agreement_ext == 'pdf' %}
-            <embed src="{{ agreement_url }}" class="border-image" height="930" type="application/pdf">
-        {% else %}
-            <img src="{{ agreement_url }}" class="border-image" >
+        {% if supplier_framework.agreementStatus != 'on hold' %}
+          <form action="{{ url_for('.put_signed_agreement_on_hold', agreement_id=supplier_framework.agreementId, organisation=supplier_framework.declaration.nameOfOrganisation) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+              {%
+                with
+                type = "secondary",
+                label = "Put on hold and continue"
+              %}
+                {% include "toolkit/button.html" %}
+              {% endwith %}
+          </form>
         {% endif %}
-    </div>
+      {% endif %}
+
+
+  </div>
+
+  <div class="column-two-thirds">
+      {% if agreement_ext == 'pdf' %}
+          <embed src="{{ agreement_url }}" class="border-image" height="930" type="application/pdf">
+      {% else %}
+          <img src="{{ agreement_url }}" class="border-image" >
+      {% endif %}
+  </div>
 {% endblock %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -101,26 +101,28 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
         </p>
 
       {% elif current_user.role == 'admin-ccs-sourcing' %}
-        <form action="{{ url_for('.approve_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, organisation=supplier_framework.declaration.nameOfOrganisation) }}" method="post">
+        <form action="{{ url_for('.approve_agreement_for_countersignature', agreement_id=supplier_framework.agreementId) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+          <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
+          {%
+            with
+            type = "save",
+            label = "Accept and continue"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        </form>
+        {% if supplier_framework.agreementStatus != 'on hold' %}
+          <form action="{{ url_for('.put_signed_agreement_on_hold', agreement_id=supplier_framework.agreementId) }}" method="post">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
             {%
               with
-              type = "save",
-              label = "Accept and continue"
+              type = "secondary",
+              label = "Put on hold and continue"
             %}
               {% include "toolkit/button.html" %}
             {% endwith %}
-        </form>
-        {% if supplier_framework.agreementStatus != 'on hold' %}
-          <form action="{{ url_for('.put_signed_agreement_on_hold', agreement_id=supplier_framework.agreementId, organisation=supplier_framework.declaration.nameOfOrganisation) }}" method="post">
-            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-              {%
-                with
-                type = "secondary",
-                label = "Put on hold and continue"
-              %}
-                {% include "toolkit/button.html" %}
-              {% endwith %}
           </form>
         {% endif %}
       {% endif %}

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v15.13.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.2.0",
     "hogan": "3.0.2",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.2.0",
     "hogan": "3.0.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.6.0#egg=digitalmarketplace-utils==21.6.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.3#egg=digitalmarketplace-apiclient==6.3.3
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.2.0#egg=digitalmarketplace-apiclient==7.2.0

--- a/tests/app/main/helpers/flash_tester.py
+++ b/tests/app/main/helpers/flash_tester.py
@@ -1,0 +1,8 @@
+def assert_flashes(self, expected_message, expected_category='message'):
+    with self.client.session_transaction() as session:
+        try:
+            category, message = session['_flashes'][0]
+        except KeyError:
+            raise AssertionError('nothing flashed')
+        assert expected_message in message
+        assert expected_category in category

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1154,7 +1154,7 @@ class TestPutSignedAgreementOnHold(LoggedInApplicationTest):
         data_api_client.put_signed_agreement_on_hold.assert_called_once_with('123', 'test@example.com')
 
     def test_it_correctly_sets_the_flash_message(self, data_api_client):
-        self.client.post("/admin/suppliers/agreements/123/on-hold?organisation=Test")
+        self.client.post("/admin/suppliers/agreements/123/on-hold", data=dict(nameOfOrganisation='Test'))
 
         assert_flashes(self, "The agreement for Test was put on hold.")
 
@@ -1177,9 +1177,9 @@ class TestApproveAgreement(LoggedInApplicationTest):
                                                                                        '1234')
 
     def test_it_correctly_sets_the_flash_message(self, data_api_client):
-        self.client.post("/admin/suppliers/agreements/123/approve?organisation=Test")
+        self.client.post("/admin/suppliers/agreements/123/approve", data=dict(nameOfOrganisation='Test'))
 
-        assert_flashes(self, "A confirmation was sent to Test.")
+        assert_flashes(self, "The agreement for Test was approved. They will receive a countersigned version soon.")
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -13,6 +13,7 @@ from dmapiclient import HTTPError, APIError
 from dmutils.email import MandrillException
 from dmapiclient.audit import AuditTypes
 from ...helpers import LoggedInApplicationTest, Response
+from ..helpers.flash_tester import assert_flashes
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -1007,13 +1008,6 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
 class TestViewingASupplierDeclaration(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
-    def test_should_not_be_visible_to_admin_users(self, s3, data_api_client):
-        self.user_role = 'admin'
-
-        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
-
-        eq_(response.status_code, 403)
-
     def test_should_404_if_supplier_does_not_exist(self, s3, data_api_client):
         data_api_client.get_supplier.side_effect = APIError(Response(404))
 
@@ -1142,3 +1136,137 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
             eq_(response.status_code, 200)
             assert len(document.xpath('//img[@src="http://example.com/document/1234.png"]')) == 1
             assert len(document.xpath('//embed[@src="http://example.com/document/1234.png"]')) == 0
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
+class TestPutSignedAgreementOnHold(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_it_fails_if_not_ccs_admin(self, data_api_client):
+        self.user_role = 'admin'
+        res = self.client.post('/admin/suppliers/agreements/123/on-hold')
+
+        assert res.status_code == 403
+
+    def test_it_correctly_calls_the_apiclient(self, data_api_client):
+        res = self.client.post('/admin/suppliers/agreements/123/on-hold')
+
+        data_api_client.put_signed_agreement_on_hold.assert_called_once_with('123', 'test@example.com')
+
+    def test_it_correctly_sets_the_flash_message(self, data_api_client):
+        self.client.post("/admin/suppliers/agreements/123/on-hold?organisation=Test")
+
+        assert_flashes(self, "The agreement for Test was put on hold.")
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
+class TestApproveAgreement(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def test_it_fails_if_not_ccs_admin(self, data_api_client):
+        self.user_role = 'admin'
+        res = self.client.post('/admin/suppliers/agreements/123/approve')
+
+        assert res.status_code == 403
+
+    def test_it_correctly_calls_the_apiclient(self, data_api_client):
+        res = self.client.post('/admin/suppliers/agreements/123/approve')
+
+        data_api_client.approve_agreement_for_countersignature.assert_called_once_with('123',
+                                                                                       'test@example.com',
+                                                                                       '1234')
+
+    def test_it_correctly_sets_the_flash_message(self, data_api_client):
+        self.client.post("/admin/suppliers/agreements/123/approve?organisation=Test")
+
+        assert_flashes(self, "A confirmation was sent to Test.")
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.get_signed_url')
+@mock.patch('app.main.views.suppliers.s3')
+class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
+    user_role = 'admin-ccs-sourcing'
+
+    def set_mocks(self, s3, get_signed_url, data_api_client, **kwargs):
+        data_api_client.get_supplier.return_value = {
+            'suppliers': {}
+        }
+        data_api_client.get_framework.return_value = {
+            'frameworks': {
+                'frameworkAgreementVersion': 'v1.0'
+            }
+        }
+        data_api_client.get_supplier_framework_info.return_value = {
+            'frameworkInterest': {
+                'agreementReturned': True,
+                'agreementStatus': kwargs['agreement_status'],
+                'declaration': '',
+                'agreementDetails': {},
+                'countersignedDetails': {}
+            }
+        }
+        data_api_client.find_services_iter.return_value = []
+        get_signed_url.return_value = '#'
+        s3.S3.return_value.list.return_value = [
+            {'path': 'g-cloud-8/agreements/1234/1234-signed-framework-agreement.png',
+             'ext': 'pdf'}
+        ]
+
+    def test_none_shown_if_user_not_ccs_admin(self, s3, get_signed_url, data_api_client):
+        self.user_role = 'admin'
+        self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='signed')
+
+        res = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'Accept and continue' not in data
+        assert 'Put on hold and continue' not in data
+
+    def test_both_shown_if_ccs_admin_and_agreement_signed(self, s3, get_signed_url, data_api_client):
+        self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='signed')
+
+        res = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'Accept and continue' in data
+        assert 'Put on hold and continue' in data
+
+    def test_only_counter_sign_shown_if_agreement_on_hold(self, s3, get_signed_url, data_api_client):
+        self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='on hold')
+
+        res = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'Accept and continue' in data
+        assert 'Put on hold and continue' not in data
+
+    def test_none_shown_if_agreement_approved(self, s3, get_signed_url, data_api_client):
+        self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='approved')
+
+        res = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'Accept and continue' not in data
+        assert 'Put on hold and continue' not in data
+        assert 'Accepted by' in data
+
+    def test_none_shown_if_agreement_countersigned(self, s3, get_signed_url, data_api_client):
+        self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='countersigned')
+
+        res = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+
+        assert 'Accept and continue' not in data
+        assert 'Put on hold and continue' not in data
+        assert 'Accepted by' in data


### PR DESCRIPTION
For [this story on Pivotal](https://www.pivotaltracker.com/story/show/128842457).
Also for [this bug on Pivotal](https://www.pivotaltracker.com/story/show/130099083).

This PR adds couple of POST routes to the admin frontend which hit the API and timestamp the relevant `framework_agreement` to show when they were countersigned or put on hold.

If countersigned some details are also stored about who legally countersigned as well as who actually hit the button.

STILL TO DO:
Currently, the post routes return the user to the framework agreement they were working on. This is not the expected behaviour. It should take the user to the next framework agreement that needs countersigning/putting on hold. The logic for getting this next agreement is a separate piece of work outside the scope of this story.


Will need [this PR on the toolkit to be merged before the tests will go green](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/274)