### PR TITLE
[#134368805]admin service editing: enable more fields for g7, g8 - take 2

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -53,7 +53,7 @@ def view(service_id):
 
     return render_template(
         "view_service.html",
-        sections=content,
+        sections=content.summary(service_data),
         service_data=service_data,
         service_id=service_id
     )
@@ -93,18 +93,24 @@ def update_service_status(service_id):
     return redirect(url_for('.view', service_id=service_id))
 
 
-@main.route('/services/<service_id>/edit/<section>', methods=['GET'])
+@main.route('/services/<service_id>/edit/<section_id>', methods=['GET'])
 @login_required
 @role_required('admin', 'admin-ccs-category')
-def edit(service_id, section):
+def edit(service_id, section_id):
     service_data = data_api_client.get_service(service_id)['services']
 
     content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
 
+    section = content.get_section(section_id)
+    if section is None:
+        abort(404)
+    # handle sections with assurance fields
+    service_data = section.unformat_data(service_data)
+
     return render_template(
         "edit_section.html",
-        section=content.get_section(section),
-        service_data=service_data
+        section=section,
+        service_data=service_data,
     )
 
 

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -1,4 +1,5 @@
 {% import 'macros/toolkit_forms.html' as forms %}
+{% from "macros/assurance.html" import assurance_question %}
 
 {% extends "_base_page.html" %}
 {% block page_title %}

--- a/app/templates/macros/assurance.html
+++ b/app/templates/macros/assurance.html
@@ -1,0 +1,102 @@
+{% from "macros/toolkit_forms.html" import radios %}
+
+{% macro assurance_question(
+  name,
+  service_data,
+  type,
+  errors
+) %}
+
+  {% set assurance_options = {
+    '2answers-type1': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'independent validation of assertion',
+       'value': 'Independent validation of assertion'}
+    ],
+    '3answers-type1': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'contractual commitment',
+       'value': 'Contractual commitment'},
+      {'label': 'independent validation of assertion',
+       'value': 'Independent validation of assertion'}
+    ],
+    '3answers-type2': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'independent validation of assertion',
+       'value': 'Independent validation of assertion'},
+      {'label': 'independent testing of implementation',
+       'value': 'Independent testing of implementation'}
+    ],
+    '3answers-type3': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'independent testing of implementation',
+       'value': 'Independent testing of implementation'},
+      {'label': 'CESG-assured components'}
+    ],
+    '3answers-type4': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'independent validation of assertion',
+       'value': 'Independent validation of assertion'},
+      {'label': 'independent testing of implementation',
+       'value': 'Independent testing of implementation'}
+    ],
+    '4answers-type1': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'independent validation of assertion',
+       'value': 'Independent validation of assertion'},
+      {'label': 'independent testing of implementation',
+       'value': 'Independent testing of implementation'},
+      {'label': 'CESG-assured components'}
+    ],
+    '4answers-type2': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'contractual commitment',
+       'value': 'Contractual commitment'},
+      {'label': 'independent validation of assertion',
+       'value': 'Independent validation of assertion'},
+      {'label': 'CESG-assured components'}
+    ],
+    '4answers-type3': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'independent testing of implementation',
+       'value': 'Independent testing of implementation'},
+      {'label': 'assurance of service design',
+       'value': 'Assurance of service design'},
+      {'label': 'CESG-assured components'}
+    ],
+    '5answers-type1': [
+      {'label': 'service provider assertion',
+       'value': 'Service provider assertion'},
+      {'label': 'contractual commitment',
+       'value': 'Contractual commitment'},
+      {'label': 'independent validation of assertion',
+       'value': 'Independent validation of assertion'},
+      {'label': 'independent testing of implementation',
+       'value': 'Independent testing of implementation'},
+      {'label': 'CESG-assured components'}
+    ]
+  } %}
+
+  {{
+    radios(
+      question_content = {
+        'question': 'You may have to provide evidence to back up your answer. Please confirm whether your response is assured by:',
+        'id': name + '--assurance',
+        'hint': 'Read more about <a href="https://www.gov.uk/government/publications/implementing-the-cloud-security-principles/implementing-the-cloud-security-principles#common-approaches-to-implementing-cloud-security-principles">how you can assure your responses</a>.'|safe,
+        'hint_underneath': 'True',
+        'options': assurance_options[type]
+      },
+      service_data=service_data,
+      errors = errors
+    )
+  }}
+
+{% endmacro %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -165,3 +165,23 @@
   {% endfor %}
 </fieldset>
 {%- endmacro %}
+
+{% macro number(question_content, data, errors) -%}
+  {%
+    with
+    unit_in_full=question_content.unit_in_full,
+    unit_position=question_content.unit_position,
+    unit=question_content.unit,
+    smaller=True,
+    question=question_content.question,
+    question_advice=question_content.question_advice,
+    hint=question_content.hint,
+    optional=question_content.optional,
+    name=question_content.id,
+    value=data[question_content.id],
+    error=errors.get(question_content.id)['message'],
+    question_number=question_number
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+{%- endmacro %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -67,9 +67,9 @@
     {% for section in sections %}
       {{ summary.heading(section.name) }}
       {% if section.editable and current_user.has_any_role('admin', 'admin-ccs-category') %}
-        {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section=section.id)) }}
+        {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section_id=section.id)) }}
       {% endif %}
-      {% call(item) summary.list_table(
+      {% call(question) summary.list_table(
         section.questions,
         caption="Services",
         empty_message="This supplier has no services on the Digital Marketplace",
@@ -80,8 +80,8 @@
         field_headings_visible=False
       ) %}
         {% call summary.row() %}
-          {{ summary.field_name(item.question) }}
-          {{ summary[item.type](service_data[item.id]) }}
+          {{ summary.field_name(question.label) }}
+          {{ summary[question.type](question.value, question.assurance) }}
         {% endcall %}
       {% endcall %}
     {% endfor %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.4.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.5.0",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/134368805

We're back here again. In this PR I've added support for *assurance* questions to the service editing as well as `number` form field types by transplanting them from `digitalmarketplace-supplier-frontend` :roll_eyes: . I've then pulled a new frameworks package in which uses some of these question patterns.

The other thing going on in this PR is fleshing out of a lot of tests, testing for both existing and new functionality in these views.