### PR TITLE
[#128841821]list_agreements: add ability to filter list of suppliers by latest agreement status

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -13,11 +13,11 @@ from ..auth import role_required
 from ... import data_api_client
 
 
-_status_labels = OrderedDict((
+status_labels = OrderedDict((
     ("signed", "Waiting for countersigning"),
     ("on-hold", "On hold"),
-    ("approved,countersigned", "Countersigned"),  # ugly, but i don't want to start inventing new status values - much
-                                                  # easier to just act as a filter
+    ("approved,countersigned", "Countersigned"),  # ugly key, but i don't want to start inventing new status values -
+                                                  # much easier to just act as a filter
 ))
 
 
@@ -39,7 +39,7 @@ def list_agreements(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
     status = request.args.get("status")
-    if status and status not in _status_labels:
+    if status and status not in status_labels:
         abort(400)
 
     supplier_frameworks = _get_ordered_supplier_frameworks(framework_slug, status=status)
@@ -54,7 +54,7 @@ def list_agreements(framework_slug):
         supplier_frameworks=supplier_frameworks,
         degenerate_document_path_and_return_doc_name=lambda x: degenerate_document_path_and_return_doc_name(x),
         status=status,
-        status_labels=_status_labels,
+        status_labels=status_labels,
     )
 
 

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,5 +1,7 @@
+from collections import OrderedDict
+
 from dmutils.documents import degenerate_document_path_and_return_doc_name
-from flask import render_template, redirect, url_for, abort
+from flask import render_template, redirect, url_for, abort, request
 from flask_login import login_required
 from dateutil.parser import parse as parse_date
 from six import next
@@ -11,9 +13,19 @@ from ..auth import role_required
 from ... import data_api_client
 
 
-def _get_ordered_supplier_frameworks(framework_slug):
+_status_labels = OrderedDict((
+    ("signed", "Waiting for countersigning"),
+    ("on-hold", "On hold"),
+    ("approved,countersigned", "Countersigned"),  # ugly, but i don't want to start inventing new status values - much
+                                                  # easier to just act as a filter
+))
+
+
+def _get_ordered_supplier_frameworks(framework_slug, status=None):
     supplier_frameworks = data_api_client.find_framework_suppliers(
-        framework_slug, agreement_returned=True
+        framework_slug,
+        agreement_returned=True,
+        **({"statuses": status} if status else {})
     )['supplierFrameworks']
 
     # API now returns SupplierFrameworks by agreementReturnedAt ascending (oldest first)
@@ -25,7 +37,12 @@ def _get_ordered_supplier_frameworks(framework_slug):
 @role_required('admin', 'admin-ccs-sourcing')
 def list_agreements(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
-    supplier_frameworks = _get_ordered_supplier_frameworks(framework_slug)
+
+    status = request.args.get("status")
+    if status and status not in _status_labels:
+        abort(400)
+
+    supplier_frameworks = _get_ordered_supplier_frameworks(framework_slug, status=status)
 
     for supplier_framework in supplier_frameworks:
         supplier_framework['agreementReturnedAt'] = datetimeformat(
@@ -35,7 +52,9 @@ def list_agreements(framework_slug):
         "view_agreements_g8.html" if framework_slug == "g-cloud-8" else 'view_agreements.html',
         framework=framework,
         supplier_frameworks=supplier_frameworks,
-        degenerate_document_path_and_return_doc_name=lambda x: degenerate_document_path_and_return_doc_name(x)
+        degenerate_document_path_and_return_doc_name=lambda x: degenerate_document_path_and_return_doc_name(x),
+        status=status,
+        status_labels=_status_labels,
     )
 
 

--- a/app/templates/view_agreements_g8.html
+++ b/app/templates/view_agreements_g8.html
@@ -39,9 +39,20 @@
     <div class="column-one-third search-page-filters">
       <div class="status-filters">
         <h2>Choose a status</h2>
-        <ul>
-          <li>Waiting for countersigning</li>
-        </ul>
+          <ul>
+            <li>
+              {% if status %}<a href="{{ url_for(".list_agreements", framework_slug=framework.slug) }}">{% endif %}
+                All
+              {% if status %}</a>{% endif %}
+            </li>
+        {% for status_key, status_label in status_labels.items() %}
+            <li>
+              {% if status_key != status %}<a href="{{ url_for(".list_agreements", framework_slug=framework.slug, status=status_key) }}">{% endif %}
+                {{ status_label }}
+              {% if status_key != status %}</a>{% endif %}
+            </li>
+        {% endfor %}
+          </ul>
       </div>
     </div>
     <div class="column-two-thirds">

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.2.1#egg=digitalmarketplace-apiclient==7.2.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.4.0#egg=digitalmarketplace-apiclient==7.4.0

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -1,14 +1,42 @@
+from itertools import chain
+
 import mock
 from lxml import html
 from nose.tools import eq_
-from six.moves.urllib.parse import urlparse, urlunparse
+from six import iteritems, iterkeys
+from six.moves.urllib.parse import urlparse, urlunparse, parse_qs
 
+from app.main.views.agreements import status_labels
 from ...helpers import LoggedInApplicationTest
 
 
 @mock.patch('app.main.views.agreements.data_api_client')
 class TestListAgreements(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
+
+    @property
+    def find_framework_suppliers_return_value_g8(self):
+        # a property so we always get a fresh *copy* of this
+        return {
+            'supplierFrameworks': [
+                {
+                    'supplierName': 'My other supplier',
+                    'supplierId': 11112,
+                    'agreementReturned': True,
+                    'agreementReturnedAt': '2015-10-30T01:01:01.000000Z',
+                    'agreementPath': 'path/11112-agreement.pdf',
+                    'frameworkSlug': 'g-cloud-8',
+                },
+                {
+                    'supplierName': 'My Supplier',
+                    'supplierId': 11111,
+                    'agreementReturned': True,
+                    'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
+                    'agreementPath': 'path/11111-agreement.pdf',
+                    'frameworkSlug': 'g-cloud-8',
+                },
+            ],
+        }
 
     def test_happy_path(self, data_api_client):
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
@@ -39,48 +67,35 @@ class TestListAgreements(LoggedInApplicationTest):
         eq_(len(rows), 2)
 
     @staticmethod
-    def _unpack_single_a_elem(elems):
-        assert len(elems) == 1
-        return urlunparse(("", "",) + urlparse(elems[0].attrib["href"])[2:]), elems[0].text
+    def _unpack_search_result(elem):
+        a_elems = elem.cssselect(".search-result-title a")
+        assert len(a_elems) == 1
+        mi_elems = elem.cssselect(".search-result-metadata-item")
+        assert len(mi_elems) == 1
+        return (
+            urlunparse(("", "",) + urlparse(a_elems[0].attrib["href"])[2:]),
+            a_elems[0].xpath("normalize-space(string())"),
+            mi_elems[0].xpath("normalize-space(string())"),
+        )
 
-    def test_happy_path_g8(self, data_api_client):
+    def test_happy_path_all_g8(self, data_api_client):
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
-        data_api_client.find_framework_suppliers.return_value = {
-            'supplierFrameworks': [
-                {
-                    'supplierName': 'My other supplier',
-                    'supplierId': 11112,
-                    'agreementReturned': True,
-                    'agreementReturnedAt': '2015-10-30T01:01:01.000000Z',
-                    'frameworkSlug': 'g-cloud-8',
-                },
-                {
-                    'supplierName': 'My Supplier',
-                    'supplierId': 11111,
-                    'agreementReturned': True,
-                    'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
-                    'frameworkSlug': 'g-cloud-8',
-                },
-            ],
-        }
+        data_api_client.find_framework_suppliers.return_value = self.find_framework_suppliers_return_value_g8
 
         response = self.client.get('/admin/agreements/g-cloud-8')
         page = html.fromstring(response.get_data(as_text=True))
 
         assert response.status_code == 200
-        rows = page.cssselect('.search-result')
 
-        def unpack_search_result(elem):
-            a_elems = elem.cssselect(".search-result-title a")
-            assert len(a_elems) == 1
-            mi_elems = elem.cssselect(".search-result-metadata-item")
-            assert len(mi_elems) == 1
-            return (
-                urlunparse(("", "",) + urlparse(a_elems[0].attrib["href"])[2:]),
-                a_elems[0].text.strip(),
-                mi_elems[0].text.strip(),
-            )
-        assert tuple(unpack_search_result(result) for result in page.cssselect('.search-result')) == (
+        call_args = data_api_client.find_framework_suppliers.call_args
+        assert call_args[0] == ("g-cloud-8",)
+        # slightly elaborate assertion here to allow for missing kwargs defaulting to None
+        assert all(call_args[1].get(key) == value for key, value in (
+            ("agreement_returned", True),
+            ("statuses", None),
+        ))
+
+        assert tuple(self._unpack_search_result(result) for result in page.cssselect('.search-result')) == (
             (
                 "/admin/suppliers/11112/agreements/g-cloud-8",
                 "My other supplier",
@@ -92,6 +107,69 @@ class TestListAgreements(LoggedInApplicationTest):
                 "Submitted: Sunday 1 November 2015 at 01:01",
             ),
         )
+
+        assert page.xpath("//*[@class='status-filters']//li[normalize-space(string())='All']")
+
+        assert tuple(
+            (parse_qs(urlparse(a_element.attrib["href"]).query), a_element.xpath("normalize-space(string())"))
+            for a_element in page.cssselect('.status-filters a')
+        ) == tuple(
+            ({"status": [status_key]}, status_label)
+            for status_key, status_label in iteritems(status_labels)
+        )
+
+    def test_happy_path_notall_g8(self, data_api_client):
+        data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
+        data_api_client.find_framework_suppliers.return_value = self.find_framework_suppliers_return_value_g8
+
+        # choose the second status (if there is one, otherwise first)
+        chosen_status_key = tuple(iterkeys(status_labels))[:2][-1]
+
+        response = self.client.get('/admin/agreements/g-cloud-8?status={}'.format(chosen_status_key))
+        page = html.fromstring(response.get_data(as_text=True))
+
+        assert response.status_code == 200
+
+        call_args = data_api_client.find_framework_suppliers.call_args
+        assert call_args[0] == ("g-cloud-8",)
+        # slightly elaborate assertion here to allow for missing kwargs defaulting to None
+        assert all(call_args[1].get(key) == value for key, value in (
+            ("agreement_returned", True),
+            ("statuses", chosen_status_key),
+        ))
+
+        assert tuple(self._unpack_search_result(result) for result in page.cssselect('.search-result')) == (
+            (
+                "/admin/suppliers/11112/agreements/g-cloud-8",
+                "My other supplier",
+                "Submitted: Friday 30 October 2015 at 01:01",
+            ),
+            (
+                "/admin/suppliers/11111/agreements/g-cloud-8",
+                "My Supplier",
+                "Submitted: Sunday 1 November 2015 at 01:01",
+            ),
+        )
+
+        assert any(
+            # (don't really want to risk shoving unescaped text into the xpath query, so pulling the elements out and
+            # comparing them in python)
+            element.xpath("normalize-space(string())") == status_labels[chosen_status_key]
+            for element in page.xpath("//*[@class='status-filters']//li")
+        )
+
+        assert tuple(
+            (parse_qs(urlparse(a_element.attrib["href"]).query), a_element.xpath("normalize-space(string())"))
+            for a_element in page.cssselect('.status-filters a')
+        ) == tuple(chain(
+            (
+                ({}, "All",),
+            ),
+            (
+                ({"status": [status_key]}, status_label)
+                for status_key, status_label in iteritems(status_labels) if status_key != chosen_status_key
+            ),
+        ))
 
     def test_unauthorised_roles_are_rejected_access(self, data_api_client):
         self.user_role = 'admin-ccs-category'


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/128841821

I'm intending to push the functionality enabling the "next" link between agreements to just traverse over the currently filtered set of agreements. However, to do that, this would need to sit on top of #218 which is not merged yet. So here's the straightforward filtering functionality.