### PR TITLE
[#137953083]: add DOS2 link to admin front page to approve agreements for countersigning

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -21,7 +21,12 @@ from ..helpers.diff_tools import get_diffs_from_service_data, get_revision_dates
 @login_required
 @role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
 def index():
-    return render_template("index.html")
+    frameworks = data_api_client.find_frameworks()
+    frameworks = [fw for fw in frameworks['frameworks'] if fw['status'] in ('standstill', 'live')]
+    frameworks = sorted(frameworks, key=lambda x: x['id'], reverse=True)
+
+    return render_template("index.html",
+                           frameworks_for_countersigning=frameworks)
 
 
 @main.route('/services', methods=['GET'])

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -110,26 +110,20 @@
     %}
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
-    {% with items = [
+    {% for framework in frameworks_for_countersigning %}
+      {% with items = [
         {
-            "body": "Download G-Cloud 7 agreements",
-            "link": "/admin/agreements/g-cloud-7",
-            "title": "G-Cloud 7 agreements"
-        },
-        {
-            "body": "Download Digital Outcomes and Specialists agreements",
-            "link": "/admin/agreements/digital-outcomes-and-specialists",
-            "title": "Digital Outcomes and Specialists agreements"
-        },
-        {
-            "body": "Approve G-Cloud 8 agreements for countersigning",
-            "link": "/admin/agreements/g-cloud-8?status=signed",
-            "title": "G-Cloud 8 agreements"
-        },
+          "body": "Approve " + framework.name + " agreements for countersigning"
+                  if framework['frameworkAgreementVersion'] else
+                  "Download " + framework.name + " agreements",
+          "title": framework.name + " agreements",
+          "link": url_for('.list_agreements', framework_slug=framework['slug'], status='signed')
+        }
       ]
-    %}
-      {% include "toolkit/browse-list.html" %}
-    {% endwith %}
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+    {% endfor %}
   {% endif %}
 
   {% if current_user.has_any_role('admin') %}

--- a/tests/app/main/views/test_application.py
+++ b/tests/app/main/views/test_application.py
@@ -1,10 +1,13 @@
 # coding=utf-8
 
+import mock
 from ...helpers import LoggedInApplicationTest
 
 
 class TestApplication(LoggedInApplicationTest):
-    def test_main_index(self):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_main_index(self, data_api_client):
+        data_api_client.get_frameworks.return_value = {"frameworks": []}
         response = self.client.get('/admin')
         assert response.status_code == 200
 
@@ -17,13 +20,17 @@ class TestApplication(LoggedInApplicationTest):
         response = self.client.get('/')
         assert response.status_code == 404
 
-    def test_headers(self):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_headers(self, data_api_client):
+        data_api_client.get_frameworks.return_value = {"frameworks": []}
         res = self.client.get('/admin')
         assert res.status_code == 200
         assert 'Secure;' in res.headers['Set-Cookie']
         assert 'DENY' in res.headers['X-Frame-Options']
 
-    def test_response_headers(self):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_response_headers(self, data_api_client):
+        data_api_client.get_frameworks.return_value = {"frameworks": []}
         response = self.client.get('/admin')
 
         assert response.headers['cache-control'] == "no-cache"

--- a/tests/app/main/views/test_login.py
+++ b/tests/app/main/views/test_login.py
@@ -35,11 +35,14 @@ class TestLogin(BaseApplicationTest):
         assert res.status_code == 200
         assert "Administrator login" in res.get_data(as_text=True)
 
+    @mock.patch('app.main.views.services.data_api_client')
     @mock.patch('app.data_api_client')
     @mock.patch('app.main.views.login.data_api_client')
-    def test_valid_login(self, login_data_api_client, init_data_api_client):
+    def test_valid_login(self, login_data_api_client, init_data_api_client, services_data_api_client):
         login_data_api_client.authenticate_user.return_value = user_data()
         init_data_api_client.get_user.return_value = user_data()
+        services_data_api_client.get_frameworks.return_value = {"frameworks": []}
+
         res = self.client.post('/admin/login', data={
             'email_address': 'valid@email.com',
             'password': '1234567890'
@@ -218,7 +221,9 @@ class TestRoleRequired(LoggedInApplicationTest):
                 user_id, 'test@example.com', None, None, False, True, 'tester', 'admin-ccs-category'
             )
 
-    def test_admin_ccs_can_view_admin_dashboard(self):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_admin_ccs_can_view_admin_dashboard(self, data_api_client):
+        data_api_client.get_frameworks.return_value = {"frameworks": []}
         response = self.client.get('/admin')
         assert response.status_code == 200
 

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -13,6 +13,32 @@ from dmapiclient import HTTPError, REQUEST_ERROR_MESSAGE
 from ...helpers import LoggedInApplicationTest
 
 
+class TestIndex(LoggedInApplicationTest):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_index_shows_frameworks_in_standstill_or_live(self, data_api_client):
+        data_api_client.find_frameworks.return_value = {'frameworks': [
+            {'id': 1, 'frameworkAgreementVersion':   None, 'name': 'Framework 1', 'slug': 'framework-1',
+             'status': 'standstill'},
+            {'id': 2, 'frameworkAgreementVersion': 'v1.0', 'name': 'Framework 2', 'slug': 'framework-2',
+             'status': 'live'},
+            {'id': 3, 'frameworkAgreementVersion':   None, 'name': 'Framework 3', 'slug': 'framework-3',
+             'status': 'open'},
+        ]}
+
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+
+        assert 'Download Framework 1 agreements' in data
+        assert 'Approve Framework 2 agreements for countersigning' in data
+
+        # Agreements should be in reverse-chronological order.
+        assert data.index('Approve Framework 2 agreements for countersigning') < \
+            data.index('Download Framework 1 agreements')
+
+        # Only standstill/live agreements should be listed.
+        assert 'Download Framework 3 agreements' not in data
+
+
 class TestServiceView(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_view_no_features_or_benefits_status_disabled(self, data_api_client):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/137953083

Removes hard-coded list of frameworks/links from the template; pulls from the API and shows link to list of agreements for all frameworks in standstill or live.

![screen shot 2017-01-24 at 11 05 10](https://cloud.githubusercontent.com/assets/2920760/22244833/07f8a90c-e225-11e6-9355-d1552fd1298f.png)
