### PR TITLE
Use file paths from FrameworkAgreements to find agreement files

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,9 +1,9 @@
+from dmutils.documents import degenerate_document_path_and_return_doc_name
 from flask import render_template
 from flask_login import login_required
 from dateutil.parser import parse as parse_date
 
 from dmutils.formats import datetimeformat
-from dmutils.documents import SIGNED_AGREEMENT_PREFIX
 
 from .. import main
 from ..auth import role_required
@@ -31,5 +31,5 @@ def list_agreements(framework_slug):
         "view_agreements_g8.html" if framework_slug == "g-cloud-8" else 'view_agreements.html',
         framework=framework,
         supplier_frameworks=supplier_frameworks,
-        signed_agreement_prefix=SIGNED_AGREEMENT_PREFIX
+        degenerate_document_path_and_return_doc_name=lambda x: degenerate_document_path_and_return_doc_name(x)
     )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, redirect, url_for, flash, current_app, abort
+from flask import abort, current_app, flash, redirect, render_template, request, url_for
 from flask_login import login_required, current_user
 from datetime import datetime
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -14,7 +14,7 @@ from dmutils.email import send_email, generate_token, MandrillException
 from dmutils.documents import (
     get_signed_url, get_agreement_document_path, file_is_pdf,
     AGREEMENT_FILENAME, SIGNED_AGREEMENT_PREFIX, COUNTERSIGNED_AGREEMENT_FILENAME,
-)
+    get_extension)
 from dmutils import s3
 from dmutils.formats import datetimeformat
 
@@ -100,11 +100,7 @@ def view_signed_agreement(supplier_id, framework_slug):
     )
 
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    prefix = get_agreement_document_path(framework_slug, supplier_id, SIGNED_AGREEMENT_PREFIX)
-    agreement_documents = agreements_bucket.list(prefix=prefix)
-    if not len(agreement_documents):
-        abort(404)
-    path = agreement_documents[-1]['path']
+    path = supplier_framework['agreementPath']
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
         abort(404)
@@ -115,7 +111,7 @@ def view_signed_agreement(supplier_id, framework_slug):
         supplier_framework=supplier_framework,
         lot_slugs_names=lot_slugs_names,
         agreement_url=url,
-        agreement_ext=agreement_documents[-1]['ext']
+        agreement_ext=get_extension(path)
     )
 
 

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -85,7 +85,7 @@
       {{ summary.field_name("{} countersigned agreement".format(framework.name)) }}
       {{ summary.text(countersigned_agreement.last_modified) }}
       {% call summary.field(wide=True) %}
-        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug, document_name=countersigned_agreement_filename) }}" download>Download agreement</a>
+        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug, document_name=countersigned_agreement.document_name) }}" download>Download agreement</a>
       {% endcall %}
       {{ summary.remove_link("Remove", url_for('.remove_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug) ) }}
     {% endcall %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -126,12 +126,10 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           </form>
         {% endif %}
       {% endif %}
-
-
   </div>
 
   <div class="column-two-thirds">
-      {% if agreement_ext == 'pdf' %}
+      {% if agreement_ext == '.pdf' %}
           <embed src="{{ agreement_url }}" class="border-image" height="930" type="application/pdf">
       {% else %}
           <img src="{{ agreement_url }}" class="border-image" >

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -37,7 +37,7 @@
       {{ summary.field_name(supplier_framework.supplierName) }}
       {{ summary.field_name(supplier_framework.agreementReturnedAt) }}
       {% call summary.field(wide=True) %}
-        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name=signed_agreement_prefix) }}" download>Download agreement</a>
+        <a href="{{ url_for('.download_agreement_file', supplier_id=supplier_framework.supplierId, framework_slug=framework.slug, document_name=degenerate_document_path_and_return_doc_name(supplier_framework.agreementPath)) }}" download>Download agreement</a>
       {% endcall %}
     {% endcall %}
   {% endcall %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -45,7 +45,7 @@
     {% endif %}
 
     {% call(item) summary.list_table(
-      suppliers,
+      supplier_and_framework_info,
       caption="Suppliers",
       empty_message="No suppliers were found",
       field_headings=field_headings,
@@ -59,15 +59,19 @@
         {% if current_user.has_role('admin-ccs-sourcing') %}
           {% call summary.field() %}
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">Edit declaration</a></div>
-            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=agreement_prefix) }}">Agreement</a></div>
-            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=signed_agreement_prefix) }}">Signed agreement</a></div>
-            <div>⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Countersigned agreement</a></div>
+            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=agreement_filename) }}">Agreement</a></div>
+            {% if item.get('g-cloud-7-signed-agreement-document-name') %}
+              <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=item['g-cloud-7-signed-agreement-document-name']) }}">Signed agreement</a></div>
+              <div>⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Countersigned agreement</a></div>
+            {% endif %}
           {% endcall %}
           {% call summary.field() %}
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Edit declaration</a></div>
-            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=agreement_prefix) }}" >Agreement</a></div>
-            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=signed_agreement_prefix) }}">Signed agreement</a></div>
-            <div>⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Countersigned agreement</a></div>
+            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=agreement_filename) }}" >Agreement</a></div>
+            {% if item.get('digital-outcomes-and-specialists-signed-agreement-document-name') %}
+              <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=item['digital-outcomes-and-specialists-signed-agreement-document-name']) }}">Signed agreement</a></div>
+              <div>⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Countersigned agreement</a></div>
+            {% endif %}
           {% endcall %}
           {% call summary.field() %}
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-8") }}">Edit declaration</a></div>

--- a/example_responses/supplier_framework_response.json
+++ b/example_responses/supplier_framework_response.json
@@ -1,13 +1,9 @@
 {
   "frameworkInterest": {
-    "agreementReturnedAt": "2016-08-25T15:24:04.625965Z",
     "supplierId": 1234,
+    "supplierName": "Lighthouse Supplier Name",
     "frameworkSlug": "g-cloud-8",
-    "countersignedAt": null,
     "onFramework": true,
-    "agreementReturned": true,
-    "agreedVariations": {
-    },
     "declaration": {
       "termsAndConditions": true,
       "registeredAddressBuilding": "Corsewall Lighthouse",
@@ -65,8 +61,8 @@
       "fraudAndTheft": false,
       "tradingNames": "Lighthouse Trading Name"
     },
-    "countersigned": false,
-    "supplierName": "Lighthouse Supplier Name",
+    "agreementReturnedAt": "2016-08-25T15:24:04.625965Z",
+    "agreementReturned": true,
     "agreementDetails": {
       "frameworkAgreementVersion": "v1.0",
       "uploaderUserEmail": "uploader@email.com",
@@ -74,6 +70,14 @@
       "signerName": "Signer Name",
       "uploaderUserName": "Uploader Name",
       "signerRole": "Ace Developer"
+    },
+    "agreementPath": "g-cloud-8/agreements/1234/framework-agreement.pdf",
+    "countersignedAt": null,
+    "countersigned": false,
+    "countersignedDetails": null,
+    "countersignedPath": null,
+    "agreementStatus": "signed",
+    "agreedVariations": {
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ unicodecsv==0.14.1
 boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.6.0#egg=digitalmarketplace-utils==21.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.2.1#egg=digitalmarketplace-apiclient==7.2.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -10,3 +10,4 @@ watchdog==0.8.3
 coverage==3.7.1
 pytest-cov==2.2.0
 python-coveralls==2.5.0
+freezegun==0.3.7

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -19,12 +19,14 @@ class TestListAgreements(LoggedInApplicationTest):
                     'supplierId': 11111,
                     'agreementReturned': True,
                     'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
+                    'agreementPath': 'path/11111-agreement.pdf',
                 },
                 {
                     'supplierName': 'My other supplier',
                     'supplierId': 11112,
                     'agreementReturned': True,
                     'agreementReturnedAt': '2015-10-30T01:01:01.000000Z',
+                    'agreementPath': 'path/11112-agreement.pdf',
                 },
             ]
         }

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1064,6 +1064,7 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.s3')
 class TestViewingASupplierDeclaration(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
@@ -1076,7 +1077,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_supplier.assert_called_with('1234')
         assert not data_api_client.get_framework.called
 
-    def test_should_404_if_framework_does_not_exist(self, data_api_client):
+    def test_should_404_if_framework_does_not_exist(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.get_framework.side_effect = APIError(Response(404))
 
@@ -1086,7 +1087,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_supplier.assert_called_with('1234')
         data_api_client.get_framework.assert_called_with('g-cloud-8')
 
-    def test_should_404_if_agreement_not_returned(self, data_api_client):
+    def test_should_404_if_agreement_not_returned(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
         not_returned = self.load_example_listing('supplier_framework_response')
@@ -1099,7 +1100,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_framework.assert_called_with('g-cloud-8')
         data_api_client.get_supplier_framework_info.assert_called_with('1234', 'g-cloud-8')
 
-    def test_should_show_agreement_details_on_page(self, data_api_client):
+    def test_should_show_agreement_details_on_page(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
         data_api_client.get_supplier_framework_info.return_value = self.load_example_listing(
@@ -1151,7 +1152,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
             assert len(document.xpath('//p[contains(text(), "Uploader Name")]')) == 1
             assert len(document.xpath('//span[contains(text(), "uploader@email.com")]')) == 1
 
-    def test_should_embed_for_pdf_file(self, data_api_client):
+    def test_should_embed_for_pdf_file(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
         data_api_client.get_supplier_framework_info.return_value = self.load_example_listing(
@@ -1166,7 +1167,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
             assert len(document.xpath('//embed[@src="http://example.com/document/1234.pdf"]')) == 1
             assert len(document.xpath('//img[@src="http://example.com/document/1234.pdf"]')) == 0
 
-    def test_should_img_for_image_file(self, data_api_client):
+    def test_should_img_for_image_file(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
         supplier_framework_info = self.load_example_listing(


### PR DESCRIPTION
#### Use file paths from FrameworkAgreements to find agreement files
This updates the app to use the new FrameworkAgreement data to ascertain whether an agreement has been returned and/or countersigned, rather than checking for the existence of a file in S3.

When providing links to download a signed framework agreement or countersigned framework agreement, we are able to use the paths from the `FrameworkAgreement` rather than generating a path on the fly. We then strip the full paths to their document root and pass this as a parameter to the `download_agreement_file` route.

Admins have the ability to upload individual countersigned documents (for g-cloud-7 and dos) and so we save these with unique timestamped filename, with the path being saved into the FrameworkAgreement table. 

===
#### Tidying up the admin view

We've tidied up the admin user interface when viewing suppliers. Previously we would provide links to download agreements, countersigned agreements and upload new countersigned agreements.
![image](https://cloud.githubusercontent.com/assets/7228605/19232093/b58339e6-8ed5-11e6-98ba-d696f91fae5b.png)

Now we only show links to documents that exist. We only provide a link to upload a new countersigned agreement if the agreement has already been signed.
![image](https://cloud.githubusercontent.com/assets/7228605/19232043/6a7dbc64-8ed5-11e6-8a6c-ad8cc731d405.png)

Note, for g-cloud-8 we do not provide links to download/upload signed agreements or countersigned agreements. This is because all of the paperwork process should be done through the countersigning flow that is currently being built for g-cloud-8.

