### PR TITLE
Kill the cryptography bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,13 @@ run_app: show_environment virtualenv
 virtualenv:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
 
-requirements: virtualenv requirements.txt
+upgrade_pip: virtualenv
+	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
+
+requirements: virtualenv upgrade_pip requirements.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
 
-requirements_for_test: virtualenv requirements_for_test.txt
+requirements_for_test: virtualenv upgrade_pip requirements_for_test.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements_for_test.txt
 
 npm_install: package.json


### PR DESCRIPTION
We've had a problem installing cryptography on local machines,
one solution to which is to make sure your 'pip' is updated.

This pull request would add a step to the Makefile to always
upgrade pip before installing the rest of the requirements.

Same as was in the supplier app.

[Issue on github](https://github.com/pyca/cryptography/issues/2350)