### PR TITLE
Stop using the `search-summary` pattern for our search summary

### DIFF
--- a/app/templates/_view_agreements_summary.html
+++ b/app/templates/_view_agreements_summary.html
@@ -1,8 +1,7 @@
 {% if supplier_frameworks %}
-{% set content %}
+<p class="search-summary">
   <em class="search-summary-count">{{ supplier_frameworks|length }}</em>
   {{ pluralize(supplier_frameworks|length, "agreement", "agreements") }}
   <em>{{ status_labels.get(status)|lower if status else "returned" }}</em>
-{% endset %}
-{% include "toolkit/search-summary.html" %}
+</p>
 {% endif %}


### PR DESCRIPTION
While this is admittedly a retrograde move, I think it's fine
right now.

- the buyer app is using [two](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/app/presenters/search_summary.py#L7) [different](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/app/templates/search/_briefs_summary.html) search summary templates,
  none of which are from the toolkit
- this app is effectively doing its own search summary and them
  passing it into a 3-line template
- the template has nothing in it

It seems like the real thing to do if we think this is a pattern
(I think it is) is to rewrite it so that it works for all cases
and doesn't just echo an unescaped message.

This achieves the short-term goal of being able to remove the 
`safe` filters from the front-end toolkit, so that seems worth doing first.