### PR TITLE
Fix summary tables

### DIFF
--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -55,7 +55,11 @@
     %}
 
       {% call summary.row() %}
-        {{ summary.field_name(item.name, rowspan=5) }}
+        {% if current_user.has_role('admin-ccs-sourcing') %}
+          {{ summary.field_name(item.name, rowspan=5) }}
+        {% else %}
+          {{ summary.field_name(item.name) }}
+        {% endif %}
         {% if current_user.has_role('admin') %}
           {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
         {% endif %}


### PR DESCRIPTION
Remove rowspan option where admin is not sourcing as these tables are different.

Before:
<img width="1008" alt="screen shot 2017-04-19 at 17 58 55" src="https://cloud.githubusercontent.com/assets/11633362/25192150/09572a6a-252a-11e7-835f-b702e68eac40.png">

After:
<img width="1021" alt="screen shot 2017-04-19 at 17 56 55" src="https://cloud.githubusercontent.com/assets/11633362/25192154/0b231912-252a-11e7-9903-3f1e1afeb239.png">
