### PR TITLE
[#134368805]frameworks dependency: bump to 5.4.0 to effectively revert change 921e1e1f099ba03e56dd2df1101e8839a73717ce

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.3.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.4.0",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }


### PR DESCRIPTION
Turns out this app doesn't properly support "assurance" questions, so revert
the question additions temporarily to unblock the release pipeline.

Story https://www.pivotaltracker.com/story/show/134368805