### PR TITLE
[#131440081] Use a framework-specific manifest for editing services

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,10 +20,16 @@ feature_flags = flask_featureflags.FeatureFlag()
 login_manager = LoginManager()
 
 content_loader = ContentLoader('app/content')
+
 content_loader.load_manifest('g-cloud-6', 'services', 'edit_service_as_admin')
+content_loader.load_manifest('g-cloud-7', 'services', 'edit_service_as_admin')
+content_loader.load_manifest('g-cloud-8', 'services', 'edit_service_as_admin')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_service_as_admin')
+
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
-content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
 content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')
+
+content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
 
 from app.main.helpers.service import parse_document_upload_time
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -49,7 +49,7 @@ def view(service_id):
         return redirect(url_for('.index'))
 
     service_data['priceString'] = format_service_price(service_data)
-    content = content_loader.get_manifest('g-cloud-6', 'edit_service_as_admin').filter(service_data)
+    content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
 
     return render_template(
         "view_service.html",
@@ -99,7 +99,7 @@ def update_service_status(service_id):
 def edit(service_id, section):
     service_data = data_api_client.get_service(service_id)['services']
 
-    content = content_loader.get_manifest('g-cloud-6', 'edit_service_as_admin').filter(service_data)
+    content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
 
     return render_template(
         "edit_section.html",
@@ -186,7 +186,7 @@ def update(service_id, section_id):
         abort(404)
     service = service['services']
 
-    content = content_loader.get_manifest('g-cloud-6', 'edit_service_as_admin').filter(service)
+    content = content_loader.get_manifest(service['frameworkSlug'], 'edit_service_as_admin').filter(service)
     section = content.get_section(section_id)
     if section is None or not section.editable:
         abort(404)

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v15.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.1.2",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.2.0",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -13,7 +13,9 @@ from ...helpers import LoggedInApplicationTest
 class TestServiceView(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_response(self, data_api_client):
-        data_api_client.get_service.return_value = {'services': {}}
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'g-cloud-8'
+        }}
         response = self.client.get('/admin/services/1')
 
         data_api_client.get_service.assert_called_with('1')
@@ -22,7 +24,9 @@ class TestServiceView(LoggedInApplicationTest):
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_view_with_no_features_or_benefits(self, data_api_client):
-        data_api_client.get_service.return_value = {'services': {}}
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'g-cloud-8'
+        }}
         response = self.client.get('/admin/services/1')
 
         data_api_client.get_service.assert_called_with('1')
@@ -45,19 +49,22 @@ class TestServiceView(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
     def test_independence_of_viewing_services(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
-            'lot': 'SCS'
+            'lot': 'SCS',
+            'frameworkSlug': 'g-cloud-8',
         }}
         response = self.client.get('/admin/services/1')
         self.assertIn(b'Termination cost', response.data)
 
         data_api_client.get_service.return_value = {'services': {
-            'lot': 'SaaS'
+            'lot': 'SaaS',
+            'frameworkSlug': 'g-cloud-8',
         }}
         response = self.client.get('/admin/services/1')
         self.assertNotIn(b'Termination cost', response.data)
 
         data_api_client.get_service.return_value = {'services': {
-            'lot': 'SCS'
+            'lot': 'SCS',
+            'frameworkSlug': 'g-cloud-8',
         }}
         response = self.client.get('/admin/services/1')
         self.assertIn(b'Termination cost', response.data)
@@ -65,8 +72,21 @@ class TestServiceView(LoggedInApplicationTest):
 
 class TestServiceEdit(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
+    def test_edit_dos_service_title(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'digital-outcomes-and-specialists'
+        }}
+        response = self.client.get('/admin/services/1/edit/description')
+
+        data_api_client.get_service.assert_called_with('1')
+
+        assert response.status_code == 200
+
+    @mock.patch('app.main.views.services.data_api_client')
     def test_service_edit_documents_get_response(self, data_api_client):
-        data_api_client.get_service.return_value = {'services': {}}
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'g-cloud-8'
+        }}
         response = self.client.get('/admin/services/1/edit/documents')
 
         data_api_client.get_service.assert_called_with('1')
@@ -161,6 +181,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
             'supplierId': 2,
+            'frameworkSlug': 'g-cloud-8',
             'lot': 'IaaS',
             'serviceFeatures': [
                 "bar",
@@ -196,7 +217,8 @@ class TestServiceEdit(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_edit_with_no_features_or_benefits(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
-            'lot': 'SaaS'
+            'lot': 'SaaS',
+            'frameworkSlug': 'g-cloud-8',
         }}
         response = self.client.get(
             '/admin/services/1/edit/features-and-benefits')
@@ -240,6 +262,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_cannot_make_removed_service_public(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
+            'frameworkSlug': 'g-cloud-8',
             'supplierId': 2,
             'status': 'disabled'
         }}
@@ -251,6 +274,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_can_make_private_service_public_or_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
+            'frameworkSlug': 'g-cloud-8',
             'supplierId': 2,
             'status': 'enabled'
         }}
@@ -262,6 +286,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_can_make_public_service_private_or_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
+            'frameworkSlug': 'g-cloud-8',
             'supplierId': 2,
             'status': 'published'
         }}
@@ -271,7 +296,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         self.assertIn(b'<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />', response.data)  # noqa
 
     def test_status_update_to_removed(self, data_api_client):
-        data_api_client.get_service.return_value = {'services': {}}
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'g-cloud-7',
+        }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'removed'})
         data_api_client.update_service_status.assert_called_with(
@@ -284,7 +311,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
                       response2.data)
 
     def test_status_update_to_private(self, data_api_client):
-        data_api_client.get_service.return_value = {'services': {}}
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'g-cloud-8',
+        }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'private'})
         data_api_client.update_service_status.assert_called_with(
@@ -297,7 +326,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
                       response2.data)
 
     def test_status_update_to_published(self, data_api_client):
-        data_api_client.get_service.return_value = {'services': {}}
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'digital-outcomes-and-specialists',
+        }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'public'})
         data_api_client.update_service_status.assert_called_with(
@@ -310,6 +341,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
                       response2.data)
 
     def test_bad_status_gives_error_message(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkSlug': 'g-cloud-7',
+        }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'suspended'})
         self.assertEquals(302, response1.status_code)


### PR DESCRIPTION
Service update view always used g-cloud-6 manifest for editing services, which happened to work for DOS services since most G-Cloud questions explicitly list service lots.

Updating the view to use a separate manifest for each framework.

Adds loading manifests for G7, G8 and DOS. Also updates frameworks content to allow editing 'Support' section for G-Cloud services and titles for DOS user research labs.