### PR TITLE
Add G-Cloud 9 communications link to homepage

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -145,6 +145,11 @@
           "title": "Digital Outcomes and Specialists 2 communications"
       },
       {
+        "body": "Manage G-Cloud 9 communications",
+        "link": "/admin/communications/g-cloud-9",
+        "title": "G-Cloud 9 communications"
+      },
+      {
           "body": "Download a list of users for frameworks that are open, pending or live",
           "link": url_for(".list_frameworks_with_users"),
           "title": "Download user lists"


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/138703755

New link added as below:
![screen shot 2017-03-02 at 12 07 52](https://cloud.githubusercontent.com/assets/6525554/23506632/1bbccc5a-ff41-11e6-9f33-795f884b2e3c.png)

