### PR TITLE
Admin links for DOS2

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -94,9 +94,9 @@
   {% endwith %}
   {% with items = [
       {
-          "body": "View G-Cloud 8 statistics",
-          "link": "/admin/statistics/g-cloud-8",
-          "title": "G-Cloud 8 statistics"
+          "body": "View Digital Outcomes and Specialists 2 statistics",
+          "link": "/admin/statistics/digital-outcomes-and-specialists-2",
+          "title": "Digital Outcomes and Specialists 2 statistics"
       }
   ]
   %}
@@ -136,14 +136,14 @@
     {% endwith %}
     {% with items = [
       {
-          "body": "Manage Digital Outcomes and Specialists communications",
-          "link": "/admin/communications/digital-outcomes-and-specialists",
-          "title": "Digital Outcomes and Specialists communications"
-      },
-      {
         "body": "Manage G-Cloud 8 communications",
         "link": "/admin/communications/g-cloud-8",
         "title": "G-Cloud 8 communications"
+      },
+      {
+          "body": "Manage Digital Outcomes and Specialists 2 communications",
+          "link": "/admin/communications/digital-outcomes-and-specialists-2",
+          "title": "Digital Outcomes and Specialists 2 communications"
       },
       {
           "body": "Download a list of users for frameworks that are open, pending or live",

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -22,9 +22,7 @@
               {% if category == 'upload_communication' %}
                 <div class="banner-success-without-action">
                   <p class="banner-message">
-                  {% if message == 'itt_pack' %}
-                    ITT pack was uploaded.
-                  {% elif message == 'clarification' %}
+                  {% if message == 'clarification' %}
                     New clarification was uploaded.
                   {% elif message == 'communication' %}
                     New communication was uploaded.
@@ -38,8 +36,6 @@
                         Communication file is not a PDF or CSV.
                     {% elif category == 'not_pdf' and message == 'clarification' %}
                         Clarification file is not a PDF.
-                    {% elif category == 'not_zip' and message == 'itt_pack' %}
-                        ITT pack is not a zip file.
                     {% endif %}
                   </p>
                 </div>
@@ -76,17 +72,6 @@
     {% endwith %}
     {% endif %}
 
-    {% if framework.status in ['open', 'closed'] %}
-    {% with
-       question="ITT pack",
-       hint="This must be ZIP",
-       name="itt_pack",
-       value="Last modified {}".format(itt_pack.last_modified),
-       error=itt_pack_error
-    %}
-      {% include "toolkit/forms/upload.html" %}
-    {% endwith %}
-    {% endif %}
     {%
       with
       type = "save",


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/131616157

As well as adding and checking DOS2 links I've removed the "ITT pack" functionality as we don't have an ITT pack for DOS2 or for future frameworks.
 
All tested locally (including local user list download, file uploads to dev bucket, checking they appear in supplier frontend pages) and Works-For-Me™

# As a digital marketplace admin, I want:
## to be able to view DOS2 applications statistics
![screen shot 2016-11-04 at 16 46 46](https://cloud.githubusercontent.com/assets/6525554/20014271/4d1614b8-a2ae-11e6-99d4-651306ce430d.png)

![screen shot 2016-11-04 at 16 46 02](https://cloud.githubusercontent.com/assets/6525554/20014281/513ae640-a2ae-11e6-9899-9506c63118a0.png)

## to be able to upload clarification and communication files
![screen shot 2016-11-04 at 16 42 31](https://cloud.githubusercontent.com/assets/6525554/20014309/6b4adea0-a2ae-11e6-89d2-b8be7a18b647.png)

------------------------------------------
![screen shot 2016-11-04 at 16 42 18](https://cloud.githubusercontent.com/assets/6525554/20014314/727e369a-a2ae-11e6-8209-04af362f6acd.png)

## to be able to download DOS2 user list
![screen shot 2016-11-04 at 16 42 41](https://cloud.githubusercontent.com/assets/6525554/20014289/5933cda8-a2ae-11e6-9032-6721443b9221.png)
