### PR TITLE
Change redirect location following supplier name update

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -391,7 +391,7 @@ def update_supplier_name(supplier_id):
         supplier['suppliers']['id'], {'name': new_supplier_name}, current_user.email_address
     )
 
-    return redirect(url_for('.find_suppliers', supplier_name_prefix=new_supplier_name[:1]))
+    return redirect(url_for('.find_suppliers', supplier_id=supplier_id))
 
 
 @main.route('/suppliers/users', methods=['GET'])

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -630,6 +630,29 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
+class TestUpdatintSupplierName(LoggedInApplicationTest):
+    def test_admin_can_test_update_supplier_name(self, data_api_client):
+        data_api_client.get_supplier.return_value = {"suppliers": {"id": 1234, "name": "Something Old"}}
+        response = self.client.post(
+            '/admin/suppliers/1234/edit/name',
+            data={'new_supplier_name': 'Something New'}
+        )
+        assert response.status_code == 302
+        assert response.location == 'http://localhost/admin/suppliers?supplier_id=1234'
+        data_api_client.update_supplier.assert_called_once_with(1234, {'name': "Something New"}, "test@example.com")
+
+    def test_ccs_roles_can_not_update_supplier_name(self, data_api_client):
+        for role in ('admin-ccs-sourcing', 'admin-ccs-category'):
+            self.user_role = role
+            response = self.client.post(
+                '/admin/suppliers/1234/edit/name',
+                data={'new_supplier_name': 'Something New'}
+            )
+            assert response.status_code == 403
+            data_api_client.update_supplier.assert_not_called()
+
+
+@mock.patch('app.main.views.suppliers.data_api_client')
 class TestViewingASupplierDeclaration(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 


### PR DESCRIPTION
Also adds a couple of basic tests for previously untested route.