### PR TITLE
Wrap invitation link in anchor tag

### DIFF
--- a/app/templates/emails/invite_user_email.html
+++ b/app/templates/emails/invite_user_email.html
@@ -11,7 +11,7 @@ The Digital Marketplace team have invited you to become a contributor for {{ sup
 <br /><br />
 To accept this invitation, please click the link below:
 <br /><br />
-{{ url }}
+<a href="{{ url }}">{{ url }}</a>
 <br /><br />
 This is an automated message. Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.
 <br /><br />


### PR DESCRIPTION
Some users have had issues with clicking the link in their invitation emails.
This *may* help alleviate the problem (and I have no other ideas how to address the issue).