### PR TITLE
Framework documents content disposition

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
+include = app/*
 omit = app/templates/*.html

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -6,7 +6,7 @@ from .. import main
 from ..auth import role_required
 from ... import data_api_client
 
-from dmutils import s3
+from dmutils import s3  # this style of import so we only have to mock once
 from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
 
 

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -16,8 +16,8 @@ def _get_path(framework_slug, path):
 
 def _save_file(bucket, framework_slug, path, the_file, flash_message):
     path = "{}/{}".format(_get_path(framework_slug, path), the_file.filename)
-    download_filename = "{}-{}".format(framework_slug, the_file.filename)
-    bucket.save(path, the_file, download_filename=download_filename)
+    # setting download_filename ensures Content-Disposition: attachment
+    bucket.save(path, the_file, download_filename=the_file.filename)
     flash(flash_message, 'upload_communication')
 
 

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -14,6 +14,13 @@ def _get_path(framework_slug, path):
     return '{}/communications/{}'.format(framework_slug, path)
 
 
+def _save_file(bucket, framework_slug, path, the_file, flash_message):
+    path = "{}/{}".format(_get_path(framework_slug, path), the_file.filename)
+    download_filename = "{}-{}".format(framework_slug, the_file.filename)
+    bucket.save(path, the_file, download_filename=download_filename)
+    flash(flash_message, 'upload_communication')
+
+
 @main.route('/communications/<framework_slug>', methods=['GET'])
 @login_required
 @role_required('admin')
@@ -45,9 +52,7 @@ def upload_communication(framework_slug):
             errors['communication'] = 'not_open_document_format_or_csv'
 
         if 'communication' not in errors.keys():
-            filename = _get_path(framework_slug, 'updates/communications') + '/' + the_file.filename
-            communications_bucket.save(filename, the_file)
-            flash('communication', 'upload_communication')
+            _save_file(communications_bucket, framework_slug, 'updates/communications', the_file, 'communication')
 
     if request.files.get('clarification'):
         the_file = request.files['clarification']
@@ -55,9 +60,7 @@ def upload_communication(framework_slug):
             errors['clarification'] = 'not_pdf'
 
         if 'clarification' not in errors.keys():
-            filename = _get_path(framework_slug, 'updates/clarifications') + '/' + the_file.filename
-            communications_bucket.save(filename, the_file)
-            flash('clarification', 'upload_communication')
+            _save_file(communications_bucket, framework_slug, 'updates/clarifications', the_file, 'clarification')
 
     if len(errors) > 0:
         for category, message in errors.items():

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -6,7 +6,7 @@ from dmapiclient import HTTPError
 from dmutils.formats import DATETIME_FORMAT
 from dmcontent.formats import format_service_price
 from dmutils.documents import upload_service_documents
-from dmutils.s3 import S3
+from dmutils import s3  # this style of import so we only have to mock once
 
 
 from ... import data_api_client
@@ -206,7 +206,7 @@ def update(service_id, section_id):
     posted_data = section.get_data(request.form)
 
     uploaded_documents, document_errors = upload_service_documents(
-        S3(current_app.config['DM_S3_DOCUMENT_BUCKET']),
+        s3.S3(current_app.config['DM_S3_DOCUMENT_BUCKET']),
         current_app.config['DM_DOCUMENTS_URL'],
         service, request.files, section)
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -4,6 +4,7 @@ import os
 
 from dmutils.user import User
 from flask import json
+from werkzeug.datastructures import MultiDict
 
 from app import create_app
 from app import login_manager
@@ -39,6 +40,10 @@ class BaseApplicationTest(object):
     def strip_all_whitespace(content):
         pattern = re.compile(r'\s+')
         return re.sub(pattern, '', content)
+
+    def _get_flash_messages(self):
+        with self.client.session_transaction() as session:
+            return MultiDict(session['_flashes'])
 
 
 class Response:

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -15,11 +15,12 @@ class BaseApplicationTest(object):
         self.app = create_app('test')
         self.client = self.app.test_client()
 
-        self._s3_patch = mock.patch('app.main.views.services.S3')
+        self._s3_patch = mock.patch('dmutils.s3.S3')
         self.s3 = self._s3_patch.start()
         self.s3.return_value = mock.Mock(
             bucket_name="digitalmarketplace-documents-testing-testing",
             bucket_short_name="documents")
+        self.s3.return_value.list.return_value = []
 
         self._default_suffix_patch = mock.patch(
             'dmutils.documents.default_file_suffix',

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+from __future__ import unicode_literals
+
+import mock
+from ...helpers import LoggedInApplicationTest
+from io import BytesIO
+
+
+@mock.patch('app.main.views.communications.data_api_client')
+class TestCommunicationsView(LoggedInApplicationTest):
+
+    def test_get_document_upload_page_for_framework(self, data_api_client):
+        data_api_client.get_frameworks.return_value = {"frameworks": []}
+
+        framework_slug = self.load_example_listing('framework_response')['frameworks']['slug']
+
+        response = self.client.get("/admin/communications/{}".format(framework_slug))
+        assert response.status_code == 200
+
+    def test_post_documents_for_framework(self, data_api_client):
+        data_api_client.get_frameworks.return_value = {"frameworks": []}
+
+        framework_slug = self.load_example_listing('framework_response')['frameworks']['slug']
+        dummy_file = BytesIO(u'Lorem ipsum dolor sit amet'.encode('utf8'))
+
+        response = self.client.post(
+            "/admin/communications/{}".format(framework_slug),
+            data={
+                'communication': (dummy_file, 'test-comm.pdf'),
+                'clarification': (dummy_file, 'test-clar.pdf'),
+            }
+        )
+
+        flash_messages = self._get_flash_messages()
+        # arguably a misunderstanding here about what an appropriate 'message category' looks like
+        assert set(flash_messages.getlist('upload_communication')) == set(('clarification', 'communication',))
+
+        assert response.status_code == 302
+
+    def test_post_bad_documents_for_framework(self, data_api_client):
+        data_api_client.get_frameworks.return_value = {"frameworks": []}
+
+        framework_slug = self.load_example_listing('framework_response')['frameworks']['slug']
+        dummy_file = BytesIO(u'Lorem ipsum dolor sit amet'.encode('utf8'))
+
+        self.client.post(
+            "/admin/communications/{}".format(framework_slug),
+            data={
+                'communication': (dummy_file, 'test-comm.unknown'),
+                'clarification': (dummy_file, 'test-clar.unknown'),
+            }
+        )
+
+        flash_messages = self._get_flash_messages()
+        # definitely a misunderstanding here about what an appropriate 'message category' looks like
+        assert flash_messages.get('not_open_document_format_or_csv') == 'communication'
+        assert flash_messages.get('not_pdf') == 'clarification'

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import mock
 from ...helpers import LoggedInApplicationTest
 from io import BytesIO
+from dmutils import s3
 
 
 @mock.patch('app.main.views.communications.data_api_client')
@@ -18,6 +19,9 @@ class TestCommunicationsView(LoggedInApplicationTest):
         assert response.status_code == 200
 
     def test_post_documents_for_framework(self, data_api_client):
+        # check we are mocking s3 as we must not actually post there!
+        assert isinstance(s3.S3, mock.Mock)
+
         data_api_client.get_frameworks.return_value = {"frameworks": []}
 
         framework_slug = self.load_example_listing('framework_response')['frameworks']['slug']
@@ -31,6 +35,8 @@ class TestCommunicationsView(LoggedInApplicationTest):
             }
         )
 
+        # check that we did actually mock-send two files
+        self.s3.return_value.save.call_count == 2
         flash_messages = self._get_flash_messages()
         # arguably a misunderstanding here about what an appropriate 'message category' looks like
         assert set(flash_messages.getlist('upload_communication')) == set(('clarification', 'communication',))

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -11,6 +11,7 @@ from lxml import html
 
 from dmapiclient import HTTPError, REQUEST_ERROR_MESSAGE
 from ...helpers import LoggedInApplicationTest
+from dmutils import s3
 
 
 class TestIndex(LoggedInApplicationTest):
@@ -616,6 +617,8 @@ class TestServiceUpdate(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
     @mock.patch('app.main.views.services.upload_service_documents')
     def test_service_update_when_API_returns_error(self, upload_service_documents, data_api_client):
+        assert isinstance(s3.S3, mock.Mock)
+
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
             'supplierId': 2,


### PR DESCRIPTION
* tests for admin 'communications upload' page;
* add download_filename to S3 call to ensure Content-Disposition is set;
* we only want to mock S3 once, so use same import style in both places we use our dmutils.s3 module.