### PR TITLE
[#141299531]signed agreements: "Cancel approval" button

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -178,6 +178,9 @@ def approve_agreement_for_countersignature(agreement_id):
 @login_required
 @role_required('admin-ccs-sourcing')
 def unapprove_agreement_for_countersignature(agreement_id):
+    # not properly validating this - all we do is pass it through
+    next_status = request.args.get("next_status")
+
     agreement = data_api_client.unapprove_agreement_for_countersignature(
         agreement_id,
         current_user.email_address,
@@ -191,6 +194,7 @@ def unapprove_agreement_for_countersignature(agreement_id):
         '.view_signed_agreement',
         framework_slug=agreement["frameworkSlug"],
         supplier_id=agreement["supplierId"],
+        next_status=next_status,
     ))
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -174,6 +174,26 @@ def approve_agreement_for_countersignature(agreement_id):
     ))
 
 
+@main.route('/suppliers/agreements/<agreement_id>/unapprove', methods=['POST'])
+@login_required
+@role_required('admin-ccs-sourcing')
+def unapprove_agreement_for_countersignature(agreement_id):
+    agreement = data_api_client.unapprove_agreement_for_countersignature(
+        agreement_id,
+        current_user.email_address,
+        current_user.id,
+    )["agreement"]
+    organisation = request.form['nameOfOrganisation']
+    flash(u'The agreement for {} had its approval cancelled. You can approve it again at any time.'
+          .format(organisation), 'message')
+
+    return redirect(url_for(
+        '.view_signed_agreement',
+        framework_slug=agreement["frameworkSlug"],
+        supplier_id=agreement["supplierId"],
+    ))
+
+
 @main.route('/suppliers/<supplier_id>/agreement/<framework_slug>', methods=['GET'])
 @login_required
 @role_required('admin', 'admin-ccs-sourcing')

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -106,7 +106,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           {%
             with
             type = "save",
-            label = "Cancel approval"
+            label = "Cancel acceptance"
           %}
             {% include "toolkit/button.html" %}
           {% endwith %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -105,7 +105,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
           {%
             with
-            type = "save",
+            type = "destructive",
             label = "Cancel acceptance"
           %}
             {% include "toolkit/button.html" %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -41,15 +41,18 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
 
 
 <div class='grid-row'>
+  <div class="column-one-whole">
+    {%
+        with
+        heading = supplier_framework.declaration.nameOfOrganisation,
+        smaller = True
+    %}
+    {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+  </div>
+</div>
+<div class='grid-row'>
   <div class="column-one-third">
-      {%
-          with
-          heading = supplier_framework.declaration.nameOfOrganisation,
-          smaller = True
-      %}
-      {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-
       <h2>Registered address</h2>
       <ul class="padding-bottom-small">
           <li>{{ supplier_framework.declaration.registeredAddressBuilding }}</li>

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -99,7 +99,19 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           <br>
           {{ supplier_framework.countersignedAt|datetimeformat }}
         </p>
-
+        {% if supplier_framework.agreementStatus == 'approved' %}
+        <form action="{{ url_for('.unapprove_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
+          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+          <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
+          {%
+            with
+            type = "save",
+            label = "Cancel approval"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        </form>
+        {% endif %}
       {% elif current_user.role == 'admin-ccs-sourcing' %}
         <form action="{{ url_for('.approve_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.2#egg=digitalmarketplace-content-loader==3.5.2
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.13.0#egg=digitalmarketplace-apiclient==7.13.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.6.0#egg=digitalmarketplace-apiclient==8.6.0

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1377,6 +1377,8 @@ class TestUnapproveAgreement(LoggedInApplicationTest):
 class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
+    decl_nameOfOrganization = u"\u00a3\u00a3\u00a3 4 greengrocer's"
+
     def set_mocks(self, s3, get_signed_url, data_api_client, **kwargs):
         data_api_client.get_supplier.return_value = {
             'suppliers': {
@@ -1387,8 +1389,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
             'frameworks': {
                 'frameworkAgreementVersion': 'v1.0',
                 'slug': 'g-cloud-8',
-                'status': 'live'
-
+                'status': 'live',
             },
         }
         data_api_client.get_supplier_framework_info.return_value = {
@@ -1396,7 +1397,9 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
                 'agreementReturned': True,
                 'agreementStatus': kwargs['agreement_status'],
                 'agreementId': 4321,
-                'declaration': '',
+                'declaration': {
+                    "nameOfOrganisation": self.decl_nameOfOrganization,
+                },
                 'agreementDetails': {},
                 'agreementPath': 'g-cloud-8/1234/1234-file.pdf',
                 'countersignedDetails': {},
@@ -1473,6 +1476,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         )
         assert accept_form_elem.attrib["method"].lower() == "post"
         assert accept_form_elem.xpath("input[@name='csrf_token']")
+        assert accept_form_elem.xpath("input[@name='nameOfOrganisation'][@value=$n]", n=self.decl_nameOfOrganization)
 
         hold_input_elems = document.xpath("//form//input[@type='submit'][@value='Put on hold and continue']")
         assert len(hold_input_elems) == 1
@@ -1484,6 +1488,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         )
         assert hold_form_elem.attrib["method"].lower() == "post"
         assert hold_form_elem.xpath("input[@name='csrf_token']")
+        assert hold_form_elem.xpath("input[@name='nameOfOrganisation'][@value=$n]", n=self.decl_nameOfOrganization)
 
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
 
@@ -1522,6 +1527,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         )
         assert accept_form_elem.attrib["method"].lower() == "post"
         assert accept_form_elem.xpath("input[@name='csrf_token']")
+        assert accept_form_elem.xpath("input[@name='nameOfOrganisation'][@value=$n]", n=self.decl_nameOfOrganization)
 
         assert "Put on hold and continue" not in data
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
@@ -1563,6 +1569,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         )
         assert cancel_form_elem.attrib["method"].lower() == "post"
         assert cancel_form_elem.xpath("input[@name='csrf_token']")
+        assert cancel_form_elem.xpath("input[@name='nameOfOrganisation'][@value=$n]", n=self.decl_nameOfOrganization)
 
         next_a_elems = document.xpath("//a[normalize-space(string())='Next agreement']")
         assert len(next_a_elems) == 1

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1244,7 +1244,7 @@ class TestApproveAgreement(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
     @property
-    def put_signed_agreement_on_hold_return_value(self):
+    def approve_agreement_for_countersignature_return_value(self):
         # a property so we always get a clean *copy* of this to work with
         return {
             "agreement": {
@@ -1257,7 +1257,7 @@ class TestApproveAgreement(LoggedInApplicationTest):
     def test_it_fails_if_not_ccs_admin(self, data_api_client):
         self.user_role = 'admin'
         data_api_client.approve_agreement_for_countersignature.return_value = \
-            self.put_signed_agreement_on_hold_return_value
+            self.approve_agreement_for_countersignature_return_value
         res = self.client.post('/admin/suppliers/agreements/123/approve', data={"nameOfOrganisation": "Test"})
 
         assert data_api_client.approve_agreement_for_countersignature.called is False
@@ -1265,7 +1265,7 @@ class TestApproveAgreement(LoggedInApplicationTest):
 
     def test_happy_path(self, data_api_client):
         data_api_client.approve_agreement_for_countersignature.return_value = \
-            self.put_signed_agreement_on_hold_return_value
+            self.approve_agreement_for_countersignature_return_value
         res = self.client.post(
             "/admin/suppliers/agreements/123/approve",
             data={"nameOfOrganisation": "Test"},
@@ -1283,7 +1283,7 @@ class TestApproveAgreement(LoggedInApplicationTest):
 
     def test_happy_path_with_next_status_and_unicode_supplier_name(self, data_api_client):
         data_api_client.approve_agreement_for_countersignature.return_value = \
-            self.put_signed_agreement_on_hold_return_value
+            self.approve_agreement_for_countersignature_return_value
         res = self.client.post(
             "/admin/suppliers/agreements/123/approve?next_status=on-hold",
             data={"nameOfOrganisation": u"Test O\u2019Connor"},

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1063,7 +1063,7 @@ class TestRemoveCountersignedAgreementFile(LoggedInApplicationTest):
         assert response.status_code == 200
 
 
-@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.data_api_client', autospec=True)
 @mock.patch('app.main.views.suppliers.s3')
 class TestViewingSignedAgreement(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
@@ -1185,7 +1185,7 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
             assert len(document.xpath('//embed[@src="http://example.com/document/1234.png"]')) == 0
 
 
-@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.data_api_client', autospec=True)
 class TestPutSignedAgreementOnHold(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 
@@ -1239,7 +1239,7 @@ class TestPutSignedAgreementOnHold(LoggedInApplicationTest):
         assert parse_qs(parsed_location.query) == {"status": ["on-hold"]}
 
 
-@mock.patch('app.main.views.suppliers.data_api_client')
+@mock.patch('app.main.views.suppliers.data_api_client', autospec=True)
 class TestApproveAgreement(LoggedInApplicationTest):
     user_role = 'admin-ccs-sourcing'
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1472,6 +1472,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
             {} if next_status is None else {"next_status": [next_status]},
         )
         assert accept_form_elem.attrib["method"].lower() == "post"
+        assert accept_form_elem.xpath("input[@name='csrf_token']")
 
         hold_input_elems = document.xpath("//form//input[@type='submit'][@value='Put on hold and continue']")
         assert len(hold_input_elems) == 1
@@ -1482,6 +1483,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
             {} if next_status is None else {"next_status": [next_status]},
         )
         assert hold_form_elem.attrib["method"].lower() == "post"
+        assert hold_form_elem.xpath("input[@name='csrf_token']")
 
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
 
@@ -1519,6 +1521,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
             {} if next_status is None else {"next_status": [next_status]},
         )
         assert accept_form_elem.attrib["method"].lower() == "post"
+        assert accept_form_elem.xpath("input[@name='csrf_token']")
 
         assert "Put on hold and continue" not in data
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
@@ -1552,13 +1555,14 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
 
         cancel_input_elems = document.xpath("//form//input[@type='submit'][@value='Cancel approval']")
         assert len(cancel_input_elems) == 1
-        accept_form_elem = cancel_input_elems[0].xpath("ancestor::form")[0]
+        cancel_form_elem = cancel_input_elems[0].xpath("ancestor::form")[0]
         assert self._parsed_url_matches(
-            accept_form_elem.attrib["action"],
+            cancel_form_elem.attrib["action"],
             "/admin/suppliers/agreements/4321/unapprove",
             {} if next_status is None else {"next_status": [next_status]},
         )
-        assert accept_form_elem.attrib["method"].lower() == "post"
+        assert cancel_form_elem.attrib["method"].lower() == "post"
+        assert cancel_form_elem.xpath("input[@name='csrf_token']")
 
         next_a_elems = document.xpath("//a[normalize-space(string())='Next agreement']")
         assert len(next_a_elems) == 1

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1438,7 +1438,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
 
         assert "Accept and continue" not in data
         assert "Put on hold and continue" not in data
-        assert "Cancel approval" not in data
+        assert "Cancel acceptance" not in data
 
         assert not document.xpath("//h2[normalize-space(string())='Accepted by']")
 
@@ -1464,7 +1464,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         data = res.get_data(as_text=True)
         document = html.fromstring(data)
 
-        assert "Cancel approval" not in data
+        assert "Cancel acceptance" not in data
 
         accept_input_elems = document.xpath("//form//input[@type='submit'][@value='Accept and continue']")
         assert len(accept_input_elems) == 1
@@ -1515,7 +1515,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         data = res.get_data(as_text=True)
         document = html.fromstring(data)
 
-        assert "Cancel approval" not in data
+        assert "Cancel acceptance" not in data
 
         accept_input_elems = document.xpath("//form//input[@type='submit'][@value='Accept and continue']")
         assert len(accept_input_elems) == 1
@@ -1559,7 +1559,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         assert "Put on hold and continue" not in data
         assert len(document.xpath("//h2[normalize-space(string())='Accepted by']")) == 1
 
-        cancel_input_elems = document.xpath("//form//input[@type='submit'][@value='Cancel approval']")
+        cancel_input_elems = document.xpath("//form//input[@type='submit'][@value='Cancel acceptance']")
         assert len(cancel_input_elems) == 1
         cancel_form_elem = cancel_input_elems[0].xpath("ancestor::form")[0]
         assert self._parsed_url_matches(
@@ -1593,7 +1593,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
 
         assert "Accept and continue" not in data
         assert "Put on hold and continue" not in data
-        assert "Cancel approval" not in data
+        assert "Cancel acceptance" not in data
         assert len(document.xpath("//h2[normalize-space(string())='Accepted by']")) == 1
 
         next_a_elems = document.xpath("//a[normalize-space(string())='Next agreement']")


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/141299531

Feature in action:
![20170309_cancelapproval](https://cloud.githubusercontent.com/assets/807447/23761270/21366840-04ea-11e7-8115-9fff7246006d.png)

Things that I wonder:

- We use the text "**Accepted** by" and then "Cancel **approval**" which is a bit of a confusing mismatch - switch button to "Cancel acceptance"? "Accept" is the general term used in these pages.
- I decided to ignore the "next" behaviour entirely, including the `next_status` argument, though I now realize I might still want to at least pass through the `next_status` parameter so that the flow doesn't just totally forget what it was cycling through upon hitting "Cancel".
- Should a "Cancel" button perhaps *not* be green?