### PR TITLE
[#134368805]service editing: handle validation error page redisplaying properly

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -225,14 +225,12 @@ def update(service_id, section_id):
             errors = section.get_error_messages(e.message)
 
     if errors:
-        if not posted_data.get('serviceName', None):
-            posted_data['serviceName'] = service.get('serviceName', '')
         return render_template(
             "edit_section.html",
             section=section,
-            service_data=posted_data,
+            service_data=dict(service, **posted_data),
             service_id=service_id,
-            errors=errors
+            errors=errors,
         ), 400
 
     return redirect(url_for(".view", service_id=service_id))

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -228,7 +228,7 @@ def update(service_id, section_id):
         return render_template(
             "edit_section.html",
             section=section,
-            service_data=dict(service, **posted_data),
+            service_data=section.unformat_data(dict(service, **posted_data)),
             service_id=service_id,
             errors=errors,
         ), 400

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -463,6 +463,78 @@ class TestServiceUpdate(LoggedInApplicationTest):
             t="Return without saving",
         ) == ["/admin/services/7654"]
 
+    @mock.patch("app.main.views.services.data_api_client")
+    def test_service_update_assurance_questions_when_API_returns_error(
+            self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'id': "7654",
+            'supplierId': 2,
+            'frameworkSlug': 'g-cloud-8',
+            'lot': 'paas',
+        }}
+        data_api_client.update_service.side_effect = HTTPError(None, {'dataProtectionWithinService': 'answer_required'})
+        posted_values = {
+            "dataProtectionBetweenUserAndService": ["PSN assured service"],
+            # dataProtectionWithinService deliberately omitted
+            "dataProtectionBetweenServices": [
+                "TLS (HTTPS or VPN) version 1.2 or later",
+                "Legacy SSL or TLS (HTTPS or VPN)",
+            ],
+        }
+        posted_assurances = {
+            "dataProtectionBetweenUserAndService--assurance": "Independent testing of implementation",
+            "dataProtectionWithinService--assurance": "CESG-assured components",
+            "dataProtectionBetweenServices--assurance": "Service provider assertion",
+        }
+
+        response = self.client.post(
+            "/admin/services/7654/edit/data-in-transit-protection",
+            data=dict(posted_values, **posted_assurances),
+        )
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert response.status_code == 400
+        data_api_client.get_service.assert_called_with('7654')
+        assert data_api_client.update_service.call_args_list == [
+            (
+                (
+                    "7654",
+                    {
+                        "dataProtectionBetweenUserAndService": {
+                            "value": posted_values["dataProtectionBetweenUserAndService"],
+                            "assurance": posted_assurances["dataProtectionBetweenUserAndService--assurance"],
+                        },
+                        "dataProtectionWithinService": {
+                            "assurance": posted_assurances["dataProtectionWithinService--assurance"],
+                        },
+                        "dataProtectionBetweenServices": {
+                            "value": posted_values["dataProtectionBetweenServices"],
+                            "assurance": posted_assurances["dataProtectionBetweenServices--assurance"],
+                        },
+                    },
+                    "test@example.com",
+                ),
+                {},
+            )
+        ]
+
+        for key, values in posted_values.items():
+            assert sorted(document.xpath("//form//input[@type='checkbox'][@name=$n][@checked]/@value", n=key)) == \
+                sorted(values)
+
+        for key, value in posted_assurances.items():
+            assert sorted(document.xpath("//form//input[@type='radio'][@name=$n][@checked]/@value", n=key)) == \
+                [value]
+
+        assert document.xpath(
+            "//*[contains(@class,'validation-message')][contains(normalize-space(string()), $t)]",
+            t="You need to answer this question",
+        )
+        assert document.xpath(
+            "//a[normalize-space(string())=$t]/@href",
+            t="Return without saving",
+        ) == ["/admin/services/7654"]
+
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_update_with_one_service_feature(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/134368805

This should resolve @andrewchong 's remaining issues.

Some minor view changes to make sure we pass a full service object to the template and make sure the data is unformatted when we're redisplaying for validation errors.

Most of the work though expands the tests to cover this functionality which was previously untested.