### PR TITLE
Create companies house link with correct target

### DIFF
--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -63,7 +63,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           with
               text = supplier_framework.declaration.companyRegistrationNumber,
               link = "https://beta.companieshouse.gov.uk/company/%s" | format(supplier_framework.declaration.companyRegistrationNumber),
-              target = _blank
+              target = "_blank"
           %}
           {% include "toolkit/external-link.html" %}
           {% endwith %}


### PR DESCRIPTION
For [this story on Pivotal](https://www.pivotaltracker.com/story/show/128842457).

The link to companies house was being generated by the frontend toolkit
with the value for target set to `_blank` (missing quotes). This wasn't
valid but failed silently. This small update adds the quotes so it's
correctly applied by the toolkit.