### PR TITLE
Do not reverse order of agreements

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -16,10 +16,7 @@ def _get_ordered_supplier_frameworks(framework_slug):
         framework_slug, agreement_returned=True
     )['supplierFrameworks']
 
-    # API returns SupplierFrameworks by agreementReturnedAt descending (newest first)
-    # We want it ascending (oldest first)
-    supplier_frameworks.reverse()
-
+    # API now returns SupplierFrameworks by agreementReturnedAt ascending (oldest first)
     return supplier_frameworks
 
 

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -48,17 +48,17 @@ class TestListAgreements(LoggedInApplicationTest):
         data_api_client.find_framework_suppliers.return_value = {
             'supplierFrameworks': [
                 {
-                    'supplierName': 'My Supplier',
-                    'supplierId': 11111,
-                    'agreementReturned': True,
-                    'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
-                    'frameworkSlug': 'g-cloud-8',
-                },
-                {
                     'supplierName': 'My other supplier',
                     'supplierId': 11112,
                     'agreementReturned': True,
                     'agreementReturnedAt': '2015-10-30T01:01:01.000000Z',
+                    'frameworkSlug': 'g-cloud-8',
+                },
+                {
+                    'supplierName': 'My Supplier',
+                    'supplierId': 11111,
+                    'agreementReturned': True,
+                    'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
                     'frameworkSlug': 'g-cloud-8',
                 },
             ],

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1420,7 +1420,7 @@ class TestNextAgreementRedirect(LoggedInApplicationTest):
         data_api_client.find_framework_suppliers.return_value = self.dummy_supplier_frameworks
         res = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8/next')
         assert res.status_code == 302
-        assert res.location == "http://localhost/admin/suppliers/4321/agreements/g-cloud-8"
+        assert res.location == "http://localhost/admin/suppliers/31415/agreements/g-cloud-8"
 
     def test_unknown_supplier_returns_404(self, data_api_client):
         data_api_client.find_framework_suppliers.return_value = self.dummy_supplier_frameworks
@@ -1429,6 +1429,6 @@ class TestNextAgreementRedirect(LoggedInApplicationTest):
 
     def test_final_supplier_redirects_to_list(self, data_api_client):
         data_api_client.find_framework_suppliers.return_value = self.dummy_supplier_frameworks
-        res = self.client.get('/admin/suppliers/4321/agreements/g-cloud-8/next')
+        res = self.client.get('/admin/suppliers/141/agreements/g-cloud-8/next')
         assert res.status_code == 302
         assert res.location == "http://localhost/admin/agreements/g-cloud-8"


### PR DESCRIPTION
The API will soon ([see this pull request](https://github.com/alphagov/digitalmarketplace-api/pull/474)) return agreements in ascending order of date as that is the order we want.  So then there will be no need to reverse the agreements here.