### PR TITLE
Add Private ACL and download filename to admin-uploaded agreements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.2.0",
     "hogan": "3.0.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ unicodecsv==0.14.1
 boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@23.1.0#egg=digitalmarketplace-utils==23.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.4.0#egg=digitalmarketplace-apiclient==7.4.0


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/134844463

Our bulk upload script sets ACL=Private and a human-friendly filename, but our admin upload page wasn't.

I've moved the generate download filename method to utils so it can be used by both scripts and this frontend route.

Depends on: 
 - [x] https://github.com/alphagov/digitalmarketplace-utils/pull/289