### PR TITLE
[#134368805]allow all g7, g8 service fields to be edited by both `admin` and `admin-ccs-category`

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -95,7 +95,7 @@ def update_service_status(service_id):
 
 @main.route('/services/<service_id>/edit/<section>', methods=['GET'])
 @login_required
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def edit(service_id, section):
     service_data = data_api_client.get_service(service_id)['services']
 
@@ -179,7 +179,7 @@ def compare(old_archived_service_id, new_archived_service_id):
 
 @main.route('/services/<service_id>/edit/<section_id>', methods=['POST'])
 @login_required
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def update(service_id, section_id):
     service = data_api_client.get_service(service_id)
     if service is None:

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.2.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.2.0",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -223,14 +223,6 @@ class TestRoleRequired(LoggedInApplicationTest):
         response = self.client.get('/admin')
         assert_equal(200, response.status_code)
 
-    def test_admin_role_required_service_section_view(self):
-        response = self.client.get('/admin/services/1/edit/documents')
-        assert_equal(403, response.status_code)
-
-    def test_admin_role_required_service_section_edit(self):
-        response = self.client.post('/admin/services/1/edit/documents')
-        assert_equal(403, response.status_code)
-
     def test_admin_role_required_service_status_edit(self):
         response = self.client.post('/admin/services/status/1')
         assert_equal(403, response.status_code)


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/134368805

Being careful not to allow `admin-ccs-category` edit the `status` field. Also ended up fleshing out the tests covering this a bit.