### PR TITLE
Update dev config to use a single bucket for all upload types

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -207,6 +207,7 @@ def update(service_id, section_id):
 
     uploaded_documents, document_errors = upload_service_documents(
         s3.S3(current_app.config['DM_S3_DOCUMENT_BUCKET']),
+        'documents',
         current_app.config['DM_DOCUMENTS_URL'],
         service, request.files, section)
 

--- a/config.py
+++ b/config.py
@@ -74,16 +74,14 @@ class Test(Config):
     SHARED_EMAIL_KEY = 'KEY'
     INVITE_EMAIL_SALT = 'SALT'
     DM_MANDRILL_API_KEY = "MANDRILL"
-    DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
-    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-documents-dev-dev'
 
 
 class Development(Config):
     DEBUG = True
     SESSION_COOKIE_SECURE = False
     AUTHENTICATION = True
-    DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-communications-dev-dev'
-    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-documents-dev-dev'
+    DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-dev-uploads'
+    DM_AGREEMENTS_BUCKET = 'digitalmarketplace-dev-uploads'
 
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ unicodecsv==0.14.1
 boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.2#egg=digitalmarketplace-content-loader==3.5.2
-git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
+git+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.0#egg=digitalmarketplace-utils==25.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.6.0#egg=digitalmarketplace-apiclient==8.6.0
 
 # For Cloud Foundry

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -17,9 +17,7 @@ class BaseApplicationTest(object):
 
         self._s3_patch = mock.patch('dmutils.s3.S3')
         self.s3 = self._s3_patch.start()
-        self.s3.return_value = mock.Mock(
-            bucket_name="digitalmarketplace-documents-testing-testing",
-            bucket_short_name="documents")
+        self.s3.return_value = mock.Mock()
         self.s3.return_value.list.return_value = []
 
         self._default_suffix_patch = mock.patch(


### PR DESCRIPTION
Using a single bucket allows us to use S3 bucket domain as our
assets URL without a running a separate nginx proxy.

The bucket is empty at the moment and might get replaced in the
future when we start managing it with Terraform.

Don't set bucket names for the test config since S3 should always
be mocked.