### PR TITLE
Admin edit dos2 declarations

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,8 +28,8 @@ content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'ed
 
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
 content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')
-
 content_loader.load_manifest('digital-outcomes-and-specialists', 'declaration', 'declaration')
+content_loader.load_manifest('digital-outcomes-and-specialists-2', 'declaration', 'declaration')
 
 from app.main.helpers.service import parse_document_upload_time
 

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -32,9 +32,9 @@
     {% elif current_user.has_role("admin-ccs-sourcing") %}
       {% set field_headings = [
         "Name",
-        "G-Cloud 7",
         "Digital Outcomes<br />and Specialists"|safe,
         "G-Cloud 8",
+        "Digital Outcomes<br />and Specialists 2"|safe,
       ] %}
     {% else %}
       {% set field_headings = [
@@ -58,12 +58,6 @@
         {% endif %}
         {% if current_user.has_role('admin-ccs-sourcing') %}
           {% call summary.field() %}
-            <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">Edit declaration</a></div>
-            <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=agreement_filename) }}">Agreement</a></div>
-            <div>⬇ <a href="{{ url_for(".download_signed_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Signed agreement</a></div>
-            <div>⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Countersigned agreement</a></div>
-          {% endcall %}
-          {% call summary.field() %}
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Edit declaration</a></div>
             <div>⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=agreement_filename) }}" >Agreement</a></div>
             <div>⬇ <a href="{{ url_for(".download_signed_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Signed agreement</a></div>
@@ -72,6 +66,10 @@
           {% call summary.field() %}
             <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-8") }}">Edit declaration</a></div>
             <div><a href="{{ url_for(".view_signed_agreement", supplier_id=item.id, framework_slug="g-cloud-8") }}">View agreement</a></div>
+          {% endcall %}
+          {% call summary.field() %}
+            <div><a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists-2") }}">Edit declaration</a></div>
+            <div><a href="{{ url_for(".view_signed_agreement", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists-2") }}">View agreement</a></div>
           {% endcall %}
         {% endif %}
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}


### PR DESCRIPTION
This adds the ability for users with the role `admin-ccs-sourcing` to view and edit DOS2 declarations.

It also removes the G-Cloud 7 column from their suppliers view, because work on agreements for that framework should be all finished now (although the pages will still be accessible via direct URL if they do need to do any G7 work).

**NOTE** ~~This will require changes to the functional tests, coming soon!~
Corresponding PR for functional tests is here:
 - [ ] https://github.com/alphagov/digitalmarketplace-functional-tests/pull/238

## BEFORE
![screen shot 2017-01-12 at 06 20 08](https://cloud.githubusercontent.com/assets/6525554/21879283/7af39754-d88f-11e6-800e-aec7d0e701a1.png)


## AFTER
![screen shot 2017-01-12 at 06 13 42](https://cloud.githubusercontent.com/assets/6525554/21879284/7e6315f4-d88f-11e6-87ed-919b7eb5188a.png)
