### PR TITLE
encrypt tokens rather than just signing them

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ unicodecsv==0.14.1
 boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.11.0#egg=digitalmarketplace-utils==21.11.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.4.0#egg=digitalmarketplace-apiclient==7.4.0


### PR DESCRIPTION
so that personal emails aren't leaked to logs, analytics etc.

bump dmutils to 23.0.0


- [ ] https://github.com/alphagov/digitalmarketplace-utils/pull/288