### PR TITLE
[#128843445]agreement countersigning: add a next_agreement view...

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,7 +1,8 @@
 from dmutils.documents import degenerate_document_path_and_return_doc_name
-from flask import render_template
+from flask import render_template, redirect, url_for, abort
 from flask_login import login_required
 from dateutil.parser import parse as parse_date
+from six import next
 
 from dmutils.formats import datetimeformat
 
@@ -10,11 +11,7 @@ from ..auth import role_required
 from ... import data_api_client
 
 
-@main.route('/agreements/<framework_slug>', methods=['GET'])
-@login_required
-@role_required('admin', 'admin-ccs-sourcing')
-def list_agreements(framework_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
+def _get_ordered_supplier_frameworks(framework_slug):
     supplier_frameworks = data_api_client.find_framework_suppliers(
         framework_slug, agreement_returned=True
     )['supplierFrameworks']
@@ -22,6 +19,16 @@ def list_agreements(framework_slug):
     # API returns SupplierFrameworks by agreementReturnedAt descending (newest first)
     # We want it ascending (oldest first)
     supplier_frameworks.reverse()
+
+    return supplier_frameworks
+
+
+@main.route('/agreements/<framework_slug>', methods=['GET'])
+@login_required
+@role_required('admin', 'admin-ccs-sourcing')
+def list_agreements(framework_slug):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    supplier_frameworks = _get_ordered_supplier_frameworks(framework_slug)
 
     for supplier_framework in supplier_frameworks:
         supplier_framework['agreementReturnedAt'] = datetimeformat(
@@ -33,3 +40,34 @@ def list_agreements(framework_slug):
         supplier_frameworks=supplier_frameworks,
         degenerate_document_path_and_return_doc_name=lambda x: degenerate_document_path_and_return_doc_name(x)
     )
+
+
+@main.route('/suppliers/<int:supplier_id>/agreements/<framework_slug>/next', methods=('GET',))
+@login_required
+@role_required('admin', 'admin-ccs-sourcing')
+def next_agreement(supplier_id, framework_slug):
+    supplier_frameworks = _get_ordered_supplier_frameworks(framework_slug)
+    supplier_frameworks_iter = iter(supplier_frameworks)
+
+    try:
+        while next(supplier_frameworks_iter).get("supplierId") != supplier_id:
+            pass
+    except StopIteration:
+        # reached the end of supplier_frameworks_iter without finding an entry for supplier_id. supplier possibly
+        # doesn't exist or doesn't have a signed agreement yet
+        abort(404)
+
+    try:
+        next_supplier_framework = next(supplier_frameworks_iter)
+    except StopIteration:
+        # this was the last one.
+        return redirect(url_for(
+            '.list_agreements',
+            framework_slug=framework_slug,
+        ))
+
+    return redirect(url_for(
+        '.view_signed_agreement',
+        supplier_id=next_supplier_framework["supplierId"],
+        framework_slug=next_supplier_framework["frameworkSlug"],
+    ))

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -139,32 +139,36 @@ def view_signed_agreement(supplier_id, framework_slug):
 @login_required
 @role_required('admin-ccs-sourcing')
 def put_signed_agreement_on_hold(agreement_id):
-    data_api_client.put_signed_agreement_on_hold(agreement_id, current_user.email_address)
+    agreement = data_api_client.put_signed_agreement_on_hold(agreement_id, current_user.email_address)["agreement"]
 
     organisation = request.form['nameOfOrganisation']
     flash('The agreement for {} was put on hold.'.format(organisation), 'message')
 
     return redirect(url_for(
-        '.list_agreements',
-        framework_slug='g-cloud-8')
-    )
+        '.next_agreement',
+        framework_slug=agreement["frameworkSlug"],
+        supplier_id=agreement["supplierId"],
+    ))
 
 
 @main.route('/suppliers/agreements/<agreement_id>/approve', methods=['POST'])
 @login_required
 @role_required('admin-ccs-sourcing')
 def approve_agreement_for_countersignature(agreement_id):
-    data_api_client.approve_agreement_for_countersignature(agreement_id,
-                                                           current_user.email_address,
-                                                           current_user.id)
+    agreement = data_api_client.approve_agreement_for_countersignature(
+        agreement_id,
+        current_user.email_address,
+        current_user.id,
+    )["agreement"]
     organisation = request.form['nameOfOrganisation']
     flash('The agreement for {} was approved. They will receive a countersigned version soon.'
           .format(organisation), 'message')
 
     return redirect(url_for(
-        '.list_agreements',
-        framework_slug='g-cloud-8')
-    )
+        '.next_agreement',
+        framework_slug=agreement["frameworkSlug"],
+        supplier_id=agreement["supplierId"],
+    ))
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>/<document_name>', methods=['GET'])

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -126,6 +126,15 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           </form>
         {% endif %}
       {% endif %}
+      <p class="padding-bottom-small">
+        {%
+          with
+          url = url_for(".next_agreement", framework_slug=framework.slug, supplier_id=supplier.id),
+          text = "Next agreement"
+        %}
+          {% include "toolkit/secondary-action-link.html" %}
+        {% endwith %}
+      </p>
   </div>
 
   <div class="column-two-thirds">

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1215,6 +1215,7 @@ class TestPutSignedAgreementOnHold(LoggedInApplicationTest):
         data_api_client.put_signed_agreement_on_hold.assert_called_once_with('123', 'test@example.com')
         assert_flashes(self, "The agreement for Test was put on hold.")
         assert res.status_code == 302
+        assert res.location == "http://localhost/admin/suppliers/4321/agreements/g-cloud-99-flake/next"
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -1251,6 +1252,7 @@ class TestApproveAgreement(LoggedInApplicationTest):
                                                                                        '1234')
         assert_flashes(self, "The agreement for Test was approved. They will receive a countersigned version soon.")
         assert res.status_code == 302
+        assert res.location == "http://localhost/admin/suppliers/4321/agreements/g-cloud-99p-world/next"
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1306,6 +1306,9 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         assert "Accept and continue" not in data
         assert "Put on hold and continue" not in data
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
+        assert len(document.xpath(
+            "//a[@href='/admin/suppliers/1234/agreements/g-cloud-8/next'][normalize-space(string())='Next agreement']"
+        )) == 1
 
     def test_both_shown_if_ccs_admin_and_agreement_signed(self, s3, get_signed_url, data_api_client):
         self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='signed')
@@ -1325,6 +1328,9 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
             "//input[@type='submit'][@value='Put on hold and continue']"
         )) == 1
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
+        assert len(document.xpath(
+            "//a[@href='/admin/suppliers/1234/agreements/g-cloud-8/next'][normalize-space(string())='Next agreement']"
+        )) == 1
 
     def test_only_counter_sign_shown_if_agreement_on_hold(self, s3, get_signed_url, data_api_client):
         self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='on-hold')
@@ -1341,6 +1347,9 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         )) == 1
         assert "Put on hold and continue" not in data
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
+        assert len(document.xpath(
+            "//a[@href='/admin/suppliers/1234/agreements/g-cloud-8/next'][normalize-space(string())='Next agreement']"
+        )) == 1
 
     def test_none_shown_if_agreement_approved(self, s3, get_signed_url, data_api_client):
         self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='approved')
@@ -1354,6 +1363,9 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         assert "Accept and continue" not in data
         assert "Put on hold and continue" not in data
         assert len(document.xpath("//h2[normalize-space(string())='Accepted by']")) == 1
+        assert len(document.xpath(
+            "//a[@href='/admin/suppliers/1234/agreements/g-cloud-8/next'][normalize-space(string())='Next agreement']"
+        )) == 1
 
     def test_none_shown_if_agreement_countersigned(self, s3, get_signed_url, data_api_client):
         self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='countersigned')
@@ -1367,6 +1379,9 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         assert "Accept and continue" not in data
         assert "Put on hold and continue" not in data
         assert len(document.xpath("//h2[normalize-space(string())='Accepted by']")) == 1
+        assert len(document.xpath(
+            "//a[@href='/admin/suppliers/1234/agreements/g-cloud-8/next'][normalize-space(string())='Next agreement']"
+        )) == 1
 
 
 @mock.patch('app.main.views.agreements.data_api_client')


### PR DESCRIPTION
…which will redirect to the "next" SupplierFramework with a signed agreement

(pivotal story https://www.pivotaltracker.com/story/show/128843445)

Not yet added anything that actually _uses_ this view yet, because I'm not entirely sure about the volatility of the areas that will reference this view.