### PR TITLE
Add new watcher for frameworks to make framework dev nicer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -231,16 +231,17 @@ gulp.task(
 );
 
 gulp.task(
-  'copy:ssp_content',
+  'copy:frameworks',
   copyFactory(
-    "content YAML into app folder",
-    sspContentRoot, 'app/content'
+    "frameworks YAML into app folder",
+    sspContentRoot + '/frameworks', 'app/content/frameworks'
   )
 );
 
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);
   var cssWatcher = gulp.watch([ assetsFolder + '/**/*.scss' ], ['sass']);
+  var dmWatcher = gulp.watch([ bowerRoot + '/digitalmarketplace-frameworks/**' ], ['copy:frameworks']);
   var notice = function (event) {
     console.log('File ' + event.path + ' was ' + event.type + ' running tasks...');
   };
@@ -262,7 +263,7 @@ gulp.task('set_environment_to_production', function (cb) {
 gulp.task(
   'copy',
   [
-    'copy:ssp_content',
+    'copy:frameworks',
     'copy:template_assets:images',
     'copy:template_assets:stylesheets',
     'copy:template_assets:javascripts',


### PR DESCRIPTION
 - Add new watcher for frameworks to make framework dev nicer
 - bower now copies only the frameworks YAML directory, not the entire frameworks
   repo, for consistency with the admin frontend