### PR TITLE
Load DOS2 admin editing manifest

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,7 @@ content_loader.load_manifest('g-cloud-6', 'services', 'edit_service_as_admin')
 content_loader.load_manifest('g-cloud-7', 'services', 'edit_service_as_admin')
 content_loader.load_manifest('g-cloud-8', 'services', 'edit_service_as_admin')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'services', 'edit_service_as_admin')
+content_loader.load_manifest('digital-outcomes-and-specialists-2', 'services', 'edit_service_as_admin')
 
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
 content_loader.load_manifest('g-cloud-8', 'declaration', 'declaration')

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v20.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.5.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v6.4.8",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.2#egg=digitalmarketplace-content-loader==3.5.2
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.13.0#egg=digitalmarketplace-apiclient==7.13.0


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/141500031

No-one ever thought to add the DOS2 editing manifest so trying to edit DOS2 services failed with 500 errors.

I've also pulled in latest content and content loader - a major version bump for each, but nothing seems to have broken as far as I can tell.