### PR TITLE
[#141299531]view_signed_agreement page: don't show 'cancel acceptance' button to non-admin-ccs-sourcing users

### DIFF
--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -102,7 +102,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           <br>
           {{ supplier_framework.countersignedAt|datetimeformat }}
         </p>
-        {% if supplier_framework.agreementStatus == 'approved' %}
+        {% if supplier_framework.agreementStatus == 'approved' and current_user.role == 'admin-ccs-sourcing' %}
         <form action="{{ url_for('.unapprove_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">


### PR DESCRIPTION
Followup to story https://www.pivotaltracker.com/story/show/141299531

Also expand tests to cover more `agreement_status` cases against `admin` user