### PR TITLE
Admin edit g9 services

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.1.8",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v6.4.8",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v8.4.12",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ unicodecsv==0.14.1
 
 boto==2.36.0
 
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.2#egg=digitalmarketplace-content-loader==3.5.2
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@26.2.0#egg=digitalmarketplace-utils==26.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.6.0#egg=digitalmarketplace-apiclient==8.6.0
 
 # For Cloud Foundry

--- a/tests/app/fixtures/frameworks.json
+++ b/tests/app/fixtures/frameworks.json
@@ -1,0 +1,431 @@
+{
+  "frameworks": [
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 4,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 7",
+      "slug": "g-cloud-7",
+      "status": "live",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 1,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 6",
+      "slug": "g-cloud-6",
+      "status": "expired",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": true,
+      "application_close_date": "2016-06-01T17:00:00.000000Z",
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {
+        "frameworkAgreementVersion": "v1.0",
+        "variations": {
+          "1": {
+            "countersignedAt": "2016-10-05T11:00:00.000000Z",
+            "countersignerName": "Dan Saxby",
+            "countersignerRole": "Category Director",
+            "createdAt": "2016-08-19T15:31:00.000000Z"
+          }
+        }
+      },
+      "frameworkAgreementVersion": "v1.0",
+      "id": 6,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 8",
+      "slug": "g-cloud-8",
+      "status": "live",
+      "variations": {
+        "1": {
+          "countersignedAt": "2016-10-05T11:00:00.000000Z",
+          "countersignerName": "Dan Saxby",
+          "countersignerRole": "Category Director",
+          "createdAt": "2016-08-19T15:31:00.000000Z"
+        }
+      }
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 3,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 5",
+      "slug": "g-cloud-5",
+      "status": "expired",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 2,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 4",
+      "slug": "g-cloud-4",
+      "status": "expired",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": true,
+      "application_close_date": "2017-01-16T17:00:00.000000Z",
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "digital-outcomes-and-specialists",
+      "frameworkAgreementDetails": {
+        "frameworkAgreementVersion": "v1.0",
+        "variations": {}
+      },
+      "frameworkAgreementVersion": "v1.0",
+      "id": 7,
+      "lots": [
+        {
+          "allowsBrief": true,
+          "id": 5,
+          "name": "Digital outcomes",
+          "oneServiceLimit": true,
+          "slug": "digital-outcomes",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": true,
+          "id": 6,
+          "name": "Digital specialists",
+          "oneServiceLimit": true,
+          "slug": "digital-specialists",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 7,
+          "name": "User research studios",
+          "oneServiceLimit": false,
+          "slug": "user-research-studios",
+          "unitPlural": "labs",
+          "unitSingular": "lab"
+        },
+        {
+          "allowsBrief": true,
+          "id": 8,
+          "name": "User research participants",
+          "oneServiceLimit": true,
+          "slug": "user-research-participants",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "Digital Outcomes and Specialists 2",
+      "slug": "digital-outcomes-and-specialists-2",
+      "status": "live",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": true,
+      "application_close_date": "2016-01-01T15:00:00.000000Z",
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "digital-outcomes-and-specialists",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 5,
+      "lots": [
+        {
+          "allowsBrief": true,
+          "id": 5,
+          "name": "Digital outcomes",
+          "oneServiceLimit": true,
+          "slug": "digital-outcomes",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": true,
+          "id": 6,
+          "name": "Digital specialists",
+          "oneServiceLimit": true,
+          "slug": "digital-specialists",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 7,
+          "name": "User research studios",
+          "oneServiceLimit": false,
+          "slug": "user-research-studios",
+          "unitPlural": "labs",
+          "unitSingular": "lab"
+        },
+        {
+          "allowsBrief": true,
+          "id": 8,
+          "name": "User research participants",
+          "oneServiceLimit": true,
+          "slug": "user-research-participants",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "Digital Outcomes and Specialists",
+      "slug": "digital-outcomes-and-specialists",
+      "status": "live",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": true,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 8,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 9,
+          "name": "Cloud hosting",
+          "oneServiceLimit": false,
+          "slug": "cloud-hosting",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 10,
+          "name": "Cloud software",
+          "oneServiceLimit": false,
+          "slug": "cloud-software",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 11,
+          "name": "Cloud support",
+          "oneServiceLimit": false,
+          "slug": "cloud-support",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 9",
+      "slug": "g-cloud-9",
+      "status": "open",
+      "variations": {}
+    }
+  ]
+}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -6,12 +6,20 @@ from dmutils.user import User
 from flask import json
 from werkzeug.datastructures import MultiDict
 
-from app import create_app
+from app import create_app, data_api_client
 from app import login_manager
 
 
 class BaseApplicationTest(object):
     def setup_method(self, method):
+
+        # We need to mock the API client in create_app, however we can't use patch the constructor,
+        # as the DataAPIClient instance has already been created; nor can we temporarily replace app.data_api_client
+        # with a mock, because then the shared instance won't have been configured (done in create_app). Instead,
+        # just mock the one function that would make an API call in this case.
+        data_api_client.find_frameworks = mock.Mock()
+        data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
+
         self.app = create_app('test')
         self.client = self.app.test_client()
 
@@ -43,6 +51,21 @@ class BaseApplicationTest(object):
     def _get_flash_messages(self):
         with self.client.session_transaction() as session:
             return MultiDict(session['_flashes'])
+
+    @staticmethod
+    def _get_fixture_data(fixture_filename):
+        test_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), ".")
+        )
+        fixture_path = os.path.join(
+            test_root, 'fixtures', fixture_filename
+        )
+        with open(fixture_path) as fixture_file:
+            return json.load(fixture_file)
+
+    @staticmethod
+    def _get_frameworks_list_fixture_data():
+        return BaseApplicationTest._get_fixture_data('frameworks.json')
 
 
 class Response:


### PR DESCRIPTION
For this card: https://trello.com/c/CZEXBSy1/483-bug-the-admin-editing-of-g9-services

Admin app had a hard-coded list of manifests to load - we'd already added the one for G9 declaration but not forG9 services.

I've changed this to mimic the buyer frontend, which hits the API to find the frameworks that exists and then loads all the relevant things.

Should stop bugs like this happening again in future.