### PR TITLE
Remove plain text logs in live

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,8 +37,9 @@ class Config(object):
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
-    DM_APP_NAME = 'admin-frontend'
+    DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
+    DM_APP_NAME = 'admin-frontend'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
 
     # Feature Flags
@@ -65,6 +66,7 @@ class Config(object):
 
 class Test(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     AUTHENTICATION = True
     WTF_CSRF_ENABLED = False
     DM_DOCUMENTS_URL = 'https://assets.test.digitalmarketplace.service.gov.uk'
@@ -78,6 +80,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     SESSION_COOKIE_SECURE = False
     AUTHENTICATION = True
     DM_AGREEMENTS_BUCKET = 'digitalmarketplace-dev-uploads'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ unicodecsv==0.14.1
 boto==2.36.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.2#egg=digitalmarketplace-content-loader==3.5.2
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.0#egg=digitalmarketplace-utils==25.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.6.0#egg=digitalmarketplace-apiclient==8.6.0
 
 # For Cloud Foundry


### PR DESCRIPTION
Trello card: https://trello.com/c/o3Jkp3rK

25.2.0 of utils will create json logs by default, unless the
DM_PLAIN_TEXT_LOGS config variable is set to True in the config.

This config variable is set in dev and test so that logs are more
legible/useful.

The other thing 25.2.0 does is log to stdout instead of file by default,
unless the DM_LOG_PATH config variable is set. In the PaaS
environment, we'll need to log to stdout so will overwrite this
variable. Logging to stdout is also more useful in dev and test.