### PR TITLE
Update staging config

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -208,7 +208,7 @@ def update(service_id, section_id):
     uploaded_documents, document_errors = upload_service_documents(
         s3.S3(current_app.config['DM_S3_DOCUMENT_BUCKET']),
         'documents',
-        current_app.config['DM_DOCUMENTS_URL'],
+        current_app.config['DM_ASSETS_URL'],
         service, request.files, section)
 
     if document_errors:

--- a/config.py
+++ b/config.py
@@ -38,7 +38,6 @@ class Config(object):
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
     DM_PLAIN_TEXT_LOGS = False
-    DM_LOG_PATH = None
     DM_APP_NAME = 'admin-frontend'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
 
@@ -100,7 +99,6 @@ class Live(Config):
     AUTHENTICATION = True
     DM_HTTP_PROTO = 'https'
     DM_DOCUMENTS_URL = 'https://assets.digitalmarketplace.service.gov.uk'
-    DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
 
 
 configs = {

--- a/config.py
+++ b/config.py
@@ -103,18 +103,10 @@ class Live(Config):
     DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
 
 
-class Staging(Config):
-    DEBUG = False
-    AUTHENTICATION = True
-    WTF_CSRF_ENABLED = False
-    DM_DOCUMENTS_URL = 'https://assets.digitalmarketplace.service.gov.uk'
-    DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
-
-
 configs = {
     'development': Development,
     'preview': Live,
-    'staging': Staging,
+    'staging': Live,
     'production': Live,
     'test': Test,
 }

--- a/config.py
+++ b/config.py
@@ -18,7 +18,6 @@ class Config(object):
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SECURE = True
     DM_S3_DOCUMENT_BUCKET = None
-    DM_DOCUMENTS_URL = 'https://assets.dev.digitalmarketplace.service.gov.uk'
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None
     SECRET_KEY = None
@@ -68,7 +67,7 @@ class Test(Config):
     DM_PLAIN_TEXT_LOGS = True
     AUTHENTICATION = True
     WTF_CSRF_ENABLED = False
-    DM_DOCUMENTS_URL = 'https://assets.test.digitalmarketplace.service.gov.uk'
+    DM_ASSETS_URL = 'https://assets.test.digitalmarketplace.service.gov.uk'
     SECRET_KEY = "test_secret"
 
     DM_LOG_LEVEL = 'CRITICAL'
@@ -85,7 +84,7 @@ class Development(Config):
     DM_AGREEMENTS_BUCKET = 'digitalmarketplace-dev-uploads'
     DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-dev-uploads'
     DM_S3_DOCUMENT_BUCKET = "digitalmarketplace-dev-uploads"
-    DM_DOCUMENTS_URL = "https://{}.s3-eu-west-1.amazonaws.com".format(DM_S3_DOCUMENT_BUCKET)
+    DM_ASSETS_URL = "https://{}.s3-eu-west-1.amazonaws.com".format(DM_S3_DOCUMENT_BUCKET)
 
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
@@ -98,7 +97,6 @@ class Live(Config):
     DEBUG = False
     AUTHENTICATION = True
     DM_HTTP_PROTO = 'https'
-    DM_DOCUMENTS_URL = 'https://assets.digitalmarketplace.service.gov.uk'
 
 
 configs = {


### PR DESCRIPTION
### Fix missing DM_HTTP_PROTO in staging config

Staging was sending user invite emails with `http://` because staging
config didn't set the correct DM_HTTP_PROTO.

The config was copied from Live in #87 to disable CSRF checks in
staging. We couldn't find a reason why we'd still want this, so
I'm reverting the setting to match the Live config.

### Remove DM_LOG_PATH config variable

After the move to PaaS, we're no longer logging to files in any
environments (DM_LOG_PATH is overwritten with an empty string in
all PaaS spaces)

### Replace DM_DOCUMENTS_URL with DM_ASSETS_URL

DM_DOCUMENTS_URL was used before we introduced DM_ASSETS_URL.
Both variables should contain the same value, but DM_ASSETS_URL is
set through environment variables to the correct value for each
stage.