### PR TITLE
[#133093959] Show agreement status that has been filtered by on page

### DIFF
--- a/app/templates/_view_agreements_summary.html
+++ b/app/templates/_view_agreements_summary.html
@@ -2,7 +2,7 @@
 {% set content %}
   <em class="search-summary-count">{{ supplier_frameworks|length }}</em>
   {{ pluralize(supplier_frameworks|length, "agreement", "agreements") }}
-  <em>waiting for countersigning</em>
+  <em>{{ status_labels.get(status)|lower if status else "returned" }}</em>
 {% endset %}
 {% include "toolkit/search-summary.html" %}
 {% endif %}

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -122,6 +122,9 @@ class TestListAgreements(LoggedInApplicationTest):
             for status_key, status_label in iteritems(status_labels)
         )
 
+        summary_elem = page.xpath("//p[@class='search-summary']")[0]
+        assert summary_elem.xpath("normalize-space(string())") == '2 agreements returned'
+
     def test_happy_path_notall_g8(self, data_api_client):
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
         data_api_client.find_framework_suppliers.return_value = self.find_framework_suppliers_return_value_g8
@@ -176,6 +179,11 @@ class TestListAgreements(LoggedInApplicationTest):
                 for status_key, status_label in iteritems(status_labels) if status_key != chosen_status_key
             ),
         ))
+
+        summary_elem = page.xpath("//p[@class='search-summary']")[0]
+        assert summary_elem.xpath("normalize-space(string())") == '2 agreements {}'.format(
+            status_labels[chosen_status_key].lower()
+        )
 
     def test_unauthorised_roles_are_rejected_access(self, data_api_client):
         self.user_role = 'admin-ccs-category'


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/133093959

Previously the search summary showed "waiting to be countersigned" no matter what status agreements had been filtered by.

This updates it to show the filtered status in the summary, as follows:
# All shows "returned"
![screen shot 2016-10-25 at 17 21 57](https://cloud.githubusercontent.com/assets/6525554/19694549/bc690976-9ad7-11e6-99a8-5adb7328ab91.png)

# Waiting for countersigning
![screen shot 2016-10-25 at 17 22 13](https://cloud.githubusercontent.com/assets/6525554/19694578/d4163850-9ad7-11e6-8e22-0aed116cfd9f.png)

# On hold
![screen shot 2016-10-25 at 17 22 25](https://cloud.githubusercontent.com/assets/6525554/19694583/d7c994d8-9ad7-11e6-9fbb-f00d62deeb09.png)

# Countersigned
![screen shot 2016-10-25 at 17 22 41](https://cloud.githubusercontent.com/assets/6525554/19694587/dbaf57cc-9ad7-11e6-82cb-532bc5581fbf.png)
