### PR TITLE
Allow odt for communications

### DIFF
--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -7,7 +7,7 @@ from ..auth import role_required
 from ... import data_api_client
 
 from dmutils import s3
-from dmutils.documents import file_is_pdf, file_is_zip, file_is_csv
+from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
 
 
 def _get_path(framework_slug, path):
@@ -41,8 +41,8 @@ def upload_communication(framework_slug):
 
     if request.files.get('communication'):
         the_file = request.files['communication']
-        if not (file_is_pdf(the_file) or file_is_csv(the_file)):
-            errors['communication'] = 'not_pdf_or_csv'
+        if not (file_is_open_document_format(the_file) or file_is_csv(the_file)):
+            errors['communication'] = 'not_open_document_format_or_csv'
 
         if 'communication' not in errors.keys():
             filename = _get_path(framework_slug, 'updates/communications') + '/' + the_file.filename

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -94,9 +94,9 @@
   {% endwith %}
   {% with items = [
       {
-          "body": "View Digital Outcomes and Specialists 2 statistics",
-          "link": "/admin/statistics/digital-outcomes-and-specialists-2",
-          "title": "Digital Outcomes and Specialists 2 statistics"
+          "body": "View G-Cloud 9 statistics",
+          "link": "/admin/statistics/g-cloud-9",
+          "title": "G-Cloud 9 statistics"
       }
   ]
   %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -32,8 +32,8 @@
               {% else %}
                 <div class="banner-destructive-without-action">
                     <p class="banner-message">
-                    {% if category == 'not_pdf_or_csv' and message == 'communication' %}
-                        Communication file is not a PDF or CSV.
+                    {% if category == 'not_open_document_format_or_csv' and message == 'communication' %}
+                        Communication file is not an open document format or a CSV.
                     {% elif category == 'not_pdf' and message == 'clarification' %}
                         Clarification file is not a PDF.
                     {% endif %}
@@ -52,7 +52,7 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     {% with
        question="Communication",
-       hint="This must be PDF or CSV",
+       hint="This must be an open document format (pdf, pda, odt, ods, odp) or CSV",
        name="communication",
        value="Last modified {}".format(communication.last_modified),
        error=communication_error


### PR DESCRIPTION
For this: https://www.pivotaltracker.com/story/show/141132723
(Allow communications files to be .odt)
And this: https://www.pivotaltracker.com/story/show/141138963
(Add G9 stats link from homepage)

I've gone for allowing any open document format rather than strictly just `odt` mainly because we already have a utils method for checking that and we're in a rush.  It doesn't seem unreasonable feature creep though.

