### PR TITLE
Allow download of DOS suppliers after expiry of framework

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -47,7 +47,9 @@ def find_user_by_email_address():
 def list_frameworks_with_users(errors=None):
     bad_statuses = ['coming', 'expired']
     frameworks = [framework for framework in data_api_client.find_frameworks()['frameworks']
-                  if framework['status'] not in bad_statuses]
+                  if framework['status'] not in bad_statuses
+                  #  TODO: remove this temporary hack once we have implemented new status that covers the DOS case
+                  or framework['slug'] == 'digital-outcomes-and-specialists']
     framework_options = [{'value': framework['slug'], 'label': framework['name']} for framework
                          in sorted(frameworks, key=lambda framework: framework['name'])]
 


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/140634767

DOS has now 'expired' in the marketplace database so the link to download users is not shown.  However, the framework is not really expired, it is due to run for a few more months (buyers need to award contracts to suppliers for briefs started recently).

The proper way to fix this is to introduce a new status that covers the DOS case of "not available on the marketplace but can still be bought".  But I think this should be done as part of a bigger piece of work where we thoroughly review framework statuses.  I've written that up as a story for the (hopefully near) future: https://www.pivotaltracker.com/story/show/140922365 

But for meeting the immediate need I think this is OK.  Feel free to disagree and call me a bad person for even suggesting this.