### PR TITLE
Purge use of old test frameworks

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 pytest==2.8.2
 pep8==1.5.7
-nose==1.3.4
 mock==1.0.1
 requests-mock==0.6.0
 lxml==3.4.4

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -7,11 +7,10 @@ from flask import json
 
 from app import create_app
 from app import login_manager
-from unittest import TestCase
 
 
-class BaseApplicationTest(TestCase):
-    def setUp(self):
+class BaseApplicationTest(object):
+    def setup_method(self, method):
         self.app = create_app('test')
         self.client = self.app.test_client()
 
@@ -27,7 +26,7 @@ class BaseApplicationTest(TestCase):
         )
         self._default_suffix_patch.start()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self._s3_patch.stop()
         self._default_suffix_patch.stop()
 
@@ -59,8 +58,8 @@ class Response:
 class LoggedInApplicationTest(BaseApplicationTest):
     user_role = 'admin'
 
-    def setUp(self):
-        super(LoggedInApplicationTest, self).setUp()
+    def setup_method(self, method):
+        super(LoggedInApplicationTest, self).setup_method(method)
 
         patch_config = {
             'authenticate_user.return_value': {
@@ -94,9 +93,10 @@ class LoggedInApplicationTest(BaseApplicationTest):
                 user_id, 'test@example.com', None, None, False, True, 'tester', self.user_role
             )
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self._data_api_client.stop()
         login_manager.user_loader(self._user_callback)
+        super(LoggedInApplicationTest, self).teardown_method(method)
 
     def _replace_whitespace(self, string, replacement_substring=""):
             # Replace all runs of whitespace with replacement_substring

--- a/tests/app/main/helpers/test_sum_counts.py
+++ b/tests/app/main/helpers/test_sum_counts.py
@@ -1,135 +1,102 @@
 # coding=utf-8
 from unittest import TestCase
-from nose.tools import assert_equal, assert_true, assert_false
 
 from app.main.helpers.sum_counts import _label_and_count, _sum_counts, _find
 
 
 class TestLabelAndCount(TestCase):
     def test_formatting(self):
-        assert_equal(
-            _label_and_count({}, {
-                'one': {
-                    'filter_one': None
-                },
-                'two': {
-                    'filter_one': False,
-                    'filter_two': True,
-                },
-                'three': {
-                    'filter_two': True
-                }
-            }, created_at='today'),
-            {'created_at': 'today', 'one': 0, 'two': 0, 'three': 0}
-        )
+        assert _label_and_count({}, {
+            'one': {
+                'filter_one': None
+            },
+            'two': {
+                'filter_one': False,
+                'filter_two': True,
+            },
+            'three': {
+                'filter_two': True
+            }
+        }, created_at='today') == {'created_at': 'today', 'one': 0, 'two': 0, 'three': 0}
 
 
 class TestSumCounts(TestCase):
     def test_summing_without_filtering(self):
-        assert_equal(
-            _sum_counts([
-                {'count': 1},
-                {'count': 2},
-                {'count': 3},
-                {'count': 4}
-            ]),
-            10
-        )
+        assert _sum_counts([
+            {'count': 1},
+            {'count': 2},
+            {'count': 3},
+            {'count': 4}
+        ]) == 10
 
     def test_summing_filtering_on_one_attribute(self):
-        assert_equal(
-            _sum_counts([
+        assert _sum_counts(
+            [
                 {'count': 1, 'include': False},
                 {'count': 2, 'include': True},
                 {'count': 3, 'include': True},
                 {'count': 4, 'include': False}
-            ], {
-                'include': True
-            }),
-            5
-        )
+            ],
+            {'include': True},
+        ) == 5
 
     def test_summing_filtering_on_multiple_attributes(self):
-        assert_equal(
-            _sum_counts([
+        assert _sum_counts(
+            [
                 {'count': 1, 'include': False, 'exclude': True},
                 {'count': 2, 'include': True, 'exclude': False},
                 {'count': 3, 'include': True, 'exclude': True},
                 {'count': 4, 'include': False, 'exclude': False}
-            ], {
+            ],
+            {
                 'include': True,
-                'exclude': False
-            }),
-            2
-        )
+                'exclude': False,
+            },
+        ) == 2
 
     def test_summing_filtering_on_various_acceptable_attributes(self):
-        assert_equal(
-            _sum_counts([
+        assert _sum_counts(
+            [
                 {'count': 1, 'colour': 'cyan'},
                 {'count': 2, 'colour': 'yellow'},
                 {'count': 3, 'colour': 'magenta'},
                 {'count': 4, 'colour': 'black'}
-            ], {
-                'colour': ['cyan', 'yellow', 'magenta']
-            }),
-            6
-        )
+            ],
+            {'colour': ['cyan', 'yellow', 'magenta']},
+        ) == 6
 
     def test_summing_by_different_column(self):
-        assert_equal(
-            _sum_counts([
+        assert _sum_counts(
+            [
                 {'count': 1, 'new_count': 10},
                 {'count': 2, 'new_count': 20},
                 {'count': 3, 'new_count': 30},
                 {'count': 4, 'new_count': 40}
-            ], sum_by='new_count'),
-            100
-        )
+            ],
+            sum_by='new_count',
+        ) == 100
 
 
 class TestFind(TestCase):
     def test_find_string(self):
-        assert_true(
-            _find('word', 'word'),
-        )
-        assert_false(
-            _find('drow', 'word')
-        )
+        assert _find('word', 'word')
+        assert not _find('drow', 'word')
 
     def test_doesnt_match_substring(self):
-        assert_false(
-            _find('word', 'word1234')
-        )
+        assert not _find('word', 'word1234')
 
     def test_find_number(self):
-        assert_true(
-            _find(99, 99)
-        )
-        assert_false(
-            _find(99, 99.99)
-        )
+        assert _find(99, 99)
+        assert not _find(99, 99.99)
 
     def test_find_none(self):
-        assert_true(
-            _find(None, None),
-        )
-        assert_false(
-            _find(None, 'None')
-        )
+        assert _find(None, None)
+        assert not _find(None, 'None')
 
     def test_find_boolean(self):
-        assert_true(
-            _find(True, True),
-        )
-        assert_false(
-            _find(False, True)
-        )
+        assert _find(True, True)
+        assert not _find(False, True)
 
     def test_find_in_list(self):
-        assert_true(
-            _find('yes', [True, 0, 'yes']),
-        )
-        assert_false(
-            _find('no', [True, 0, 'yes']),
-        )
+        assert _find('yes', [True, 0, 'yes'])
+        assert not _find('no', [True, 0, 'yes'])

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -2,7 +2,6 @@ from itertools import chain
 
 import mock
 from lxml import html
-from nose.tools import eq_
 from six import iteritems, iterkeys
 from six.moves.urllib.parse import urlparse, parse_qs
 
@@ -69,9 +68,9 @@ class TestListAgreements(LoggedInApplicationTest):
 
         response = self.client.get('/admin/agreements/g-cloud-7')
         page = html.fromstring(response.get_data(as_text=True))
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
         rows = page.cssselect('.summary-item-row')
-        eq_(len(rows), 2)
+        assert len(rows) == 2
 
     @staticmethod
     def _unpack_search_result(elem):
@@ -200,7 +199,7 @@ class TestListAgreements(LoggedInApplicationTest):
 
         response = self.client.get('/admin/agreements/g-cloud-7')
 
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
 
 @mock.patch('app.main.views.agreements.data_api_client')

--- a/tests/app/main/views/test_application.py
+++ b/tests/app/main/views/test_application.py
@@ -6,27 +6,24 @@ from ...helpers import LoggedInApplicationTest
 class TestApplication(LoggedInApplicationTest):
     def test_main_index(self):
         response = self.client.get('/admin')
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
     def test_404(self):
         with self.app.app_context():
             response = self.client.get('/admin/not-found')
-            self.assertEquals(404, response.status_code)
+            assert response.status_code == 404
 
     def test_index_is_404(self):
         response = self.client.get('/')
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     def test_headers(self):
         res = self.client.get('/admin')
-        assert 200 == res.status_code
-        self.assertIn('Secure;', res.headers['Set-Cookie'])
-        self.assertIn('DENY', res.headers['X-Frame-Options'])
+        assert res.status_code == 200
+        assert 'Secure;' in res.headers['Set-Cookie']
+        assert 'DENY' in res.headers['X-Frame-Options']
 
     def test_response_headers(self):
         response = self.client.get('/admin')
 
-        assert (
-            response.headers['cache-control'] ==
-            "no-cache"
-        )
+        assert response.headers['cache-control'] == "no-cache"

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -10,7 +10,7 @@ class TestBuyersView(LoggedInApplicationTest):
         data_api_client.get_brief.return_value = None
         response = self.client.get('admin/buyers?brief_id=1')
 
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_should_display_a_useful_message_if_no_brief_found(self, data_api_client):
         data_api_client.get_brief.return_value = None
@@ -19,7 +19,7 @@ class TestBuyersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
         banner_message = document.xpath('//p[@class="banner-message"]//text()')[0].strip()
 
-        self.assertEqual("There are no opportunities with ID 1", banner_message)
+        assert banner_message == "There are no opportunities with ID 1"
 
     def test_brief_not_found_flash_message_injection(self, data_api_client):
         """
@@ -28,11 +28,11 @@ class TestBuyersView(LoggedInApplicationTest):
         # impl copied from test_should_display_a_useful_message_if_no_brief_found
         data_api_client.get_brief.return_value = None
         response = self.client.get('admin/buyers?brief_id=1%3Cimg%20src%3Da%20onerror%3Dalert%281%29%3E')
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
         html_response = response.get_data(as_text=True)
-        self.assertNotIn("1<img src=a onerror=alert(1)>", html_response)
-        self.assertIn("1&lt;img src=a onerror=alert(1)&gt;", html_response)
+        assert "1<img src=a onerror=alert(1)>" not in html_response
+        assert "1&lt;img src=a onerror=alert(1)&gt;" in html_response
 
     def test_table_should_show_a_useful_message_if_no_users(self, data_api_client):
         data_api_client.get_brief.return_value = {
@@ -46,7 +46,7 @@ class TestBuyersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
         table_content = document.xpath('//p[@class="summary-item-no-content"]//text()')[0].strip()
 
-        self.assertEqual("No buyers to show", table_content)
+        assert table_content == "No buyers to show"
 
     def test_should_show_buyers_contact_details(self, data_api_client):
         brief = self.load_example_listing("brief_response")
@@ -58,6 +58,6 @@ class TestBuyersView(LoggedInApplicationTest):
         email = document.xpath('//td[@class="summary-item-field"]//text()')[1].strip()
         phone = document.xpath('//td[@class="summary-item-field"]//text()')[4].strip()
 
-        self.assertEqual("Test Buyer", name)
-        self.assertEqual("test_buyer@example.com", email)
-        self.assertEqual("02078888888", phone)
+        assert name == "Test Buyer"
+        assert email == "test_buyer@example.com"
+        assert phone == "02078888888"

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -1,6 +1,5 @@
 from functools import wraps
 from lxml import html
-from nose.tools import assert_equal, assert_in
 import mock
 try:
     from urlparse import urlsplit
@@ -28,13 +27,13 @@ def user_data(role='admin'):
 class TestLogin(BaseApplicationTest):
     def test_should_be_redirected_to_login_page(self):
         res = self.client.get('/admin')
-        assert_equal(res.status_code, 302)
-        assert_equal(urlsplit(res.location).path, '/admin/login')
+        assert res.status_code == 302
+        assert urlsplit(res.location).path == '/admin/login'
 
     def test_should_show_login_page(self):
         res = self.client.get("/admin/login")
-        assert_equal(res.status_code, 200)
-        assert_in("Administrator login", res.get_data(as_text=True))
+        assert res.status_code == 200
+        assert "Administrator login" in res.get_data(as_text=True)
 
     @mock.patch('app.data_api_client')
     @mock.patch('app.main.views.login.data_api_client')
@@ -45,10 +44,10 @@ class TestLogin(BaseApplicationTest):
             'email_address': 'valid@email.com',
             'password': '1234567890'
         })
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
 
         res = self.client.get('/admin')
-        assert_equal(res.status_code, 200)
+        assert res.status_code == 200
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_strip_whitespace_surrounding_login_email_address_field(self, data_api_client):
@@ -75,8 +74,8 @@ class TestLogin(BaseApplicationTest):
             'email_address': 'valid@example.com',
             'password': '1234567890',
         })
-        assert_equal(res.status_code, 302)
-        assert_equal(urlsplit(res.location).path, '/admin/safe')
+        assert res.status_code == 302
+        assert urlsplit(res.location).path == '/admin/safe'
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_bad_next_url_takes_user_to_dashboard(self, data_api_client):
@@ -85,8 +84,8 @@ class TestLogin(BaseApplicationTest):
             'email_address': 'valid@example.com',
             'password': '1234567890',
         })
-        assert_equal(res.status_code, 302)
-        assert_equal(urlsplit(res.location).path, '/admin')
+        assert res.status_code == 302
+        assert urlsplit(res.location).path == '/admin'
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_have_cookie_on_redirect(self, data_api_client):
@@ -99,9 +98,9 @@ class TestLogin(BaseApplicationTest):
                 'password': '1234567890',
             })
             cookie_parts = res.headers['Set-Cookie'].split('; ')
-            assert_in('Secure', cookie_parts)
-            assert_in('HttpOnly', cookie_parts)
-            assert_in('Path=/admin', cookie_parts)
+            assert 'Secure' in cookie_parts
+            assert 'HttpOnly' in cookie_parts
+            assert 'Path=/admin' in cookie_parts
 
     @mock.patch('app.data_api_client')
     @mock.patch('app.main.views.login.data_api_client')
@@ -113,8 +112,8 @@ class TestLogin(BaseApplicationTest):
             'password': '1234567890',
         })
         res = self.client.get('/admin/logout')
-        assert_equal(res.status_code, 302)
-        assert_equal(urlsplit(res.location).path, '/admin/login')
+        assert res.status_code == 302
+        assert urlsplit(res.location).path == '/admin/login'
 
     @mock.patch('app.data_api_client')
     @mock.patch('app.main.views.login.data_api_client')
@@ -127,8 +126,8 @@ class TestLogin(BaseApplicationTest):
         })
         self.client.get('/admin/logout')
         res = self.client.get('/admin')
-        assert_equal(res.status_code, 302)
-        assert_equal(urlsplit(res.location).path, '/admin/login')
+        assert res.status_code == 302
+        assert urlsplit(res.location).path == '/admin/login'
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_return_a_403_for_invalid_login(self, data_api_client):
@@ -139,7 +138,7 @@ class TestLogin(BaseApplicationTest):
             'password': '1234567890',
         })
 
-        assert_equal(res.status_code, 403)
+        assert res.status_code == 403
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_return_a_403_if_invalid_role(self, data_api_client):
@@ -150,7 +149,7 @@ class TestLogin(BaseApplicationTest):
             'password': '1234567890',
         })
 
-        assert_equal(res.status_code, 403)
+        assert res.status_code == 403
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_can_login_with_admin_ccs_role(self, data_api_client):
@@ -161,25 +160,25 @@ class TestLogin(BaseApplicationTest):
             'password': '1234567890',
         })
 
-        assert_equal(res.status_code, 302)
+        assert res.status_code == 302
 
     def test_should_be_validation_error_if_no_email_or_password(self):
         res = self.client.post('/admin/login', data={})
-        assert_equal(res.status_code, 400)
+        assert res.status_code == 400
 
     def test_should_be_validation_error_if_invalid_email(self):
         res = self.client.post('/admin/login', data={
             'email_address': 'invalid',
             'password': '1234567890',
         })
-        assert_equal(res.status_code, 400)
+        assert res.status_code == 400
 
 
 class TestSession(BaseApplicationTest):
     def test_url_with_non_canonical_trailing_slash(self):
         response = self.client.get('/admin/')
-        self.assertEquals(301, response.status_code)
-        self.assertEquals("http://localhost/admin", response.location)
+        assert response.status_code == 301
+        assert response.location == "http://localhost/admin"
 
 
 class TestLoginFormsNotAutofillable(BaseApplicationTest):
@@ -188,22 +187,22 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
             self, url, expected_title
     ):
         response = self.client.get(url)
-        self.assertEqual(200, response.status_code)
+        assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
 
         page_title = document.xpath(
             '//h1/text()')[0].strip()
-        self.assertEqual(expected_title, page_title)
+        assert page_title == expected_title
 
         forms = document.xpath('//div[@class="page-container"]//form')
 
         for form in forms:
-            self.assertEqual("off", form.get('autocomplete'))
+            assert form.get('autocomplete') == "off"
             non_hidden_inputs = form.xpath('//input[@type!="hidden"]')
 
             for input in non_hidden_inputs:
-                self.assertEqual("off", input.get('autocomplete'))
+                assert input.get('autocomplete') == "off"
 
     def test_login_form_and_inputs_not_autofillable(self):
         self._forms_and_inputs_not_autofillable(
@@ -221,28 +220,28 @@ class TestRoleRequired(LoggedInApplicationTest):
 
     def test_admin_ccs_can_view_admin_dashboard(self):
         response = self.client.get('/admin')
-        assert_equal(200, response.status_code)
+        assert response.status_code == 200
 
     def test_admin_role_required_service_status_edit(self):
         response = self.client.post('/admin/services/status/1')
-        assert_equal(403, response.status_code)
+        assert response.status_code == 403
 
     def test_admin_role_required_audit_acknowledge(self):
         response = self.client.post('/admin/service-updates/1/acknowledge')
-        assert_equal(403, response.status_code)
+        assert response.status_code == 403
 
     def test_admin_role_required_unlock_user(self):
         response = self.client.post('/admin/suppliers/users/1/unlock')
-        assert_equal(403, response.status_code)
+        assert response.status_code == 403
 
     def test_admin_role_required_activate_user(self):
         response = self.client.post('/admin/suppliers/users/1/activate')
-        assert_equal(403, response.status_code)
+        assert response.status_code == 403
 
     def test_admin_role_required_deactivate_user(self):
         response = self.client.post('/admin/suppliers/users/1/deactivate')
-        assert_equal(403, response.status_code)
+        assert response.status_code == 403
 
     def test_admin_role_required_invite_user(self):
         response = self.client.post('/admin/suppliers/1/invite-user')
-        assert_equal(403, response.status_code)
+        assert response.status_code == 403

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -13,7 +13,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         today = datetime.utcnow().strftime(DISPLAY_DATE_FORMAT)
 
         response = self.client.get('/admin/service-updates')
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         date_header = """
         <p class="context">
@@ -24,105 +24,80 @@ class TestServiceUpdates(LoggedInApplicationTest):
         </h1>
         """.format(today)
 
-        self.assertIn(
-            self._replace_whitespace(date_header),
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
+        assert self._replace_whitespace(date_header) in self._replace_whitespace(response.get_data(as_text=True))
 
         data_api_client.find_audit_events.assert_called()
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_render_correct_form_defaults(self, data_api_client):
         response = self.client.get('/admin/service-updates')
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
-        self.assertIn(
-            '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type="text" value="">',  # noqa
-            response.get_data(as_text=True)
-        )
+        assert '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type='\
+            '"text" value="">' in response.get_data(as_text=True)
 
-        self.assertIn(
-            self._replace_whitespace(
-                '<input name="acknowledged" value="false" id="acknowledged-3" type="radio" aria-controls="" checked>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
+        assert self._replace_whitespace(
+            '<input name="acknowledged" value="false" id="acknowledged-3" type="radio" aria-controls="" checked>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
 
         data_api_client.find_audit_events.assert_called()
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_not_allow_invalid_dates(self, data_api_client):
         response = self.client.get('/admin/service-updates?audit_date=invalid')
-        self.assertEquals(400, response.status_code)
-        self.assertIn(
-            "Not a valid date value",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type="text" value="invalid">',  # noqa
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 400
+        assert "Not a valid date value" in response.get_data(as_text=True)
+        assert '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type='\
+            '"text" value="invalid">' in response.get_data(as_text=True)
 
-        self.assertIn(
-            '<div class="validation-masthead" aria-labelledby="validation-masthead-heading">',  # noqa
+        assert '<div class="validation-masthead" aria-labelledby="validation-masthead-heading">' in \
             response.get_data(as_text=True)
-        )
-
-        self.assertIn(
-            self._replace_whitespace(
-                '<a href="#example-textbox" class="validation-masthead-link"><label for="audit_date">Audit Date</label></a>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
 
         data_api_client.find_audit_events.assert_not_called()
+        assert self._replace_whitespace(
+            '<a href="#example-textbox" class="validation-masthead-link"><label for="audit_date">Audit Date</label></a>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_not_allow_invalid_acknowledges(self, data_api_client):
         response = self.client.get(
             '/admin/service-updates?acknowledged=invalid'
         )
-        self.assertEquals(400, response.status_code)
+        assert response.status_code == 400
 
-        self.assertIn(
-            self._replace_whitespace(
-                '<a href="#example-textbox" class="validation-masthead-link"><label for="acknowledged">acknowledged</label></a>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
         data_api_client.find_audit_events.assert_not_called()
+        assert self._replace_whitespace(
+            '<a href="#example-textbox" class="validation-masthead-link"><label for="acknowledged">acknowledged' +
+            '</label></a>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_allow_valid_submission_all(self, data_api_client):
         data_api_client.find_audit_events.return_value = {'auditEvents': [], 'links': {}}
 
         response = self.client.get('/admin/service-updates?audit_date=2006-01-01&acknowledged=all')
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type="text" value="2006-01-01">',  # noqa
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type='\
+            '"text" value="2006-01-01">' in response.get_data(as_text=True)
 
-        self.assertIn(
-            self._replace_whitespace(
-                '<inputname="acknowledged"value="all"id="acknowledged-1"type="radio"aria-controls=""checked>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
         data_api_client.find_audit_events.assert_called()
+        assert self._replace_whitespace(
+            '<inputname="acknowledged"value="all"id="acknowledged-1"type="radio"aria-controls=""checked>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_allow_valid_submission_date_fields(self, data_api_client):
         data_api_client.find_audit_events.return_value = {'auditEvents': [], 'links': {}}
 
         response = self.client.get('/admin/service-updates?audit_date=2006-01-01')  # noqa
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type="text" value="2006-01-01">',  # noqa
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type='\
+            '"text" value="2006-01-01">' in response.get_data(as_text=True)
 
-        self.assertIn(
-            self._replace_whitespace(
-                '<inputname="acknowledged"value="false"id="acknowledged-3"type="radio"aria-controls=""checked>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
+        assert self._replace_whitespace(
+            '<inputname="acknowledged"value="false"id="acknowledged-3"type="radio"aria-controls=""checked>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
+
         data_api_client.find_audit_events.assert_called_with(
             audit_date='2006-01-01',
             audit_type=AuditTypes.update_service,
@@ -134,17 +109,14 @@ class TestServiceUpdates(LoggedInApplicationTest):
         data_api_client.find_audit_events.return_value = {'auditEvents': [], 'links': {}}
 
         response = self.client.get('/admin/service-updates?acknowledged=false')  # noqa
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type="text" value="">',  # noqa
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type='\
+            '"text" value="">' in response.get_data(as_text=True)
 
-        self.assertIn(
-            self._replace_whitespace(
-                '<inputname="acknowledged"value="false"id="acknowledged-3"type="radio"aria-controls=""checked>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
+        assert self._replace_whitespace(
+            '<inputname="acknowledged"value="false"id="acknowledged-3"type="radio"aria-controls=""checked>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
+
         data_api_client.find_audit_events.assert_called_with(
             audit_date=None,
             audit_type=AuditTypes.update_service,
@@ -156,7 +128,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         data_api_client.find_audit_events.return_value = {'auditEvents': [], 'links': {}}
 
         response = self.client.get('/admin/service-updates?audit_date=2006-01-01&acknowledged=all')  # noqa
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         data_api_client.find_audit_events.assert_called_with(
             audit_type=AuditTypes.update_service,
@@ -169,7 +141,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         data_api_client.find_audit_events.return_value = {'auditEvents': [], 'links': {}}
 
         response = self.client.get('/admin/service-updates?acknowledged=all')  # noqa
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         data_api_client.find_audit_events.assert_called_with(
             audit_type=AuditTypes.update_service,
@@ -183,7 +155,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             '/admin/service-updates?audit_date=2010-01-01'
         )
 
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         date_header = """
         <p class="context">
@@ -194,10 +166,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         </h1>
         """
 
-        self.assertIn(
-            self._replace_whitespace(date_header),
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
+        assert self._replace_whitespace(date_header) in self._replace_whitespace(response.get_data(as_text=True))
 
         data_api_client.find_audit_events.assert_called()
 
@@ -211,21 +180,14 @@ class TestServiceUpdates(LoggedInApplicationTest):
             }
         )
 
-        self.assertEquals(302, response.status_code)
-        self.assertIn(
-            'http://localhost/admin/service-updates',
-            response.location)
-        self.assertIn(
-            'acknowledged=false',
-            response.location)
-        self.assertIn(
-            'audit_date=2010-01-05',
-            response.location)
-
         data_api_client.acknowledge_audit_event.assert_called(
             audit_event_id=123,
             user='test@example.com'
         )
+        assert response.status_code == 302
+        assert 'http://localhost/admin/service-updates' in response.location
+        assert 'acknowledged=false' in response.location
+        assert 'audit_date=2010-01-05' in response.location
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_not_call_api_when_form_errors(self, data_api_client):
@@ -237,29 +199,25 @@ class TestServiceUpdates(LoggedInApplicationTest):
             }
         )
 
-        self.assertEquals(400, response.status_code)
         data_api_client.acknowledge_audit_event.assert_not_called()
-        self.assertIn(
-            self._replace_whitespace(
-                '<inputname="acknowledged"value="false"id="acknowledged-3"type="radio"aria-controls=""checked>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
-        self.assertIn(
-            '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type="text" value="invalid">',  # noqa
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 400
+        assert self._replace_whitespace(
+            '<inputname="acknowledged"value="false"id="acknowledged-3"type="radio"aria-controls=""checked>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type='\
+            '"text" value="invalid">' in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_show_no_updates_if_none_returned(self, data_api_client):
         data_api_client.find_audit_events.return_value = {'auditEvents': [], 'links': {}}
 
         response = self.client.get('/admin/service-updates?audit_date=2006-01-01')  # noqa
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
-        self.assertIn(
-            self._replace_whitespace('Noauditeventsfound'),
-            self._replace_whitespace(response.get_data(as_text=True))
+        assert self._replace_whitespace('Noauditeventsfound') in self._replace_whitespace(
+            response.get_data(as_text=True)
         )
+
         data_api_client.find_audit_events.assert_called_with(
             page=1,
             audit_date='2006-01-01',
@@ -269,11 +227,10 @@ class TestServiceUpdates(LoggedInApplicationTest):
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_show_no_updates_if_invalid_search(self, data_api_client):
         response = self.client.get('/admin/service-updates?audit_date=invalid')  # noqa
-        self.assertEquals(400, response.status_code)
+        assert response.status_code == 400
 
-        self.assertIn(
-            self._replace_whitespace('Noauditeventsfound'),
-            self._replace_whitespace(response.get_data(as_text=True))
+        assert self._replace_whitespace('Noauditeventsfound') in self._replace_whitespace(
+            response.get_data(as_text=True)
         )
         data_api_client.find_audit_events.assert_not_called()
 
@@ -302,33 +259,24 @@ class TestServiceUpdates(LoggedInApplicationTest):
 
         data_api_client.find_audit_events.return_value = audit_event
         response = self.client.get('/admin/service-updates?audit_date=2010-01-01')  # noqa
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
-        self.assertIn(
-            self._replace_whitespace(
-               '<td class="summary-item-field-first"><span>Clouded Networks</span></td>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
-        self.assertIn(
-            self._replace_whitespace(
-               '<td class="summary-item-field"><span>09:49:22<br/>17 June</span></td>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
-        self.assertIn(
-            self._replace_whitespace(
-               '<td class="summary-item-field-with-action"><span><a href="/admin/services/compare/...">View changes</a></span></td>'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
-        self.assertIn(
-            self._replace_whitespace(
-               '<form action="/admin/service-updates/25/acknowledge" method="post">'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
-        self.assertIn(
-            self._replace_whitespace(
-               '<input name="audit_date" type="hidden" value="2010-01-01">'),  # noqa
-            self._replace_whitespace(response.get_data(as_text=True))
-        )
+        assert self._replace_whitespace(
+            '<td class="summary-item-field-first"><span>Clouded Networks</span></td>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert self._replace_whitespace(
+            '<td class="summary-item-field"><span>09:49:22<br/>17 June</span></td>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert self._replace_whitespace(
+            '<td class="summary-item-field-with-action"><span><a href="/admin/services/compare/...">View changes</a>' +
+            '</span></td>'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert self._replace_whitespace(
+            '<form action="/admin/service-updates/25/acknowledge" method="post">'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert self._replace_whitespace(
+            '<input name="audit_date" type="hidden" value="2010-01-01">'
+        ) in self._replace_whitespace(response.get_data(as_text=True))
         data_api_client.find_audit_events.assert_called_with(
             page=1,
             audit_type=AuditTypes.update_service,
@@ -338,7 +286,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_call_api_ack_audit_event(self, data_api_client):
         response = self.client.post('/admin/service-updates/123/acknowledge?audit_date=2010-01-01&acknowledged=all')  # noqa
-        self.assertEquals(302, response.status_code)
+        assert response.status_code == 302
 
         data_api_client.acknowledge_audit_event.assert_called_with(
             '123', 'test@example.com'
@@ -347,7 +295,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_pass_valid_page_argument_to_api(self, data_api_client):
         response = self.client.get('/admin/service-updates?page=5')
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         data_api_client.find_audit_events.assert_called_with(
             page=5,
@@ -359,7 +307,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_not_pass_invalid_page_argument_to_api(self, data_api_client):
         response = self.client.get('/admin/service-updates?page=invalid')
-        self.assertEquals(400, response.status_code)
+        assert response.status_code == 400
 
         data_api_client.find_audit_events.assert_not_called()
 
@@ -372,15 +320,15 @@ class TestServiceStatusUpdates(LoggedInApplicationTest):
             '/admin/service-status-updates'
         )
 
-        self.assertEquals(302, response.status_code)
-        self.assertIn('http://localhost/admin/service-status-updates/20', response.location)
+        assert response.status_code == 302
+        assert 'http://localhost/admin/service-status-updates/20' in response.location
 
     def test_404s_invalid_date(self, data_api_client):
         response = self.client.get(
             '/admin/service-status-updates/invalid'
         )
 
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     def test_should_show_updates_for_a_day_with_updates(self, data_api_client):
         data_api_client.find_audit_events.return_value = {
@@ -403,12 +351,12 @@ class TestServiceStatusUpdates(LoggedInApplicationTest):
             '/admin/service-status-updates/2016-01-01'
         )
 
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         page_contents = self._replace_whitespace(response.get_data(as_text=True))
 
-        self.assertIn('Friday1January2016', page_contents)
-        self.assertIn('1234567890', page_contents)
+        assert 'Friday1January2016' in page_contents
+        assert '1234567890' in page_contents
 
     def test_should_link_to_previous_and_next_days(self, data_api_client):
         data_api_client.find_audit_events.return_value = {
@@ -421,15 +369,15 @@ class TestServiceStatusUpdates(LoggedInApplicationTest):
 
         page_contents = self._replace_whitespace(response.get_data(as_text=True))
 
-        self.assertIn('Wednesday23December2015', page_contents)
+        assert 'Wednesday23December2015' in page_contents
 
-        self.assertIn('class="next-page"', page_contents)
-        self.assertIn('Tuesday22December2015', page_contents)
-        self.assertIn('/service-status-updates/2015-12-22', page_contents)
+        assert 'class="next-page"' in page_contents
+        assert 'Tuesday22December2015' in page_contents
+        assert '/service-status-updates/2015-12-22' in page_contents
 
-        self.assertIn('class="previous-page"', page_contents)
-        self.assertIn('Thursday24December2015', page_contents)
-        self.assertIn('/service-status-updates/2015-12-24', page_contents)
+        assert 'class="previous-page"' in page_contents
+        assert 'Thursday24December2015' in page_contents
+        assert '/service-status-updates/2015-12-24' in page_contents
 
     def test_should_link_to_next_page(self, data_api_client):
         data_api_client.find_audit_events.return_value = {
@@ -445,12 +393,12 @@ class TestServiceStatusUpdates(LoggedInApplicationTest):
 
         page_contents = self._replace_whitespace(response.get_data(as_text=True))
 
-        self.assertIn('class="next-page"', page_contents)
-        self.assertIn('Page2', page_contents)
-        self.assertIn('ofWednesday23December2015', page_contents)
-        self.assertIn('/service-status-updates/2015-12-23/page-2', page_contents)
+        assert 'class="next-page"' in page_contents
+        assert 'Page2' in page_contents
+        assert 'ofWednesday23December2015' in page_contents
+        assert '/service-status-updates/2015-12-23/page-2' in page_contents
 
-        self.assertIn('Nextday', page_contents)
+        assert 'Nextday' in page_contents
 
     def test_should_link_to_previous_page(self, data_api_client):
         data_api_client.find_audit_events.return_value = {
@@ -467,7 +415,7 @@ class TestServiceStatusUpdates(LoggedInApplicationTest):
 
         page_contents = self._replace_whitespace(response.get_data(as_text=True))
 
-        self.assertIn('class="previous-page"', page_contents)
-        self.assertIn('Page1', page_contents)
-        self.assertIn('ofWednesday23December2015', page_contents)
-        self.assertIn('/service-status-updates/2015-12-23/page-1', page_contents)
+        assert 'class="previous-page"' in page_contents
+        assert 'Page1' in page_contents
+        assert 'ofWednesday23December2015' in page_contents
+        assert '/service-status-updates/2015-12-23/page-1' in page_contents

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -26,7 +26,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
 
         assert self._replace_whitespace(date_header) in self._replace_whitespace(response.get_data(as_text=True))
 
-        data_api_client.find_audit_events.assert_called()
+        assert data_api_client.find_audit_events.called is True
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_render_correct_form_defaults(self, data_api_client):
@@ -40,7 +40,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             '<input name="acknowledged" value="false" id="acknowledged-3" type="radio" aria-controls="" checked>'
         ) in self._replace_whitespace(response.get_data(as_text=True))
 
-        data_api_client.find_audit_events.assert_called()
+        assert data_api_client.find_audit_events.called is True
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_not_allow_invalid_dates(self, data_api_client):
@@ -53,10 +53,10 @@ class TestServiceUpdates(LoggedInApplicationTest):
         assert '<div class="validation-masthead" aria-labelledby="validation-masthead-heading">' in \
             response.get_data(as_text=True)
 
-        data_api_client.find_audit_events.assert_not_called()
         assert self._replace_whitespace(
             '<a href="#example-textbox" class="validation-masthead-link"><label for="audit_date">Audit Date</label></a>'
         ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert data_api_client.find_audit_events.called is False
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_not_allow_invalid_acknowledges(self, data_api_client):
@@ -65,11 +65,11 @@ class TestServiceUpdates(LoggedInApplicationTest):
         )
         assert response.status_code == 400
 
-        data_api_client.find_audit_events.assert_not_called()
         assert self._replace_whitespace(
             '<a href="#example-textbox" class="validation-masthead-link"><label for="acknowledged">acknowledged' +
             '</label></a>'
         ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert data_api_client.find_audit_events.called is False
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_allow_valid_submission_all(self, data_api_client):
@@ -80,10 +80,10 @@ class TestServiceUpdates(LoggedInApplicationTest):
         assert '<input class="filter-field-text" id="audit_date" name="audit_date" placeholder="eg, 2015-07-23" type='\
             '"text" value="2006-01-01">' in response.get_data(as_text=True)
 
-        data_api_client.find_audit_events.assert_called()
         assert self._replace_whitespace(
             '<inputname="acknowledged"value="all"id="acknowledged-1"type="radio"aria-controls=""checked>'
         ) in self._replace_whitespace(response.get_data(as_text=True))
+        assert data_api_client.find_audit_events.called
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_allow_valid_submission_date_fields(self, data_api_client):
@@ -168,7 +168,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
 
         assert self._replace_whitespace(date_header) in self._replace_whitespace(response.get_data(as_text=True))
 
-        data_api_client.find_audit_events.assert_called()
+        assert data_api_client.find_audit_events.called
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_redirect_to_update_page(self, data_api_client):
@@ -180,14 +180,12 @@ class TestServiceUpdates(LoggedInApplicationTest):
             }
         )
 
-        data_api_client.acknowledge_audit_event.assert_called(
-            audit_event_id=123,
-            user='test@example.com'
-        )
         assert response.status_code == 302
         assert 'http://localhost/admin/service-updates' in response.location
         assert 'acknowledged=false' in response.location
         assert 'audit_date=2010-01-05' in response.location
+
+        data_api_client.acknowledge_audit_event.assert_called_with("123", 'test@example.com')
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_not_call_api_when_form_errors(self, data_api_client):
@@ -199,8 +197,8 @@ class TestServiceUpdates(LoggedInApplicationTest):
             }
         )
 
-        data_api_client.acknowledge_audit_event.assert_not_called()
         assert response.status_code == 400
+        assert data_api_client.acknowledge_audit_event.called is False
         assert self._replace_whitespace(
             '<inputname="acknowledged"value="false"id="acknowledged-3"type="radio"aria-controls=""checked>'
         ) in self._replace_whitespace(response.get_data(as_text=True))
@@ -232,7 +230,8 @@ class TestServiceUpdates(LoggedInApplicationTest):
         assert self._replace_whitespace('Noauditeventsfound') in self._replace_whitespace(
             response.get_data(as_text=True)
         )
-        data_api_client.find_audit_events.assert_not_called()
+
+        assert data_api_client.find_audit_events.called is False
 
     @mock.patch('app.main.views.service_updates.data_api_client')
     def test_should_show_updates_if_valid_search(self, data_api_client):
@@ -309,7 +308,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         response = self.client.get('/admin/service-updates?page=invalid')
         assert response.status_code == 400
 
-        data_api_client.find_audit_events.assert_not_called()
+        assert data_api_client.find_audit_events.called is False
 
 
 @mock.patch('app.main.views.service_updates.data_api_client')

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -94,11 +94,10 @@ class TestServiceView(LoggedInApplicationTest):
         data_api_client.get_service.side_effect = HTTPError(response)
 
         response1 = self.client.get('/admin/services/1')
-        self.assertEquals(302, response1.status_code)
-        self.assertEquals(response1.location, 'http://localhost/admin')
+        assert response1.status_code == 302
+        assert response1.location == 'http://localhost/admin'
         response2 = self.client.get(response1.location)
-        self.assertIn(b'Error trying to retrieve service with ID: 1',
-                      response2.data)
+        assert b'Error trying to retrieve service with ID: 1' in response2.data
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_not_found_flash_message_injection(self, data_api_client):
@@ -112,11 +111,11 @@ class TestServiceView(LoggedInApplicationTest):
 
         response1 = self.client.get('/admin/services/1%3Cimg%20src%3Da%20onerror%3Dalert%281%29%3E')
         response2 = self.client.get(response1.location)
-        self.assertEqual(response2.status_code, 200)
+        assert response2.status_code == 200
 
         html_response = response2.get_data(as_text=True)
-        self.assertNotIn("1<img src=a onerror=alert(1)>", html_response)
-        self.assertIn("1&lt;img src=a onerror=alert(1)&gt;", html_response)
+        assert "1<img src=a onerror=alert(1)>" not in html_response
+        assert "1&lt;img src=a onerror=alert(1)&gt;" in html_response
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_independence_of_viewing_services(self, data_api_client):
@@ -126,7 +125,7 @@ class TestServiceView(LoggedInApplicationTest):
             'id': "1",
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn(b'Termination cost', response.data)
+        assert b'Termination cost' in response.data
 
         data_api_client.get_service.return_value = {'services': {
             'lot': 'SaaS',
@@ -134,7 +133,7 @@ class TestServiceView(LoggedInApplicationTest):
             'id': "1",
         }}
         response = self.client.get('/admin/services/1')
-        self.assertNotIn(b'Termination cost', response.data)
+        assert b'Termination cost' not in response.data
 
         data_api_client.get_service.return_value = {'services': {
             'lot': 'SCS',
@@ -142,7 +141,7 @@ class TestServiceView(LoggedInApplicationTest):
             'id': "1",
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn(b'Termination cost', response.data)
+        assert b'Termination cost' in response.data
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_status_update_widgets_not_visible_when_not_permitted(self, data_api_client):
@@ -152,7 +151,7 @@ class TestServiceView(LoggedInApplicationTest):
             'id': "1",
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn(b'Termination cost', response.data)
+        assert b'Termination cost' in response.data
 
 
 class TestServiceEdit(LoggedInApplicationTest):
@@ -176,7 +175,7 @@ class TestServiceEdit(LoggedInApplicationTest):
 
         data_api_client.get_service.assert_called_with('1')
 
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_edit_documents_empty_post(self, data_api_client):
@@ -196,12 +195,10 @@ class TestServiceEdit(LoggedInApplicationTest):
         )
 
         data_api_client.get_service.assert_called_with('1')
-        self.assertFalse(data_api_client.update_service.called)
+        assert data_api_client.update_service.called is False
 
-        self.assertEquals(302, response.status_code)
-        self.assertEquals(
-            "/admin/services/1", urlsplit(response.location).path
-        )
+        assert response.status_code == 302
+        assert urlsplit(response.location).path == "/admin/services/1"
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_edit_documents_post(self, data_api_client):
@@ -231,7 +228,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'sfiaRateDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-7/documents/2/1-sfia-rate-card-2015-01-01-1200.pdf',  # noqa
         }, 'test@example.com')
 
-        self.assertEquals(302, response.status_code)
+        assert response.status_code == 302
 
     @mock.patch("app.main.views.services.data_api_client")
     def test_service_edit_documents_post_with_validation_errors(
@@ -256,10 +253,10 @@ class TestServiceEdit(LoggedInApplicationTest):
         )
 
         data_api_client.get_service.assert_called_with('1')
-        self.assertFalse(data_api_client.update_service.called)
+        assert data_api_client.update_service.called is False
 
-        self.assertIn('Your document is not in an open format', response.get_data(as_text=True))
-        self.assertEquals(400, response.status_code)
+        assert 'Your document is not in an open format' in response.get_data(as_text=True)
+        assert response.status_code == 400
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_edit_with_one_service_feature(self, data_api_client):
@@ -278,14 +275,10 @@ class TestServiceEdit(LoggedInApplicationTest):
         response = self.client.get(
             '/admin/services/1/edit/features-and-benefits'
         )
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
         stripped_page = self.strip_all_whitespace(response.get_data(as_text=True))
-        self.assertIn(
-            'id="input-serviceFeatures-0"class="text-box"value="bar"',
-            stripped_page)
-        self.assertIn(
-            'id="input-serviceFeatures-1"class="text-box"value=""',
-            stripped_page)
+        assert 'id="input-serviceFeatures-0"class="text-box"value="bar"' in stripped_page
+        assert 'id="input-serviceFeatures-1"class="text-box"value=""' in stripped_page
         response = self.client.post(
             '/admin/services/1/edit/features-and-benefits',
             data={
@@ -297,7 +290,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             'serviceFeatures': ['foo'],
             'serviceBenefits': ['foo'],
         }, 'test@example.com')
-        self.assertEquals(response.status_code, 302)
+        assert response.status_code == 302
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_edit_with_no_features_or_benefits(self, data_api_client):
@@ -310,10 +303,10 @@ class TestServiceEdit(LoggedInApplicationTest):
 
         data_api_client.get_service.assert_called_with('1')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            'id="input-serviceFeatures-0"class="text-box"value=""',
-            self.strip_all_whitespace(response.get_data(as_text=True)))
+        assert response.status_code == 200
+        assert 'id="input-serviceFeatures-0"class="text-box"value=""' in self.strip_all_whitespace(
+            response.get_data(as_text=True)
+        )
 
     @mock.patch('app.main.views.services.data_api_client')
     @mock.patch('app.main.views.services.upload_service_documents')
@@ -337,8 +330,7 @@ class TestServiceEdit(LoggedInApplicationTest):
                 'termsAndConditionsDocumentURL': (StringIO(), 'test.pdf'),
             }
         )
-        self.assertIn('There was a problem with the answer to this question',
-                      response.get_data(as_text=True))
+        assert 'There was a problem with the answer to this question' in response.get_data(as_text=True)
 
 
 @mock.patch('app.main.views.services.data_api_client')
@@ -352,9 +344,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'status': 'disabled'
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_disabled" value="removed" checked="checked" />', response.data)  # noqa
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
-        self.assertNotIn(b'<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_disabled" value="removed" checked="checked" />' in response.data  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_private" value="private"  />' in response.data  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_published" value="public"  />' not in response.data  # noqa
 
     def test_can_make_private_service_public_or_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -364,9 +356,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'status': 'enabled'
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked" />', response.data)  # noqa
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_published" value="public"  />', response.data)  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />' in response.data  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked" />' in response.data  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_published" value="public"  />' in response.data  # noqa
 
     def test_can_make_public_service_private_or_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -376,9 +368,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'status': 'published'
         }}
         response = self.client.get('/admin/services/1')
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />', response.data)  # noqa
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_private" value="private"  />', response.data)  # noqa
-        self.assertIn(b'<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />', response.data)  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />' in response.data  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_private" value="private"  />' in response.data  # noqa
+        assert b'<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />' in response.data  # noqa
 
     def test_status_update_to_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -388,12 +380,10 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
                                      data={'service_status': 'removed'})
         data_api_client.update_service_status.assert_called_with(
             '1', 'disabled', 'test@example.com')
-        self.assertEquals(302, response1.status_code)
-        self.assertEquals(response1.location,
-                          'http://localhost/admin/services/1')
+        assert response1.status_code == 302
+        assert response1.location == 'http://localhost/admin/services/1'
         response2 = self.client.get(response1.location)
-        self.assertIn(b'Service status has been updated to: Removed',
-                      response2.data)
+        assert b'Service status has been updated to: Removed' in response2.data
 
     def test_status_update_to_private(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -403,12 +393,10 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
                                      data={'service_status': 'private'})
         data_api_client.update_service_status.assert_called_with(
             '1', 'enabled', 'test@example.com')
-        self.assertEquals(302, response1.status_code)
-        self.assertEquals(response1.location,
-                          'http://localhost/admin/services/1')
+        assert response1.status_code == 302
+        assert response1.location == 'http://localhost/admin/services/1'
         response2 = self.client.get(response1.location)
-        self.assertIn(b'Service status has been updated to: Private',
-                      response2.data)
+        assert b'Service status has been updated to: Private' in response2.data
 
     def test_status_update_to_published(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -418,12 +406,10 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
                                      data={'service_status': 'public'})
         data_api_client.update_service_status.assert_called_with(
             '1', 'published', 'test@example.com')
-        self.assertEquals(302, response1.status_code)
-        self.assertEquals(response1.location,
-                          'http://localhost/admin/services/1')
+        assert response1.status_code == 302
+        assert response1.location == 'http://localhost/admin/services/1'
         response2 = self.client.get(response1.location)
-        self.assertIn(b'Service status has been updated to: Public',
-                      response2.data)
+        assert b'Service status has been updated to: Public' in response2.data
 
     def test_bad_status_gives_error_message(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -431,22 +417,20 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'suspended'})
-        self.assertEquals(302, response1.status_code)
-        self.assertEquals(response1.location,
-                          'http://localhost/admin/services/1')
+        assert response1.status_code == 302
+        assert response1.location == 'http://localhost/admin/services/1'
         response2 = self.client.get(response1.location)
-        self.assertIn(b"Not a valid status: 'suspended'",
-                      response2.data)
+        assert b"Not a valid status: 'suspended'" in response2.data
 
     def test_services_with_missing_id(self, data_api_client):
         response = self.client.get('/admin/services')
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
 
 class TestCompareServiceArchives(LoggedInApplicationTest):
 
-    def setUp(self):
-        super(TestCompareServiceArchives, self).setUp()
+    def setup_method(self, method):
+        super(TestCompareServiceArchives, self).setup_method(method)
         self._services = {
             1: {'services': {
                 'id': 1,
@@ -500,7 +484,7 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
                      'try again.'
             }
 
-    class TestContent(object):
+    class _TestContent(object):
         def __init__(self):
             self.sections = [{
                 'editable': True,
@@ -549,30 +533,30 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
 
         # Both archived services don't exist
         response = self._get_archived_services_response('1', '2')
-        self.assertEqual(404, response.status_code)
+        assert response.status_code == 404
 
         # First archived service doesn't exist
         response = self._get_archived_services_response('1', '20')
-        self.assertEqual(404, response.status_code)
+        assert response.status_code == 404
 
         # Second archived service doesn't exist
         response = self._get_archived_services_response('10', '2')
-        self.assertEqual(404, response.status_code)
+        assert response.status_code == 404
 
     def test_cannot_get_same_archived_service(self):
 
         response = self._get_archived_services_response('10', '10')
-        self.assertEqual(404, response.status_code)
+        assert response.status_code == 404
 
     def test_cannot_get_archived_services_in_non_chronological_order(self):
 
         response = self._get_archived_services_response('20', '10')
-        self.assertEqual(404, response.status_code)
+        assert response.status_code == 404
 
     def test_cannot_get_archived_services_for_nonexistent_service_ids(self):
 
         response = self._get_archived_services_response('30', '40')
-        self.assertEqual(404, response.status_code)
+        assert response.status_code == 404
 
     @mock.patch('app.main.views.services.content_loader')
     def test_can_get_archived_services_with_dates_and_diffs(self, content_loader):
@@ -580,42 +564,39 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
         class TestBuilder(object):
             @staticmethod
             def filter(*args):
-                return self.TestContent()
+                return self._TestContent()
 
         content_loader.get_manifest.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '20')
 
         # check title is there
-        self.assertIn(
-            self.strip_all_whitespace('<h1>&lt;h1&gt;Cloudy&lt;/h1&gt; Cloud Service</h1>'),
-            self.strip_all_whitespace(response.get_data(as_text=True))
-        )
+        assert self.strip_all_whitespace(
+            '<h1>&lt;h1&gt;Cloudy&lt;/h1&gt; Cloud Service</h1>'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
 
         # check dates are right
-        self.assertIn(
-            self.strip_all_whitespace('Monday 1 December 2014 at 10:55'),
-            self.strip_all_whitespace(response.get_data(as_text=True))
-        )
-        self.assertIn(
-            self.strip_all_whitespace('Tuesday 2 December 2014 at 10:55'),
-            self.strip_all_whitespace(response.get_data(as_text=True))
-        )
+        assert self.strip_all_whitespace(
+            'Monday 1 December 2014 at 10:55'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
+
+        assert self.strip_all_whitespace(
+            'Tuesday 2 December 2014 at 10:55'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
 
         # check lines are there
-        self.assertIn(
-            self.strip_all_whitespace('<td class=\'line-content unchanged\'>Cloud Service</td>'),
-            self.strip_all_whitespace(response.get_data(as_text=True))
-        )
-        self.assertIn(
-            self.strip_all_whitespace('<td class=\'line-content addition\'><strong>&lt;h1&gt;Cloudy&lt;/h1&gt;</strong> Cloud Service</td>'),  # noqa
-            self.strip_all_whitespace(response.get_data(as_text=True))
-        )
+        assert self.strip_all_whitespace(
+            '<td class=\'line-content unchanged\'>Cloud Service</td>'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
+
+        assert self.strip_all_whitespace(
+            '<td class=\'line-content addition\'><strong>&lt;h1&gt;Cloudy&lt;/h1&gt;</strong> Cloud Service</td>'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
 
         # check status is right
-        self.assertIn(self.strip_all_whitespace(
-            '<input type="radio" name="service_status" id="service_status_published" value="public" checked="checked" />'),  # noqa
-            self.strip_all_whitespace(response.get_data(as_text=True))
-        )
+        assert self.strip_all_whitespace(
+            '<input type="radio" name="service_status" id="service_status_published" value="public" checked=' +
+            '"checked" />'
+        ) in self.strip_all_whitespace(response.get_data(as_text=True))
 
     @mock.patch('app.main.views.services.content_loader')
     def test_can_get_archived_services_with_differing_keys(self, content_loader):
@@ -623,8 +604,8 @@ class TestCompareServiceArchives(LoggedInApplicationTest):
         class TestBuilder(object):
             @staticmethod
             def filter(*args):
-                return self.TestContent()
+                return self._TestContent()
 
         content_loader.get_manifest.return_value = TestBuilder()
         response = self._get_archived_services_response('10', '50')
-        self.assertEqual(200, response.status_code)
+        assert response.status_code == 200

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -1,4 +1,3 @@
-from nose.tools import assert_in
 import mock
 
 from dmapiclient import HTTPError
@@ -22,7 +21,7 @@ class TestStats(LoggedInApplicationTest):
             per_page=1260
         )
 
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
     def test_supplier_counts_on_stats_page(self, data_api_client):
         data_api_client.find_audit_events.return_value = {
@@ -79,23 +78,23 @@ class TestStats(LoggedInApplicationTest):
             per_page=1260
         )
 
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
         page_without_whitespace = ''.join(response.get_data(as_text=True).split())
-        assert_in('<span>214</span>', page_without_whitespace)  # Interested suppliers = 101+113
-        assert_in('<span>107</span>', page_without_whitespace)  # Declaration only
-        assert_in('<span>230</span>', page_without_whitespace)  # Completed services only 103 + 127
-        assert_in('<span>109</span>', page_without_whitespace)  # Eligible application
+        assert '<span>214</span>' in page_without_whitespace  # Interested suppliers = 101+113
+        assert '<span>107</span>' in page_without_whitespace  # Declaration only
+        assert '<span>230</span>' in page_without_whitespace  # Completed services only 103 + 127
+        assert '<span>109</span>' in page_without_whitespace  # Eligible application
 
     def test_get_stats_page_for_invalid_framework(self, data_api_client):
         api_response = mock.Mock()
         api_response.status_code = 404
         data_api_client.find_audit_events.side_effect = HTTPError(api_response)
         response = self.client.get('/admin/statistics/g-cloud-11')
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     def test_get_stats_page_when_API_is_down(self, data_api_client):
         api_response = mock.Mock()
         api_response.status_code = 500
         data_api_client.find_audit_events.side_effect = HTTPError(api_response)
         response = self.client.get('/admin/statistics/g-cloud-7')
-        self.assertEquals(500, response.status_code)
+        assert response.status_code == 500

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -3,8 +3,6 @@ from six.moves.urllib.parse import urlsplit, urlparse, parse_qs
 import mock
 from freezegun import freeze_time
 from lxml import html
-from nose.tools import eq_
-from nose.tools import assert_equals
 from dmapiclient import HTTPError, APIError
 from dmutils.email import MandrillException
 from dmapiclient.audit import AuditTypes
@@ -18,7 +16,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
     def test_should_raise_http_error_from_api(self, data_api_client):
         data_api_client.find_suppliers.side_effect = HTTPError(Response(404))
         response = self.client.get('/admin/suppliers')
-        assert_equals(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_should_list_suppliers(self, data_api_client):
         data_api_client.find_suppliers.return_value = {
@@ -36,8 +34,8 @@ class TestSuppliersListView(LoggedInApplicationTest):
         response = self.client.get("/admin/suppliers")
         document = html.fromstring(response.get_data(as_text=True))
 
-        assert_equals(response.status_code, 200)
-        assert_equals(len(document.cssselect('.summary-item-row')), 2)
+        assert response.status_code == 200
+        assert len(document.cssselect('.summary-item-row')) == 2
 
     def test_should_search_by_prefix(self, data_api_client):
         data_api_client.find_suppliers.side_effect = HTTPError(Response(404))
@@ -64,18 +62,18 @@ class TestSupplierUsersView(LoggedInApplicationTest):
     def test_should_404_if_no_supplier_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.side_effect = HTTPError(Response(404))
         response = self.client.get('/admin/suppliers/users?supplier_id=999')
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     def test_should_404_if_no_supplier_id(self):
         response = self.client.get('/admin/suppliers/users')
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_apis_with_supplier_id(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         data_api_client.get_supplier.assert_called_with('1000')
         data_api_client.find_users.assert_called_with('1000')
@@ -85,11 +83,8 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "Supplier Name",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "Supplier Name" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_indicate_if_there_are_no_users(self, data_api_client):
@@ -98,11 +93,8 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "This supplier has no users on the Digital Marketplace",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "This supplier has no users on the Digital Marketplace" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_user_details_on_page(self, data_api_client):
@@ -111,55 +103,21 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "Test User",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "test.user@sme.com",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "10:33:53",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "23 July",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "13:46:01",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "29 June",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "No",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "Test User" in response.get_data(as_text=True)
+        assert "test.user@sme.com" in response.get_data(as_text=True)
+        assert "10:33:53" in response.get_data(as_text=True)
+        assert "23 July" in response.get_data(as_text=True)
+        assert "13:46:01" in response.get_data(as_text=True)
+        assert "29 June" in response.get_data(as_text=True)
+        assert "No" in response.get_data(as_text=True)
 
-        self.assertIn(
-            '<input type="submit" class="button-destructive"  value="Deactivate" />',
+        assert '<input type="submit" class="button-destructive"  value="Deactivate" />' in \
             response.get_data(as_text=True)
-        )
-
-        self.assertIn(
-            '<form action="/admin/suppliers/users/999/deactivate" method="post">',
+        assert '<form action="/admin/suppliers/users/999/deactivate" method="post">' in response.get_data(as_text=True)
+        assert '<button class="button-save">Move user to this supplier</button>' in response.get_data(as_text=True)
+        assert '<form action="/admin/suppliers/1234/move-existing-user" method="post">' in \
             response.get_data(as_text=True)
-        )
-
-        self.assertIn(
-            '<button class="button-save">Move user to this supplier</button>',
-            response.get_data(as_text=True)
-        )
-
-        self.assertIn(
-            '<form action="/admin/suppliers/1234/move-existing-user" method="post">',
-            response.get_data(as_text=True)
-        )
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_unlock_button_if_user_locked(self, data_api_client):
@@ -171,15 +129,9 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            '<form action="/admin/suppliers/users/999/unlock" method="post">',
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            '<input type="submit" class="button-secondary"  value="Unlock" />',
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert '<form action="/admin/suppliers/users/999/unlock" method="post">' in response.get_data(as_text=True)
+        assert '<input type="submit" class="button-secondary"  value="Unlock" />' in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_activate_button_if_user_deactivated(self, data_api_client):
@@ -191,15 +143,9 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            '<form action="/admin/suppliers/users/999/activate" method="post">',
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            '<input type="submit" class="button-secondary"  value="Activate" />',
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert '<form action="/admin/suppliers/users/999/activate" method="post">' in response.get_data(as_text=True)
+        assert '<input type="submit" class="button-secondary"  value="Activate" />' in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_unlock_user(self, data_api_client):
@@ -210,8 +156,8 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         data_api_client.update_user.assert_called_with(999, locked=False, updater="test@example.com")
 
-        self.assertEquals(302, response.status_code)
-        self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
+        assert response.status_code == 302
+        assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_activate_user(self, data_api_client):
@@ -222,8 +168,8 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         data_api_client.update_user.assert_called_with(999, active=True, updater="test@example.com")
 
-        self.assertEquals(302, response.status_code)
-        self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
+        assert response.status_code == 302
+        assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_deactivate_user(self, data_api_client):
@@ -237,8 +183,8 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         data_api_client.update_user.assert_called_with(999, active=False, updater="test@example.com")
 
-        self.assertEquals(302, response.status_code)
-        self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
+        assert response.status_code == 302
+        assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_move_user_to_another_supplier(self, data_api_client):
@@ -255,8 +201,8 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             999, role='supplier', supplier_id=1000, active=True, updater="test@example.com"
         )
 
-        self.assertEquals(302, response.status_code)
-        self.assertEquals("http://localhost/admin/suppliers/users?supplier_id=1000", response.location)
+        assert response.status_code == 302
+        assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
 
 class TestSupplierServicesView(LoggedInApplicationTest):
@@ -265,18 +211,18 @@ class TestSupplierServicesView(LoggedInApplicationTest):
     def test_should_404_if_supplier_does_not_exist_on_services(self, data_api_client):
         data_api_client.get_supplier.side_effect = HTTPError(Response(404))
         response = self.client.get('/admin/suppliers/services?supplier_id=999')
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     def test_should_404_if_no_supplier_id_on_services(self):
         response = self.client.get('/admin/suppliers/users')
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_service_apis_with_supplier_id(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         response = self.client.get('/admin/suppliers/services?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         data_api_client.get_supplier.assert_called_with('1000')
         data_api_client.find_services.assert_called_with('1000')
@@ -287,11 +233,8 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         data_api_client.find_services.return_value = {'services': []}
         response = self.client.get('/admin/suppliers/services?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "This supplier has no services on the Digital Marketplace",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "This supplier has no services on the Digital Marketplace" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_have_supplier_name_on_services_page(self, data_api_client):
@@ -300,11 +243,8 @@ class TestSupplierServicesView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/services?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "Supplier Name",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "Supplier Name" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_service_details_on_page(self, data_api_client):
@@ -313,39 +253,15 @@ class TestSupplierServicesView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/services?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "Contract Management",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            '<a href="/g-cloud/services/5687123785023488">',
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "5687123785023488",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "G-Cloud 6",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "Software as a Service",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "Public",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            '<a href="/admin/services/5687123785023488">',
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "Edit",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "Contract Management" in response.get_data(as_text=True)
+        assert '<a href="/g-cloud/services/5687123785023488">' in response.get_data(as_text=True)
+        assert "5687123785023488" in response.get_data(as_text=True)
+        assert "G-Cloud 6" in response.get_data(as_text=True)
+        assert "Software as a Service" in response.get_data(as_text=True)
+        assert "Public" in response.get_data(as_text=True)
+        assert '<a href="/admin/services/5687123785023488">' in response.get_data(as_text=True)
+        assert "Edit" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_correct_fields_for_disabled_service(self, data_api_client):
@@ -357,15 +273,9 @@ class TestSupplierServicesView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/services?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "Removed",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "Details",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "Removed" in response.get_data(as_text=True)
+        assert "Details" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_correct_fields_for_enabled_service(self, data_api_client):
@@ -377,15 +287,9 @@ class TestSupplierServicesView(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/services?supplier_id=1000')
 
-        self.assertEquals(200, response.status_code)
-        self.assertIn(
-            "Private",
-            response.get_data(as_text=True)
-        )
-        self.assertIn(
-            "Edit",
-            response.get_data(as_text=True)
-        )
+        assert response.status_code == 200
+        assert "Private" in response.get_data(as_text=True)
+        assert "Edit" in response.get_data(as_text=True)
 
 
 class TestSupplierInviteUserView(LoggedInApplicationTest):
@@ -401,8 +305,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             follow_redirects=True
         )
 
-        self.assertEquals(400, response.status_code)
-        self.assertTrue("Please enter a valid email address" in response.get_data(as_text=True))
+        assert response.status_code == 400
+        assert "Please enter a valid email address" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_not_allow_missing_email_on_invite_user(self, data_api_client):
@@ -415,8 +319,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             follow_redirects=True
         )
 
-        self.assertEquals(400, response.status_code)
-        self.assertTrue("Email can not be empty" in response.get_data(as_text=True))
+        assert response.status_code == 400
+        assert "Email can not be empty" in response.get_data(as_text=True)
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_be_a_404_if_non_int_supplier_id(self, data_api_client):
@@ -427,8 +331,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             follow_redirects=True
         )
 
-        self.assertEquals(404, response.status_code)
-        self.assertFalse(data_api_client.called)
+        assert response.status_code == 404
+        assert data_api_client.called is False
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_be_a_404_if_supplier_id_not_found(self, data_api_client):
@@ -442,8 +346,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
         )
 
         data_api_client.get_supplier.assert_called_with(1234)
-        self.assertFalse(data_api_client.find_users.called)
-        self.assertEquals(404, response.status_code)
+        assert data_api_client.find_users.called is False
+        assert response.status_code == 404
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_be_a_404_if_supplier_users_not_found(self, data_api_client):
@@ -458,7 +362,7 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
 
         data_api_client.get_supplier.assert_called_with(1234)
         data_api_client.find_users.assert_called_with(1234)
-        self.assertEquals(404, response.status_code)
+        assert response.status_code == 404
 
     @mock.patch('app.main.views.suppliers.generate_token')
     @mock.patch('app.main.views.suppliers.send_email')
@@ -484,8 +388,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             'SALT'
         )
 
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, 'http://localhost/admin/suppliers/users?supplier_id=1234')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/admin/suppliers/users?supplier_id=1234'
 
     @mock.patch('app.main.views.suppliers.generate_token')
     @mock.patch('app.main.views.suppliers.send_email')
@@ -507,8 +411,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             object_id=1234,
             data={'invitedEmail': 'email@example.com'})
 
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, 'http://localhost/admin/suppliers/users?supplier_id=1234')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/admin/suppliers/users?supplier_id=1234'
 
     @mock.patch('app.main.views.suppliers.generate_token')
     @mock.patch('app.main.views.suppliers.send_email')
@@ -523,10 +427,10 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
                 'email_address': 'this@isvalid.com',
             })
 
-        self.assertFalse(data_api_client.find_users.called)
-        self.assertFalse(send_email.called)
-        self.assertFalse(generate_token.called)
-        self.assertEqual(res.status_code, 404)
+        assert data_api_client.find_users.called is False
+        assert send_email.called is False
+        assert generate_token.called is False
+        assert res.status_code == 404
 
     @mock.patch('app.main.views.suppliers.send_email')
     @mock.patch('app.main.views.suppliers.data_api_client')
@@ -551,8 +455,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             ["user-invite"]
         )
 
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, 'http://localhost/admin/suppliers/users?supplier_id=1234')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/admin/suppliers/users?supplier_id=1234'
 
     @mock.patch('app.main.views.suppliers.send_email')
     @mock.patch('app.main.views.suppliers.data_api_client')
@@ -601,8 +505,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             supplier="Supplier Name"
         )
 
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, 'http://localhost/admin/suppliers/users?supplier_id=1234')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/admin/suppliers/users?supplier_id=1234'
 
     @mock.patch('app.main.views.suppliers.send_email')
     @mock.patch('app.main.views.suppliers.data_api_client')
@@ -626,7 +530,7 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             ["user-invite"]
         )
 
-        self.assertEqual(res.status_code, 503)
+        assert res.status_code == 503
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -661,14 +565,14 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
 
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_should_404_if_supplier_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.side_effect = APIError(Response(404))
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
         assert not data_api_client.get_framework.called
 
@@ -678,7 +582,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
         data_api_client.get_framework.assert_called_with('g-cloud-7')
 
@@ -689,7 +593,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
 
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
         data_api_client.get_supplier.assert_called_with('1234')
         data_api_client.get_framework.assert_called_with('g-cloud-7')
         data_api_client.get_supplier_declaration.assert_called_with('1234', 'g-cloud-7')
@@ -702,9 +606,9 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
         document = html.fromstring(response.get_data(as_text=True))
 
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
         data = document.cssselect('.summary-item-row td.summary-item-field')
-        eq_(data[0].text_content().strip(), "Yes")
+        assert data[0].text_content().strip() == "Yes"
 
     def test_should_show_dos_declaration(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -714,9 +618,9 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/digital-outcomes-and-specialists')
         document = html.fromstring(response.get_data(as_text=True))
 
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
         data = document.cssselect('.summary-item-row td.summary-item-field')
-        eq_(data[0].text_content().strip(), "Yes")
+        assert data[0].text_content().strip() == "Yes"
 
     def test_should_403_if_framework_is_open(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -725,7 +629,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_supplier_declaration.return_value = self.load_example_listing('declaration_response')
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/digital-outcomes-and-specialists')
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -737,14 +641,14 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/section')
 
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_should_404_if_supplier_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.side_effect = APIError(Response(404))
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
         assert not data_api_client.get_framework.called
 
@@ -754,7 +658,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
         data_api_client.get_framework.assert_called_with('g-cloud-7')
 
@@ -765,7 +669,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/not_a_section')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_should_not_404_if_declaration_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -774,7 +678,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
         data_api_client.get_supplier.assert_called_with('1234')
         data_api_client.get_framework.assert_called_with('g-cloud-7')
         data_api_client.get_supplier_declaration.assert_called_with('1234', 'g-cloud-7')
@@ -787,7 +691,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
         document = html.fromstring(response.get_data(as_text=True))
 
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
         assert document.cssselect('#input-PR1-yes')[0].checked
         assert not document.cssselect('#input-PR1-no')[0].checked
 
@@ -834,7 +738,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_should_404_if_document_does_not_exist(self, s3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = {
@@ -845,7 +749,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 
         s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-foo.pdf')
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_should_redirect(self, s3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = {
@@ -858,8 +762,8 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 
         s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-foo.pdf')
-        eq_(response.status_code, 302)
-        eq_(response.location, 'https://example/blah?extra')
+        assert response.status_code == 302
+        assert response.location == 'https://example/blah?extra'
 
     def test_admin_should_be_able_to_download_countersigned_agreement(self, s3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = {
@@ -875,7 +779,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
         s3.S3.return_value.get_signed_url.assert_called_with(
             'g-cloud-7/agreements/1234/1234-countersigned-framework-agreement.pdf'
         )
-        eq_(response.status_code, 302)
+        assert response.status_code == 302
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -888,7 +792,7 @@ class TestListCountersignedAgreementFile(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/countersigned-agreements/g-cloud-7')
 
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_should_be_visible_to_admin_sourcing_users(self, s3, data_api_client):
         s3.S3.return_value.get_key.return_value = {
@@ -906,7 +810,7 @@ class TestListCountersignedAgreementFile(LoggedInApplicationTest):
             }}
 
         response = self.client.get('/admin/suppliers/1234/countersigned-agreements/g-cloud-7')
-        eq_(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_should_display_no_documents_if_no_documents_listed(self, s3, data_api_client):
         s3.S3.return_value.get_key.return_value = []
@@ -919,10 +823,7 @@ class TestListCountersignedAgreementFile(LoggedInApplicationTest):
         }
 
         response = self.client.get('/admin/suppliers/1234/countersigned-agreements/g-cloud-7')
-        self.assertIn(
-            'No agreements have been uploaded',
-            response.get_data(as_text=True)
-        )
+        assert 'No agreements have been uploaded' in response.get_data(as_text=True)
 
 
 @freeze_time('2016-12-25 06:30:01')
@@ -952,11 +853,8 @@ class TestUploadCountersignedAgreementFile(LoggedInApplicationTest):
                                         countersigned_agreement=(BytesIO(b"this is a test"),
                                                                  'test.odt'), ), follow_redirects=True)
 
-        self.assertIn(
-            'This must be a pdf',
-            response.get_data(as_text=True)
-        )
-        eq_(response.status_code, 200)
+        assert 'This must be a pdf' in response.get_data(as_text=True)
+        assert response.status_code == 200
 
     def test_can_upload_countersigned_agreement_for_signed_agreement(self, s3, data_api_client):
         s3.S3.return_value.get_key.return_value = {
@@ -1135,7 +1033,7 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
                                                       ',g-cloud-7/agreements/93495/93495-'
                                                       'countersigned-framework-agreement.pdf'}
         response = self.client.post('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7')
-        eq_(response.status_code, 302)
+        assert response.status_code == 302
 
     def test_admin_should_not_be_able_to_remove_countersigned_agreement(self, s3, data_api_client):
         self.user_role = 'admin'
@@ -1143,7 +1041,7 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
                                                       ',g-cloud-7/agreements/93495/93495-'
                                                       'countersigned-framework-agreement.pdf'}
         response = self.client.post('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7')
-        eq_(response.status_code, 403)
+        assert response.status_code == 403
 
     def test_should_display_remove_countersigned_agreement_message(self, s3, data_api_client):
         s3.S3.return_value.get_key.return_value = {
@@ -1161,11 +1059,8 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
             }}
         response = self.client.get('/admin/suppliers/1234/countersigned-agreements-remove/g-cloud-7',
                                    follow_redirects=True)
-        self.assertIn(
-            'Do you want to remove the countersigned agreement?',
-            response.get_data(as_text=True)
-        )
-        eq_(response.status_code, 200)
+        assert 'Do you want to remove the countersigned agreement?' in response.get_data(as_text=True)
+        assert response.status_code == 200
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -1178,7 +1073,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
         assert not data_api_client.get_framework.called
 
@@ -1188,7 +1083,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
         data_api_client.get_framework.assert_called_with('g-cloud-8')
 
@@ -1200,7 +1095,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         data_api_client.get_supplier_framework_info.return_value = not_returned
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
 
-        eq_(response.status_code, 404)
+        assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
         data_api_client.get_framework.assert_called_with('g-cloud-8')
         data_api_client.get_supplier_framework_info.assert_called_with('1234', 'g-cloud-8')
@@ -1240,7 +1135,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
             response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
             document = html.fromstring(response.get_data(as_text=True))
-            eq_(response.status_code, 200)
+            assert response.status_code == 200
             # Registered Address
             assert len(document.xpath('//li[contains(text(), "Corsewall Lighthouse")]')) == 1
             assert len(document.xpath('//li[contains(text(), "Stranraer")]')) == 1
@@ -1268,7 +1163,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
             mock_get_url.return_value = "http://example.com/document/1234.pdf"
             response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
             document = html.fromstring(response.get_data(as_text=True))
-            eq_(response.status_code, 200)
+            assert response.status_code == 200
             assert len(document.xpath('//embed[@src="http://example.com/document/1234.pdf"]')) == 1
             assert len(document.xpath('//img[@src="http://example.com/document/1234.pdf"]')) == 0
 
@@ -1285,7 +1180,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
             mock_get_url.return_value = "http://example.com/document/1234.png"
             response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
             document = html.fromstring(response.get_data(as_text=True))
-            eq_(response.status_code, 200)
+            assert response.status_code == 200
             assert len(document.xpath('//img[@src="http://example.com/document/1234.png"]')) == 1
             assert len(document.xpath('//embed[@src="http://example.com/document/1234.png"]')) == 0
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -553,7 +553,7 @@ class TestUpdatintSupplierName(LoggedInApplicationTest):
                 data={'new_supplier_name': 'Something New'}
             )
             assert response.status_code == 403
-            data_api_client.update_supplier.assert_not_called()
+            assert data_api_client.update_supplier.called is False
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
@@ -574,7 +574,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
-        assert not data_api_client.get_framework.called
+        assert data_api_client.get_framework.called is False
 
     def test_should_404_if_framework_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -650,7 +650,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
 
         assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
-        assert not data_api_client.get_framework.called
+        assert data_api_client.get_framework.called is False
 
     def test_should_404_if_framework_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -934,7 +934,7 @@ class TestUploadCountersignedAgreementFile(LoggedInApplicationTest):
                                                                  'countersigned_agreement.pdf'),
                                     ))
 
-        data_api_client.approve_agreement_for_countersignature.assert_not_called()
+        assert data_api_client.approve_agreement_for_countersignature.called is False
 
         s3.S3.return_value.save.assert_called_once_with(
             "g-cloud-7/agreements/1234/1234-agreement-countersignature-2016-12-25-063001.pdf",
@@ -1075,7 +1075,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         assert response.status_code == 404
         data_api_client.get_supplier.assert_called_with('1234')
-        assert not data_api_client.get_framework.called
+        assert data_api_client.get_framework.called is False
 
     def test_should_404_if_framework_does_not_exist(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -1205,7 +1205,7 @@ class TestPutSignedAgreementOnHold(LoggedInApplicationTest):
         data_api_client.put_signed_agreement_on_hold.return_value = self.put_signed_agreement_on_hold_return_value
         res = self.client.post('/admin/suppliers/agreements/123/on-hold', data={"nameOfOrganisation": "Test"})
 
-        assert not data_api_client.put_signed_agreement_on_hold.called
+        assert data_api_client.put_signed_agreement_on_hold.called is False
         assert res.status_code == 403
 
     def test_happy_path(self, data_api_client):
@@ -1260,7 +1260,7 @@ class TestApproveAgreement(LoggedInApplicationTest):
             self.put_signed_agreement_on_hold_return_value
         res = self.client.post('/admin/suppliers/agreements/123/approve', data={"nameOfOrganisation": "Test"})
 
-        assert not data_api_client.approve_agreement_for_countersignature.called
+        assert data_api_client.approve_agreement_for_countersignature.called is False
         assert res.status_code == 403
 
     def test_happy_path(self, data_api_client):

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -16,47 +16,47 @@ class TestUsersView(LoggedInApplicationTest):
     def test_should_be_a_404_if_user_not_found(self, data_api_client):
         data_api_client.get_user.return_value = None
         response = self.client.get('/admin/users?email_address=some@email.com')
-        self.assertEquals(response.status_code, 404)
+        assert response.status_code == 404
 
         document = html.fromstring(response.get_data(as_text=True))
 
         page_title = document.xpath(
             '//p[@class="banner-message"]//text()')[0].strip()
-        self.assertEqual("Sorry, we couldn't find an account with that email address", page_title)
+        assert page_title == "Sorry, we couldn't find an account with that email address"
 
         page_title = document.xpath(
             '//p[@class="summary-item-no-content"]//text()')[0].strip()
-        self.assertEqual("No users to show", page_title)
+        assert page_title == "No users to show"
 
     def test_should_be_a_404_if_no_email_provided(self, data_api_client):
         data_api_client.get_user.return_value = None
         response = self.client.get('/admin/users?email_address=')
-        self.assertEquals(response.status_code, 404)
+        assert response.status_code == 404
 
         document = html.fromstring(response.get_data(as_text=True))
 
         page_title = document.xpath(
             '//p[@class="banner-message"]//text()')[0].strip()
-        self.assertEqual("Sorry, we couldn't find an account with that email address", page_title)
+        assert page_title == "Sorry, we couldn't find an account with that email address"
 
         page_title = document.xpath(
             '//p[@class="summary-item-no-content"]//text()')[0].strip()
-        self.assertEqual("No users to show", page_title)
+        assert page_title == "No users to show"
 
     def test_should_be_a_404_if_no_email_param_provided(self, data_api_client):
         data_api_client.get_user.return_value = None
         response = self.client.get('/admin/users')
-        self.assertEquals(response.status_code, 404)
+        assert response.status_code == 404
 
         document = html.fromstring(response.get_data(as_text=True))
 
         page_title = document.xpath(
             '//p[@class="banner-message"]//text()')[0].strip()
-        self.assertEqual("Sorry, we couldn't find an account with that email address", page_title)
+        assert page_title == "Sorry, we couldn't find an account with that email address"
 
         page_title = document.xpath(
             '//p[@class="summary-item-no-content"]//text()')[0].strip()
-        self.assertEqual("No users to show", page_title)
+        assert page_title == "No users to show"
 
     def test_should_show_buyer_user(self, data_api_client):
         buyer = self.load_example_listing("user_response")
@@ -64,73 +64,73 @@ class TestUsersView(LoggedInApplicationTest):
         buyer['users']['role'] = 'buyer'
         data_api_client.get_user.return_value = buyer
         response = self.client.get('/admin/users?email_address=test.user@sme.com')
-        self.assertEquals(response.status_code, 200)
+        assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
 
         email_address = document.xpath(
             '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
-        self.assertEqual("test.user@sme.com", email_address)
+        assert email_address == "test.user@sme.com"
 
         name = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[0].strip()
-        self.assertEqual("Test User", name)
+        assert name == "Test User"
 
         role = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()
-        self.assertEqual("buyer", role)
+        assert role == "buyer"
 
         supplier = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[2].strip()
-        self.assertEquals('', supplier)
+        assert supplier == ''
 
         last_login = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[3].strip()
-        self.assertEquals('10:33:53', last_login)
+        assert last_login == '10:33:53'
 
         last_login_day = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[4].strip()
-        self.assertEquals('23 July', last_login_day)
+        assert last_login_day == '23 July'
 
         last_password_changed = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[5].strip()
-        self.assertEquals('13:46:01', last_password_changed)
+        assert last_password_changed == '13:46:01'
 
         last_password_changed_day = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[6].strip()
-        self.assertEquals('29 June', last_password_changed_day)
+        assert last_password_changed_day == '29 June'
 
         locked = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[7].strip()
-        self.assertEquals('No', locked)
+        assert locked == 'No'
 
         button = document.xpath(
             '//input[@class="button-destructive"]')[0].value
-        self.assertEquals('Deactivate', button)
+        assert button == 'Deactivate'
 
     def test_should_show_supplier_user(self, data_api_client):
         buyer = self.load_example_listing("user_response")
         data_api_client.get_user.return_value = buyer
         response = self.client.get('/admin/users?email_address=test.user@sme.com')
-        self.assertEquals(response.status_code, 200)
+        assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
 
         email_address = document.xpath(
             '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
-        self.assertEqual("test.user@sme.com", email_address)
+        assert email_address == "test.user@sme.com"
 
         role = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()
-        self.assertEqual("supplier", role)
+        assert role == "supplier"
 
         supplier = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/a/text()')[0].strip()
-        self.assertEquals('SME Corp UK Limited', supplier)
+        assert supplier == 'SME Corp UK Limited'
 
         supplier_link = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/a')[0]
-        self.assertEquals('/admin/suppliers?supplier_id=1000', supplier_link.attrib['href'])
+        assert supplier_link.attrib['href'] == '/admin/suppliers?supplier_id=1000'
 
     def test_should_show_unlock_button(self, data_api_client):
         buyer = self.load_example_listing("user_response")
@@ -138,7 +138,7 @@ class TestUsersView(LoggedInApplicationTest):
 
         data_api_client.get_user.return_value = buyer
         response = self.client.get('/admin/users?email_address=test.user@sme.com')
-        self.assertEquals(response.status_code, 200)
+        assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -148,16 +148,16 @@ class TestUsersView(LoggedInApplicationTest):
             '//tr[@class="summary-item-row"]//td/span/form')[0]
         return_link = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/form/input')[1]
-        self.assertEquals('/admin/suppliers/users/999/unlock', unlock_link.attrib['action'])
-        self.assertEquals('Unlock', unlock_button)
-        self.assertEquals('/admin/users?email_address=test.user%40sme.com', return_link.attrib['value'])
+        assert unlock_link.attrib['action'] == '/admin/suppliers/users/999/unlock'
+        assert unlock_button == 'Unlock'
+        assert return_link.attrib['value'] == '/admin/users?email_address=test.user%40sme.com'
 
     def test_should_show_deactivate_button(self, data_api_client):
         buyer = self.load_example_listing("user_response")
 
         data_api_client.get_user.return_value = buyer
         response = self.client.get('/admin/users?email_address=test.user@sme.com')
-        self.assertEquals(response.status_code, 200)
+        assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -167,9 +167,9 @@ class TestUsersView(LoggedInApplicationTest):
             '//tr[@class="summary-item-row"]//td/span/form')[0]
         return_link = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/form/input')[1]
-        self.assertEquals('/admin/suppliers/users/999/deactivate', deactivate_link.attrib['action'])
-        self.assertEquals('Deactivate', deactivate_button)
-        self.assertEquals('/admin/users?email_address=test.user%40sme.com', return_link.attrib['value'])
+        assert deactivate_link.attrib['action'] == '/admin/suppliers/users/999/deactivate'
+        assert deactivate_button == 'Deactivate'
+        assert return_link.attrib['value'] == '/admin/users?email_address=test.user%40sme.com'
 
 
 @mock.patch('app.main.views.users.data_api_client')

--- a/tests/app/status/test_views.py
+++ b/tests/app/status/test_views.py
@@ -9,8 +9,8 @@ class TestStatus(BaseApplicationTest):
     @mock.patch('app.status.views.data_api_client')
     def test_should_return_200_from_elb_status_check(self, data_api_client):
         status_response = self.client.get('/admin/_status?ignore-dependencies')
-        self.assertEquals(200, status_response.status_code)
-        self.assertFalse(data_api_client.called)
+        assert status_response.status_code == 200
+        assert data_api_client.called is False
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_ok(self, data_api_client):
@@ -18,13 +18,12 @@ class TestStatus(BaseApplicationTest):
         data_api_client.get_status.return_value = {"status": "ok"}
 
         response = self.client.get('/admin/_status')
-        self.assertEquals(200, response.status_code)
+        assert response.status_code == 200
 
         json_data = json.loads(response.get_data())
 
-        self.assertEquals("ok", "{}".format(json_data['status']))
-        self.assertEquals("ok", "{}".format(
-            json_data['api_status']['status']))
+        assert "{}".format(json_data['status']) == "ok"
+        assert "{}".format(json_data['api_status']['status']) == "ok"
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_error(self, data_api_client):
@@ -36,8 +35,8 @@ class TestStatus(BaseApplicationTest):
         }
 
         response = self.client.get('/admin/_status')
-        self.assertEquals(500, response.status_code)
+        assert response.status_code == 500
 
         json_data = json.loads(response.get_data())
 
-        self.assertEquals("error", "{}".format(json_data['status']))
+        assert "{}".format(json_data['status']) == "error"

--- a/tests/app/test_diff_tool.py
+++ b/tests/app/test_diff_tool.py
@@ -5,10 +5,10 @@ from flask import Markup
 
 class TestDiffToolsHelpers(unittest.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
-    def tearDown(self):
+    def teardown_method(self, method):
         pass
 
     def _get_original_line_from_revision(self, words):
@@ -18,7 +18,7 @@ class TestDiffToolsHelpers(unittest.TestCase):
     def _check_correct_number_of_lines_in_revisions(
             self, lines, expected_number_of_lines):
         for key in lines.keys():
-            self.assertEqual(len(lines[key]), expected_number_of_lines)
+            assert len(lines[key]) == expected_number_of_lines
 
     def test_correct_number_of_lines(self):
         revision_1 = """line one""".splitlines()
@@ -67,21 +67,15 @@ class TestDiffToolsHelpers(unittest.TestCase):
         revision_2 = """line one\nline two""".splitlines()
         rendered_lines = render_lines(revision_1, revision_2)
 
-        self.assertEqual(
-            rendered_lines['revision_1'][0],
-            Markup(
-                u"<td class='line-number line-number-empty'>2</td>"
-                u"<td class='line-content empty'></td>"
-            )
+        assert rendered_lines['revision_1'][0] == Markup(
+            u"<td class='line-number line-number-empty'>2</td>"
+            u"<td class='line-content empty'></td>"
         )
-        self.assertEqual(
-            rendered_lines['revision_2'][0],
-            Markup(
-                u"<td class='line-number line-number-addition'>2</td>"
-                u"<td class='line-content addition'>"
-                u"<strong>line two</strong>"
-                u"</td>"
-            )
+        assert rendered_lines['revision_2'][0] == Markup(
+            u"<td class='line-number line-number-addition'>2</td>"
+            u"<td class='line-content addition'>"
+            u"<strong>line two</strong>"
+            u"</td>"
         )
 
     def test_rendered_lines_work_for_removed_line(self):
@@ -89,42 +83,30 @@ class TestDiffToolsHelpers(unittest.TestCase):
         revision_2 = """line one""".splitlines()
         rendered_lines = render_lines(revision_1, revision_2)
 
-        self.assertEqual(
-            rendered_lines['revision_1'][0],
-            Markup(
-                u"<td class='line-number line-number-removal'>2</td>"
-                u"<td class='line-content removal'>"
-                u"<strong>line two</strong>"
-                u"</td>"
-            )
+        assert rendered_lines['revision_1'][0] == Markup(
+            u"<td class='line-number line-number-removal'>2</td>"
+            u"<td class='line-content removal'>"
+            u"<strong>line two</strong>"
+            u"</td>"
         )
-        self.assertEqual(
-            rendered_lines['revision_2'][0],
-            Markup(
-                u"<td class='line-number line-number-empty'>2</td>"
-                u"<td class='line-content empty'></td>"
-            )
+        assert rendered_lines['revision_2'][0] == Markup(
+            u"<td class='line-number line-number-empty'>2</td>"
+            u"<td class='line-content empty'></td>"
         )
 
     def test_rendered_lines_work_for_edited_line(self):
         revision_1 = """line number one has changed""".splitlines()
         revision_2 = """line one has actually changed""".splitlines()
         rendered_lines = render_lines(revision_1, revision_2)
-        self.assertEqual(
-            rendered_lines['revision_1'][0],
-            Markup(
-                u"<td class='line-number line-number-removal'>1</td>"
-                u"<td class='line-content removal'>"
-                u"line <strong>number</strong> one has changed"
-                u"</td>"
-            )
+        assert rendered_lines['revision_1'][0] == Markup(
+            u"<td class='line-number line-number-removal'>1</td>"
+            u"<td class='line-content removal'>"
+            u"line <strong>number</strong> one has changed"
+            u"</td>"
         )
-        self.assertEqual(
-            rendered_lines['revision_2'][0],
-            Markup(
-                u"<td class='line-number line-number-addition'>1</td>"
-                u"<td class='line-content addition'>"
-                u"line one has <strong>actually</strong> changed"
-                u"</td>"
-            )
+        assert rendered_lines['revision_2'][0] == Markup(
+            u"<td class='line-number line-number-addition'>1</td>"
+            u"<td class='line-content addition'>"
+            u"line one has <strong>actually</strong> changed"
+            u"</td>"
         )


### PR DESCRIPTION
It's happened. I've removed all uses of nose and unittest's `self.assert*` so that we will be able to in the future use py.test features such as parametrization.

~~Unfortunately this sits on top of #239 so will have to wait until it's been merged (and as such will also not pass its tests until https://github.com/alphagov/digitalmarketplace-frameworks/pull/349 is merged). But that's not really avoidable without me having to do a bunch of ugly rebasing.~~ merged now.

I've also done a bit of an audit of uses of the mock `*called*` properties/methods switching them to use safer ones. More information in the comment for that commit:

```
assert_called() does not exist (except in the *absolute latest* mock
packages) and doesn't do anything. assert_not_called() does not exist
(same caveat) and does not do anything. the only way to make absolutely
sure an assertion is being performed is to include the assert keyword. for
similar reasons identity comparisons of .called against True, False are
preferred over just asserting against the property's truthiness/falsiness.
```

