### PR TITLE
[#138031851]service updates page

### DIFF
--- a/app/assets/scss/_diff.scss
+++ b/app/assets/scss/_diff.scss
@@ -1,29 +1,10 @@
 .diff {
   margin-bottom: $gutter;
 
-  .diff-title {
-    @include heading-27;
-    font-weight: bold;
-    margin-bottom: $gutter-half;
-  }
-
-  .revision-dates {
-    @extend %contain-floats;
-    margin-bottom: $gutter-half;
-
-    p {
-      float: none;
-      width: 100%;
-      @include media(tablet) {
-        float: left;
-        width: 50%;
+  .page-column-headings + table {
+      caption {
+          padding-top: $gutter/2;
       }
-
-      .revision-date-type {
-        font-weight: bold;
-        margin-right: $gutter-half;
-      }
-    }
   }
 
   table {
@@ -54,7 +35,7 @@
       }
 
       &.line-non-existent {
-          background-color: #EEEEEE;
+          background-color: $highlight-colour;
       }
 
       &.removal {

--- a/app/assets/scss/_diff.scss
+++ b/app/assets/scss/_diff.scss
@@ -53,6 +53,10 @@
         border-right: 5px solid white;
       }
 
+      &.line-non-existent {
+          background-color: #EEEEEE;
+      }
+
       &.removal {
         background-color: #FEE5E5;
 
@@ -76,7 +80,6 @@
         text-align: right;
         float: left;
         clear: both;
-        background-color: transparent;
         width: 3%;
         padding-right: 1%;
         border-right: none;

--- a/app/assets/scss/_diff.scss
+++ b/app/assets/scss/_diff.scss
@@ -56,7 +56,7 @@
       &.removal {
         background-color: #FEE5E5;
 
-        strong {
+        del {
           background-color: #FDABAB;
           font-weight: normal;
         }
@@ -64,9 +64,10 @@
       &.addition {
         background-color: #E5FEE5;
 
-        strong {
+        ins {
           background-color: #ABFDAB;
           font-weight: normal;
+          text-decoration: none;
         }
       }
 
@@ -99,6 +100,7 @@
         width: 95%;
         padding-left: 1%;
         float: right;
+        white-space: pre-wrap;
 
         @include media(tablet) {
           width: 41%;

--- a/app/main/helpers/diff_tools.py
+++ b/app/main/helpers/diff_tools.py
@@ -97,19 +97,27 @@ def _clean_difflib_html_table(table_src, table_preamble_template=None, table_pre
         tr[0].attrib["class"] = tr[2].attrib["class"] = "line-number"
         tr[1].attrib["class"] = tr[3].attrib["class"] = "line-content"
 
-        if len(tr[1]):  # i.e. left side is interesting because the content has (presumably span.diff_*) child elements
-            tr[0].attrib["class"] += " line-number-removal"
-            tr[1].attrib["class"] += " removal"
-            for span in tr[1].xpath("./span[@class='diff_sub' or @class='diff_chg']"):
-                span.tag = "del"
-                del span.attrib["class"]
+        if (tr[0].text or "").strip() or len(tr[0]):  # i.e. left side has what is presumably a line number
+            if len(tr[1]):  # i.e. left side is interesting because the content has (presumably span.diff_*) child elems
+                tr[0].attrib["class"] += " line-number-removal"
+                tr[1].attrib["class"] += " removal"
+                for span in tr[1].xpath("./span[@class='diff_sub' or @class='diff_chg']"):
+                    span.tag = "del"
+                    del span.attrib["class"]
+        else:
+            tr[0].attrib["class"] += " line-non-existent"
+            tr[1].attrib["class"] += " line-non-existent"
 
-        if len(tr[3]):  # i.e. right side is interesting because the content has (presumably span.diff_*) child elements
-            tr[2].attrib["class"] += " line-number-addition"
-            tr[3].attrib["class"] += " addition"
-            for span in tr[3].xpath("./span[@class='diff_add' or @class='diff_chg']"):
-                span.tag = "ins"
-                del span.attrib["class"]
+        if (tr[2].text or "").strip() or len(tr[2]):  # i.e. right side has what is presumably a line number
+            if len(tr[3]):  # i.e. right side's interesting because the content has (presumably span.diff_*) child elems
+                tr[2].attrib["class"] += " line-number-addition"
+                tr[3].attrib["class"] += " addition"
+                for span in tr[3].xpath("./span[@class='diff_add' or @class='diff_chg']"):
+                    span.tag = "ins"
+                    del span.attrib["class"]
+        else:
+            tr[2].attrib["class"] += " line-non-existent"
+            tr[3].attrib["class"] += " line-non-existent"
 
     if table_preamble_template:
         preamble_src = render_template(table_preamble_template, **table_preamble_context)

--- a/app/main/helpers/diff_tools.py
+++ b/app/main/helpers/diff_tools.py
@@ -1,209 +1,120 @@
 import difflib
-try:
-    from itertools import izip_longest
-except ImportError:
-    from itertools import zip_longest as izip_longest
 from datetime import datetime
-from flask import Markup, escape
+from itertools import chain
+import re
+
+from flask import Markup, escape, render_template
 from flask._compat import string_types
+
+from lxml import html
+from six.moves import zip_longest as izip_longest
+
+from dmcontent.questions import Multiquestion
 from dmutils.formats import DATETIME_FORMAT, DISPLAY_DATETIME_FORMAT
 
 
-def get_diffs_from_service_data(
-        sections=None,
-        revision_1=None,
-        revision_2=None,
-        include_unchanged_lines_in_output=False
+def _question_iter(question):
+    # type testing is weird - this should eventually belong in the question subclass itself
+    if isinstance(question, Multiquestion):
+        for sub_question in question.questions:
+            yield sub_question
+    else:
+        yield question
+
+
+def html_diff_tables_from_sections_iter(
+        sections,
+        revision_1,
+        revision_2,
+        table_preamble_template=None,
 ):
-    def all_are_lists(*args):
-        return all(isinstance(arg, list) for arg in args)
-
-    def all_are_strings(*args):
-        return all(isinstance(arg, string_types) for arg in args)
-
-    diffs = []
+    html_diff = difflib.HtmlDiff()
 
     for section in sections:
-        for question in section['questions']:
-            question_revision_1, question_revision_2 = None, None
+        for question in chain.from_iterable(_question_iter(question) for question in section['questions']):
+            q1, q2 = (r.get(question['id'], []) for r in (revision_1, revision_2,))
+            if q1 != q2:
+                q1, q2 = ((q.splitlines() if isinstance(q, string_types) else q) for q in (q1, q2,))
 
-            if all_are_lists(
-                    revision_1.get(question['id'], []),
-                    revision_2.get(question['id'], [])
-            ):
-                question_revision_1 = revision_1.get(question['id'], [])
-                question_revision_2 = revision_2.get(question['id'], [])
-
-            elif all_are_strings(
-                    revision_1.get(question['id'], ''),
-                    revision_2.get(question['id'], '')
-            ):
-                question_revision_1 = revision_1.get(question['id'], '').splitlines()
-                question_revision_2 = revision_2.get(question['id'], '').splitlines()
-
-            if question_revision_1 is not None and question_revision_2 is not None:
-                question_diff = render_lines(
-                    question_revision_1,
-                    question_revision_2,
-                    include_unchanged_lines_in_output
-                )
-
-                # if arrays are empty, there are no changes for this question
-                if question_diff['revision_1'] or question_diff['revision_2']:
-                    diffs.append({
-                        'section_name': section['name'],
-                        'label': question['question'],
-                        'revisions':
-                            [val + question_diff['revision_2'][i]
-                             for i, val
-                             in enumerate(question_diff['revision_1'])]
-                    })
-
-    return diffs
+                yield section.slug, question.id, Markup(_clean_difflib_html_table(
+                    html_diff.make_table(q1, q2),
+                    table_preamble_template=table_preamble_template,
+                    table_preamble_context={
+                        "section": section,
+                        "question": question,
+                    },
+                ))
 
 
-def get_revision_dates(revision_1=None, revision_2=None):
-
-    def get_revision_date(date_string):
-        # Tuesday, 10 June 2015 at 14:00
-        return datetime.strptime(
-            date_string, DATETIME_FORMAT
-        ).strftime(DISPLAY_DATETIME_FORMAT)
-
-    return {
-        'revision_1': get_revision_date(revision_1['updatedAt']),
-        'revision_2': get_revision_date(revision_2['updatedAt'])
-    }
+def _strip_nbsp(content):
+    return content.replace(u"\u00a0", u" ")
 
 
-def render_lines(
-        revision_1, revision_2, include_unchanged_lines_in_output=False):
-    """
-    Turns a pair of input lines into a list of word diffs
-
-    In:
-    revision_1: ['Hi there', 'Less letters']
-    revision_2: ['Hi there!', 'Less let']
-
-    Out:
-    { 'revision_1': ['  Hi', '- there'], ['  Less', '- letters'],
-      'revision_2': ['  Hi', '+ there!'], ['  Less', '+ let'] }
-    """
-
-    lines = {
-        'revision_1': [],
-        'revision_2': []
-    }
-
-    for index, revisions in enumerate(
-            izip_longest(revision_1, revision_2, fillvalue='')
-    ):
-        diff = get_words_diff(revisions[0], revisions[1])
-
-        # create an array of removed words and one of added rows
-        revision_1_words, revision_2_words = split_words_diff(diff)
-
-        # if revisions are equal and we want to skip unchanged lines
-        if revision_1_words == revision_2_words \
-            and get_line_type(revision_1_words) == 'unchanged' \
-            and get_line_type(revision_2_words) == 'unchanged' \
-                and not include_unchanged_lines_in_output:
-            continue
-
-        lines['revision_1'].append(
-            Markup(render_words_html(revision_1_words, index+1))
-        )
-        lines['revision_2'].append(
-            Markup(render_words_html(revision_2_words, index+1))
-        )
-
-    return lines
+def _strip_element_nbsp(element):
+    element.text = element.text and _strip_nbsp(element.text)
+    element.tail = element.tail and _strip_nbsp(element.tail)
+    for child_element in element:
+        _strip_element_nbsp(child_element)
 
 
-def split_words_diff(words_diff):
-    """
-    Accepts a list of words that have been diffed
-    Returns two lists: one with removals ('-') and one with additions ('+')
-    Ignores detail ('?') lines
+def _clean_difflib_html_table(table_src, table_preamble_template=None, table_preamble_context={}):
+    # difflib doesn't produce html *quite* how we would like, so we do the admittedly slightly strange thing here of
+    # parsing it, modifying the result in-place and re-serializing it for rendering. this is, in my opinion, the least-
+    # worst thing to do, because it allows us to take advantage of the (well tested) logic of difflib.HtmlDiff while
+    # just adding relatively simple style-mangling code of our own.
+    #
+    # another (perhaps more obvious) alternative to this would have been to adapt our stytles to difflib's output,
+    # but... frankly our style scheme for this is more well thought out and, more importantly, already cross-browser
+    # tested.
+    table_element = html.fragment_fromstring(table_src)
 
-    In:  ['  Hi', '- there', '+ there!', '?      +\n']
-    Out: (['  Hi', '- there'], ['  Hi', '+ there!'])
-    """
+    # colgroups not wanted
+    for colgroup in table_element.xpath(".//colgroup"):
+        colgroup.getparent().remove(colgroup)
 
-    return [w for w in words_diff
-            if get_word_type(w) in ['unchanged', 'removal']], \
-           [w for w in words_diff
-            if get_word_type(w) in ['unchanged', 'addition']]
+    # column of links not wanted
+    for diff_next in table_element.xpath(".//td[@class='diff_next']"):
+        diff_next.getparent().remove(diff_next)
 
+    # this isn't even valid html5 anymore
+    for td_nowrap in table_element.xpath(".//td[@nowrap]"):
+        del td_nowrap.attrib["nowrap"]
 
-def render_words_html(words, line_number):
+    for key in table_element.keys():
+        del table_element.attrib[key]
 
-    def _render_words_inner_html(words, inferred_type):
+    # we can't really safely use ids (who knows if we're going to use >1 of these in a page?)
+    for element in table_element.xpath(".//*[@id]"):
+        del element.attrib["id"]
 
-        html_words = []
+    # difflib very helpfully replaces all our spaces with nbsp, which is not something we want
+    _strip_element_nbsp(table_element.xpath("./tbody")[0])
 
-        for word in words:
-            word = escape(word)
-            type = get_word_type(word)
+    for line_number_td in table_element.xpath(".//td[@class='diff_header']"):
+        line_number_td.attrib["class"] = "line-number"
 
-            if type == 'unchanged':
-                html_words.append(u"{}".format(word[2:]))
+    for tr in table_element.xpath("./tbody/tr"):
+        tr[0].attrib["class"] = tr[2].attrib["class"] = "line-number"
+        tr[1].attrib["class"] = tr[3].attrib["class"] = "line-content"
 
-            elif type == inferred_type:
-                html_words.append(u"<strong>{}</strong>".format(word[2:]))
+        if len(tr[1]):  # i.e. left side is interesting because the content has (presumably span.diff_*) child elements
+            tr[0].attrib["class"] += " line-number-removal"
+            tr[1].attrib["class"] += " removal"
+            for span in tr[1].xpath("./span[@class='diff_sub' or @class='diff_chg']"):
+                span.tag = "del"
+                del span.attrib["class"]
 
-        return ' '.join(html_words).replace(u'</strong> <strong>', ' ')
+        if len(tr[3]):  # i.e. right side is interesting because the content has (presumably span.diff_*) child elements
+            tr[2].attrib["class"] += " line-number-addition"
+            tr[3].attrib["class"] += " addition"
+            for span in tr[3].xpath("./span[@class='diff_add' or @class='diff_chg']"):
+                span.tag = "ins"
+                del span.attrib["class"]
 
-    # Can only have one inferred type per line
-    inferred_type = get_line_type(words)
+    if table_preamble_template:
+        preamble_src = render_template(table_preamble_template, **table_preamble_context)
+        preamble_elements = html.fragments_fromstring(preamble_src)
+        for element in reversed(preamble_elements):
+            table_element.insert(0, element)
 
-    return \
-        u"<td class='line-number line-number-{type}'>{line_number}</td>" \
-        u"<td class='line-content {type}'>{line}</td>".format(
-            type=inferred_type,
-            line_number=line_number,
-            line=_render_words_inner_html(words, inferred_type)
-        )
-
-
-def get_words_diff(revision_1_line, revision_2_line):
-    """
-    Accepts two strings which are split into lists
-    Returns a list of word-diffs
-
-    In:  'Hi there', 'Hi there!'
-    Out: ['  Hi', '- there', '+ there!', '?      +\n']
-    """
-    differ = difflib.Differ()
-    # Splitting the lines on whitespace to that we get a word diff
-    return list(differ.compare(
-        revision_1_line.split(), revision_2_line.split()
-    ))
-
-
-def get_line_type(words, types_to_look_for=None):
-
-    if not words:
-        return 'empty'
-
-    if not types_to_look_for:
-        types_to_look_for = ['addition', 'removal']
-
-    for word in words:
-        type = get_word_type(word)
-        if type in types_to_look_for:
-            return type
-
-    # if words is empty, this is still what we want
-    return 'unchanged'
-
-
-def get_word_type(string):
-    if string.startswith('+ '):
-        return 'addition'
-    if string.startswith('- '):
-        return 'removal'
-    if string.startswith('? '):
-        return 'detail'
-    if string.startswith('  '):
-        return 'unchanged'
+    return html.tostring(table_element)

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -57,7 +57,7 @@
     {% include "toolkit/secondary-action-link.html" %}
   {% endwith %}
     <div class="grid-row">
-      <div class="column-two-thirds">
+      <div class="column-two-thirds page-section">
         <p>
           {{ unack_update_events|length }} unacknowledged {{ pluralize(unack_update_events|length, "edit", "edits") }}
           {%- if unack_update_events %}
@@ -80,26 +80,28 @@
     </div>
 
     {% if unack_update_events %}
-    <div class="grid-row">
-      <div class="column-one-half">
-        <h3>
-          Previously acknowledged version
-        </h3>
-        <p>
-          Changed on {{ unack_update_events.0.createdAt|datetimeformat }}
-        </p>
-      </div>
-      <div class="column-one-half">
-        <h3>
-          Current version
-        </h3>
-      </div>
-    </div>
     <div class="diff">
+    {% if diffs %}
+      <div class="grid-row page-column-headings">
+        <div class="column-one-half">
+          <h3>
+            Previously acknowledged version
+          </h3>
+          <p>
+            Changed on {{ unack_update_events.0.createdAt|datetimeformat }}
+          </p>
+        </div>
+        <div class="column-one-half">
+          <h3>
+            Current version
+          </h3>
+        </div>
+      </div>
+    {% endif %}
     {% for diff_table in diffs.values() %}
       {{ diff_table }}
     {% else %}
-      <p>All changes were reverted.</p>
+      <p>All changes were reversed.</p>
     {% endfor %}
     </div><!-- end of .diff -->
     <form method="post" action="ACK_URL">

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -59,19 +59,26 @@
     <div class="grid-row">
       <div class="column-two-thirds page-section">
         <p>
-          {{ unack_update_events|length }} unacknowledged {{ pluralize(unack_update_events|length, "edit", "edits") }}
-          {%- if unack_update_events %}
-            by
-            {% if n_editing_users == 1 %}
-              {{ unack_update_events.0.user }}
-            {% else %}
-              {{ n_editing_users }} users
+          {% if all_update_events is none %}
+            Multiple
+          {% else %}
+            {{ all_update_events|length }}
+          {% endif %}
+          unacknowledged {{ pluralize((all_update_events or (oldest_update_events+latest_update_events))|length, "edit", "edits") }}
+          {%- if latest_update_events %}
+            {% if all_update_events is not none %}
+              by
+              {% if n_editing_users_min == 1 %}
+                {{ latest_update_events.0.user }}
+              {% else %}
+                {{ n_editing_users_min }} users
+              {% endif %}
             {% endif %}
-            {% if unack_update_events[0].createdAt|dateformat == unack_update_events[-1].createdAt|dateformat %}
-              on {{ unack_update_events[0].createdAt|dateformat }}
+            {% if latest_update_events[0].createdAt|dateformat == oldest_update_events[-1].createdAt|dateformat %}
+              on {{ latest_update_events[0].createdAt|dateformat }}
             {%- else %}
-              between {{ unack_update_events[0].createdAt|dateformat }}
-              and {{ unack_update_events[-1].createdAt|dateformat }}
+              between {{ oldest_update_events[-1].createdAt|dateformat }}
+              and {{ latest_update_events[0].createdAt|dateformat }}
             {%- endif -%}
           {%- endif -%}
           .
@@ -79,7 +86,7 @@
       </div>
     </div>
 
-    {% if unack_update_events %}
+    {% if latest_update_events %}
     <div class="diff">
     {% if diffs %}
       <div class="grid-row page-column-headings">
@@ -88,7 +95,7 @@
             Previously acknowledged version
           </h3>
           <p>
-            Changed on {{ unack_update_events.0.createdAt|datetimeformat }}
+            Changed on {{ oldest_update_events[-1].createdAt|datetimeformat }}
           </p>
         </div>
         <div class="column-one-half">
@@ -109,7 +116,7 @@
         <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
       </div>
       <button type="submit" class="button-save">
-        Acknowledge {{ pluralize(unack_update_events|length, "edit", "edits") }}
+        Acknowledge {{ pluralize((all_update_events or (oldest_update_events+latest_update_events))|length, "edit", "edits") }}
       </button>
     </form>
     {% endif %}

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 {% block page_title %}
-  {{ service_data['serviceName'] }} – Digital Marketplace admin
+  {{ service['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}
@@ -41,89 +41,102 @@
   {% endif %}
   {% endwith %}
 
-    {% if service_data %}
-      {%
-        with
-        smaller = true,
-        heading = service_data['serviceName'],
-        context = service_data['supplierName']
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-      {%
-        with
-          url = "/g-cloud/services/{}".format(service_data.id),
-          text = "View service page on the Digital Marketplace"
-      %}
-        {% include "toolkit/secondary-action-link.html" %}
-      {% endwith %}
-    <br />
+  {%
+    with
+    smaller = true,
+    heading = service['serviceName'],
+    context = service['supplierName']
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  {%
+    with
+      url = "/g-cloud/services/{}".format(service.id),
+      text = "View service"
+  %}
+    {% include "toolkit/secondary-action-link.html" %}
+  {% endwith %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <p>
+          {{ unack_update_events|length }} unacknowledged {{ pluralize(unack_update_events|length, "edit", "edits") }}
+          {%- if unack_update_events %}
+            by
+            {% if n_editing_users == 1 %}
+              {{ unack_update_events.0.user }}
+            {% else %}
+              {{ n_editing_users }} users
+            {% endif %}
+            {% if unack_update_events[0].createdAt|dateformat == unack_update_events[-1].createdAt|dateformat %}
+              on {{ unack_update_events[0].createdAt|dateformat }}
+            {%- else %}
+              between {{ unack_update_events[0].createdAt|dateformat }}
+              and {{ unack_update_events[-1].createdAt|dateformat }}
+            {%- endif -%}
+          {%- endif -%}
+          .
+        </p>
+      </div>
+    </div>
 
-      <div class="diff">
-        <h2 class="diff-title">Service Revisions</h2>
-        {% if revision_dates %}
-        <div class="revision-dates">
-          <p><span class="revision-date-type">Original</span><span class="visuallyhidden">:</span> {{ revision_dates.revision_1 }}</p>
-          <p><span class="revision-date-type">Revised</span><span class="visuallyhidden">:</span> {{ revision_dates.revision_2 }}</p>
-        </div>
-        {% endif %}
-      {% for section in sections %}
-        {% for diff in diffs %}
-          {% if section.name in diff.section_name %}
-            <table>
-              <caption>{{ diff.label }}</caption>
-              <thead>
-                <tr>
-                  <th class="line-number"><span class="visuallyhidden">Revision 1 line number</span></th>
-                  <th class="line-content"><span class="visuallyhidden">Revision 1 changes</span></th>
-                  <th class="line-number"><span class="visuallyhidden">Revision 2 line number</span></th>
-                  <th class="line-content"><span class="visuallyhidden">Revision 2 changes</span></th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for line in diff.revisions %}
-                  <tr class='diff-row'>
-                    {{ line }}
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          {% endif %}
-        {% endfor %}
-      {% endfor %}
-      </div><!-- end of .diff -->
-
-      {% if current_user.has_role('admin') %}
-      <form action="{{ url_for('.update_service_status', service_id=service_data.id ) }}" method="post">
-          <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
-          <fieldset class="question">
-              <legend class="question-heading">
-                  Service status
-              </legend>
-              <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service_data['status'] == 'disabled' %}checked="checked"{% endif %} />
-                  Removed
-              </label>
-              <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
-                  Private
-              </label>
-              {% if service_data.status != 'disabled' %}
-              <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
-                  Public
-              </label>
-              {% endif %}
-          </fieldset>
-          <button type="submit" class="button-save">Update status</button>
-      </form>
-      {% endif %}
-
+    {% if unack_update_events %}
+    <div class="grid-row">
+      <div class="column-one-half">
+        <h3>
+          Previously acknowledged version
+        </h3>
+        <p>
+          Changed on {{ unack_update_events.0.createdAt|datetimeformat }}
+        </p>
+      </div>
+      <div class="column-one-half">
+        <h3>
+          Current version
+        </h3>
+      </div>
+    </div>
+    <div class="diff">
+    {% for diff_table in diffs.values() %}
+      {{ diff_table }}
     {% else %}
-    <h1>Error</h1>
-    <p>
-      No service data
-    </p>
+      <p>All changes were reverted.</p>
+    {% endfor %}
+    </div><!-- end of .diff -->
+    {% endif %}
+
+    <div class="grid-row">
+      <div class="column-one-whole">
+        <h4>Contact supplier:</h4>
+        <p><a href="mailto:{{ supplier["contactInformation"][0]["email"] }}">
+            {{ supplier["contactInformation"][0]["email"] }}
+        </a></p>
+      </div>
+    </div>
+
+    {% if current_user.has_role('admin') %}
+    <form action="{{ url_for('.update_service_status', service_id=service.id ) }}" method="post">
+        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+        <fieldset class="question">
+            <legend class="question-heading">
+                Service status
+            </legend>
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service['status'] == 'disabled' %}checked="checked"{% endif %} />
+                Removed
+            </label>
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_private" value="private" {% if service['status'] == 'enabled' %}checked="checked"{% endif %} />
+                Private
+            </label>
+            {% if service.status != 'disabled' %}
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_published" value="public" {% if service['status'] == 'published' %}checked="checked"{% endif %} />
+                Public
+            </label>
+            {% endif %}
+        </fieldset>
+        <button type="submit" class="button-save">Update status</button>
+    </form>
     {% endif %}
   </div>
 {% endblock %}

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -102,6 +102,14 @@
       <p>All changes were reverted.</p>
     {% endfor %}
     </div><!-- end of .diff -->
+    <form method="post" action="ACK_URL">
+      <div style="display:none;">
+        <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
+      </div>
+      <button type="submit" class="button-save">
+        Acknowledge {{ pluralize(unack_update_events|length, "edit", "edits") }}
+      </button>
+    </form>
     {% endif %}
 
     <div class="grid-row">

--- a/app/templates/diff_table/_table_preamble.html
+++ b/app/templates/diff_table/_table_preamble.html
@@ -1,0 +1,9 @@
+<caption>{{ question.name or question.question }}</caption>
+<thead>
+  <tr>
+    <th class="line-number"><span class="visuallyhidden">Previously acknowledged version line number</span></th>
+    <th class="line-content"><span class="visuallyhidden">Previously acknowledged version changes</span></th>
+    <th class="line-number"><span class="visuallyhidden">Current version line number</span></th>
+    <th class="line-content"><span class="visuallyhidden">Current version changes</span></th>
+  </tr>
+</thead>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-Bootstrap==3.3.0.1
 Flask-WTF==0.11
+lxml==3.4.4
 pbkdf2==1.3
 python-dateutil==2.4.2
 six==1.9.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,7 +3,6 @@ pytest==2.8.2
 pep8==1.5.7
 mock==2.0.0
 requests-mock==0.6.0
-lxml==3.4.4
 cssselect==0.9.1
 watchdog==0.8.3
 coverage==3.7.1

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1030,7 +1030,6 @@ class TestServiceUpdates(LoggedInApplicationTest):
             "//*[normalize-space(string())=$reverted_text][not(.//*[normalize-space(string())=$reverted_text])]",
             reverted_text="All changes were reverted.",
         )) == (1 if fae_response and not resultant_diff else 0)
-        
 
         if fae_response:
             assert html_diff_tables_from_sections_iter.call_args_list == [
@@ -1049,9 +1048,9 @@ class TestServiceUpdates(LoggedInApplicationTest):
             )
             assert len(ack_forms) == 1
             assert ack_forms[0].method == "POST"
-            #assert ack_forms[0].action == "/admin/services/151/updates/{}/acknowledge".format(
-            #    text_type(fae_response[0]["oldArchivedServiceId"])
-            #)
+#            assert ack_forms[0].action == "/admin/services/151/updates/{}/acknowledge".format(
+#                text_type(fae_response[0]["oldArchivedServiceId"])
+#            )
             assert sorted(ack_forms[0].form_values()) == [
                 ("csrf_token", mock.ANY),
             ]

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1,3 +1,5 @@
+import pytest
+from functools import partial
 try:
     from urlparse import urlsplit
     from StringIO import StringIO
@@ -7,9 +9,11 @@ except ImportError:
 from itertools import chain
 import mock
 
+from flask import Markup
 from lxml import html
 
 from dmapiclient import HTTPError, REQUEST_ERROR_MESSAGE
+from dmapiclient.audit import AuditTypes
 from ...helpers import LoggedInApplicationTest
 from dmutils import s3
 
@@ -735,185 +739,344 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         assert response.status_code == 404
 
 
-class TestCompareServiceArchives(LoggedInApplicationTest):
+@mock.patch("app.main.views.services.html_diff_tables_from_sections_iter")
+@mock.patch('app.main.views.services.data_api_client', autospec=True)
+class TestServiceUpdates(LoggedInApplicationTest):
+    def test_nonexistent_service(self, data_api_client, html_diff_tables_from_sections_iter):
+        data_api_client.get_service.return_value = None
+        response = self.client.get('/admin/services/31415/updates')
+        assert response.status_code == 404
+        assert data_api_client.get_service.call_args_list == [(("31415",), {},)]
 
-    def setup_method(self, method):
-        super(TestCompareServiceArchives, self).setup_method(method)
-        self._services = {
-            1: {'services': {
-                'id': 1,
-                'supplierId': 2,
-                'updatedAt': '2014-12-10T10:55:25.00000Z',
-                'serviceName': '<h1>Cloudy</h1> Cloud Service',
-                'status': 'published',
-                'serviceSummary': 'Something'
-            }}
-        }
+    @staticmethod
+    def _mock_get_service_side_effect(status, service_id):
+        return {"services": {
+            "151": {
+                "id": "151",
+                "frameworkSlug": "g-cloud-9",
+                "lot": "cloud-hosting",
+                "status": status,
+                "supplierId": 909090,
+                "supplierName": "Barrington's",
+                "serviceName": "Lemonflavoured soap",
+            },
+        }[service_id]}
 
-        self._archived_services = {
-            10: {'services': {
-                'id': 1,
-                'supplierId': 2,
-                'updatedAt': '2014-12-01T10:55:25.00000Z',
-                'serviceName': 'Cloud Service',
-                'serviceSummary': 'Something'
-            }},
-            20: {'services': {
-                'id': 1,
-                'supplierId': 2,
-                'updatedAt': '2014-12-02T10:55:25.00000Z',
-                'serviceName': '<h1>Cloudy</h1> Cloud Service',
-                'serviceSummary': 'Something'
-            }},
-            # Service id doesn't exist
-            30: {'services': {
-                'id': 2,
-                'supplierId': 2,
-                'updatedAt': '2014-12-03T10:55:25.00000Z'
-            }},
-            # Service id doesn't exist
-            40: {'services': {
-                'id': 2,
-                'supplierId': 2,
-                'updatedAt': '2014-12-04T10:55:25.00000Z'
-            }},
-            # missing the serviceSummary
-            50: {'services': {
-                'id': 1,
-                'supplierId': 2,
-                'updatedAt': '2014-12-03T10:55:25.00000Z',
-                'serviceName': '<h1>Cloudy</h1> Cloud Service'
-            }}
-        }
+    @staticmethod
+    def _mock_get_archived_service_side_effect(available_archived_services, archived_service_id):
+        return {"services": available_archived_services[archived_service_id]}
 
-        self._service_not_found = {
-            'error': 'The requested URL was not found on the server.  If you '
-                     'entered the URL manually please check your spelling and '
-                     'try again.'
-            }
-
-    class _TestContent(object):
-        def __init__(self):
-            self.sections = [{
-                'editable': True,
-                'name': 'Description',
-                'questions': [
+    @staticmethod
+    def _mock_get_supplier_side_effect(supplier_id):
+        return {"suppliers": {
+            909090: {
+                "id": 909090,
+                "name": "Barrington's",
+                "contactInformation": [
                     {
-                        'question': 'Service name',
-                        'id': 'serviceName'
+                        "email": "sir.jonah.barrington@example.com",
                     },
-                    {
-                        'question': 'Service summary',
-                        'id': 'serviceSummary',
-                    }
                 ],
-                'id': 'description'
-            }]
+            },
+        }[supplier_id]}
 
-    def _get_archived_service(self, *args):
-        try:
-            return self._archived_services[int(args[0])]
-        except KeyError:
-            return self._service_not_found
+    _service_status_labels = {
+        "disabled": "Removed",
+        "enabled": "Private",
+        "published": "Public",
+    }
 
-    def _get_service(self, *args):
-        try:
-            return self._services[int(args[0])]
-        except KeyError:
-            return self._service_not_found
-
-    @mock.patch('app.main.views.services.data_api_client')
-    def _get_archived_services_response(
+    @pytest.mark.parametrize("fae_response,avail_arch_svcs,svc_status,exp_summ_text,exp_oldver_ctxt_text", (
+        (
+            # fae_response (find_audit_events response)
+            (
+                {
+                    "id": 567567,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "789",
+                        "newArchivedServiceId": "678",
+                    },
+                    "createdAt": "2010-02-03T10:11:12.345Z",
+                    "user": "someone@example.com",
+                },
+            ),
+            # avail_arch_svcs (available archived services)
+            {
+                "789": {
+                    "frameworkSlug": "g-cloud-9",
+                    "lot": "cloud-hosting",
+                    "supplierId": 909090,
+                    "supplierName": "Barrington's",
+                    "serviceName": "Melonflavoured soap",
+                },
+            },
+            # svc_status (service status)
+            "disabled",
+            # exp_summ_text (expected summary text)
+            "1 unacknowledged edit by someone@example.com on Wednesday 3 February 2010.",
+            # exp_oldver_ctxt_text (expected oldversion title context text)
+            "Changed on Wednesday 3 February 2010 at 10:11",
+        ),
+        (
+            (
+                {
+                    "id": 1928374,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "111",
+                        "newArchivedServiceId": "222",
+                    },
+                    "createdAt": "2015-02-03T20:11:12.345Z",
+                    "user": "lynch@example.com",
+                },
+                {
+                    "id": 293847,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "222",
+                        "newArchivedServiceId": "333",
+                    },
+                    "createdAt": "2015-03-22T12:55:12.345Z",
+                    "user": "lynch@example.com",
+                },
+                {
+                    "id": 948576,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "333",
+                        "newArchivedServiceId": "444",
+                    },
+                    "createdAt": "2015-03-22T12:57:12.345Z",
+                    "user": "florrie@example.com",
+                },
+            ),
+            {
+                "111": {
+                    "frameworkSlug": "g-cloud-9",
+                    "lot": "cloud-hosting",
+                    "supplierId": 909090,
+                    "supplierName": "Mr Lambe from London",
+                    "serviceName": "Lamb of London, who takest away the sins of our world.",
+                    "somethingIrrelevant": "Soiled personal linen, wrong side up with care.",
+                },
+            },
+            "published",
+            "3 unacknowledged edits by 2 users between Tuesday 3 February 2015 and Sunday 22 March 2015.",
+            "Changed on Tuesday 3 February 2015 at 20:11",
+        ),
+        (
+            (
+                {
+                    "id": 65432,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "4444",
+                        "newArchivedServiceId": "5555",
+                    },
+                    "createdAt": "2012-06-30T20:01:12.345Z",
+                    "user": "marion@example.com",
+                },
+                {
+                    "id": 76543,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "5555",
+                        "newArchivedServiceId": "6666",
+                    },
+                    "createdAt": "2012-06-30T22:55:12.345Z",
+                    "user": "marion@example.com",
+                },
+            ),
+            {
+                "4444": {
+                    "id": "151",
+                    "frameworkSlug": "g-cloud-9",
+                    "lot": "cloud-hosting",
+                    "supplierId": 909090,
+                    "supplierName": "Barrington's",
+                    "serviceName": "Lemonflavoured soap",
+                },
+            },
+            "enabled",
+            "2 unacknowledged edits by marion@example.com on Saturday 30 June 2012.",
+            "Changed on Saturday 30 June 2012 at 21:01",
+        ),
+        (
+            (
+                {
+                    "id": 556677,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "3535",
+                        "newArchivedServiceId": "6767",
+                    },
+                    "createdAt": "2005-11-12T15:01:12.345Z",
+                    "user": "private.carr@example.com",
+                },
+                {
+                    "id": 668833,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "6767",
+                        "newArchivedServiceId": "7373",
+                    },
+                    "createdAt": "2005-12-10T11:55:12.345Z",
+                    "user": "private.carr@example.com",
+                },
+                {
+                    "id": 449966,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "7373",
+                        "newArchivedServiceId": "4747",
+                    },
+                    "createdAt": "2005-12-11T12:55:12.345Z",
+                    "user": "cissy@example.com",
+                },
+                {
+                    "id": 221188,
+                    "type": "update_service",
+                    "acknowledged": False,
+                    "data": {
+                        "oldArchivedServiceId": "4747",
+                        "newArchivedServiceId": "9292",
+                    },
+                    "createdAt": "2005-12-17T09:22:12.345Z",
+                    "user": "private.carr@example.com",
+                },
+            ),
+            {
+                "3535": {
+                    "id": "151",
+                    "frameworkSlug": "g-cloud-9",
+                    "lot": "cloud-hosting",
+                    "supplierId": 909090,
+                    "supplierName": "Barrington's",
+                    "serviceName": "Lemonflavoured soup",
+                },
+            },
+            "enabled",
+            "4 unacknowledged edits by 2 users between Saturday 12 November 2005 and Saturday 17 December 2005.",
+            "Changed on Saturday 12 November 2005 at 15:01",
+        ),
+        (
+            (),
+            {},
+            "enabled",
+            "0 unacknowledged edits.",
+            None,
+        ),
+    ))
+    @pytest.mark.parametrize("resultant_diff", (False, True))
+    def test_unacknowledged_updates(
             self,
-            archived_service_id_1,
-            archived_service_id_2,
-            data_api_client
-    ):
-        data_api_client.get_archived_service.side_effect = \
-            self._get_archived_service
-        data_api_client.get_service.side_effect = self._get_service
+            data_api_client,
+            html_diff_tables_from_sections_iter,
+            fae_response,
+            avail_arch_svcs,
+            svc_status,
+            exp_summ_text,
+            exp_oldver_ctxt_text,
+            resultant_diff,
+            ):
+        data_api_client.get_service.side_effect = partial(self._mock_get_service_side_effect, svc_status)
+        data_api_client.find_audit_events_iter.side_effect = lambda *a, **ka: iter(fae_response)
+        data_api_client.get_archived_service.side_effect = partial(
+            self._mock_get_archived_service_side_effect,
+            avail_arch_svcs,
+        )
+        data_api_client.get_supplier.side_effect = self._mock_get_supplier_side_effect
+        html_diff_tables_from_sections_iter.side_effect = lambda *a, **ka: iter((
+            ("dummy_section", "dummy_question", Markup("<div class='dummy-diff-table'>dummy</div>")),
+        ) if resultant_diff else ())
 
-        return self.client.get('/admin/services/compare/{}...{}'.format(
-            archived_service_id_1, archived_service_id_2
-        ))
+        response = self.client.get('/admin/services/151/updates')
 
-    def test_cannot_get_nonexistent_archived_service(self):
-
-        # Both archived services don't exist
-        response = self._get_archived_services_response('1', '2')
-        assert response.status_code == 404
-
-        # First archived service doesn't exist
-        response = self._get_archived_services_response('1', '20')
-        assert response.status_code == 404
-
-        # Second archived service doesn't exist
-        response = self._get_archived_services_response('10', '2')
-        assert response.status_code == 404
-
-    def test_cannot_get_same_archived_service(self):
-
-        response = self._get_archived_services_response('10', '10')
-        assert response.status_code == 404
-
-    def test_cannot_get_archived_services_in_non_chronological_order(self):
-
-        response = self._get_archived_services_response('20', '10')
-        assert response.status_code == 404
-
-    def test_cannot_get_archived_services_for_nonexistent_service_ids(self):
-
-        response = self._get_archived_services_response('30', '40')
-        assert response.status_code == 404
-
-    @mock.patch('app.main.views.services.content_loader')
-    def test_can_get_archived_services_with_dates_and_diffs(self, content_loader):
-
-        class TestBuilder(object):
-            @staticmethod
-            def filter(*args):
-                return self._TestContent()
-
-        content_loader.get_manifest.return_value = TestBuilder()
-        response = self._get_archived_services_response('10', '20')
-
-        # check title is there
-        assert self.strip_all_whitespace(
-            '<h1>&lt;h1&gt;Cloudy&lt;/h1&gt; Cloud Service</h1>'
-        ) in self.strip_all_whitespace(response.get_data(as_text=True))
-
-        # check dates are right
-        assert self.strip_all_whitespace(
-            'Monday 1 December 2014 at 10:55'
-        ) in self.strip_all_whitespace(response.get_data(as_text=True))
-
-        assert self.strip_all_whitespace(
-            'Tuesday 2 December 2014 at 10:55'
-        ) in self.strip_all_whitespace(response.get_data(as_text=True))
-
-        # check lines are there
-        assert self.strip_all_whitespace(
-            '<td class=\'line-content unchanged\'>Cloud Service</td>'
-        ) in self.strip_all_whitespace(response.get_data(as_text=True))
-
-        assert self.strip_all_whitespace(
-            '<td class=\'line-content addition\'><strong>&lt;h1&gt;Cloudy&lt;/h1&gt;</strong> Cloud Service</td>'
-        ) in self.strip_all_whitespace(response.get_data(as_text=True))
-
-        # check status is right
-        assert self.strip_all_whitespace(
-            '<input type="radio" name="service_status" id="service_status_published" value="public" checked=' +
-            '"checked" />'
-        ) in self.strip_all_whitespace(response.get_data(as_text=True))
-
-    @mock.patch('app.main.views.services.content_loader')
-    def test_can_get_archived_services_with_differing_keys(self, content_loader):
-
-        class TestBuilder(object):
-            @staticmethod
-            def filter(*args):
-                return self._TestContent()
-
-        content_loader.get_manifest.return_value = TestBuilder()
-        response = self._get_archived_services_response('10', '50')
         assert response.status_code == 200
+        doc = html.fromstring(response.get_data(as_text=True))
+
+        assert data_api_client.find_audit_events_iter.call_args_list == [
+            ((), {
+                "object_id": "151",
+                "object_type": "services",
+                "audit_type": AuditTypes.update_service,
+                "acknowledged": "false",
+                "latest_first": "false",
+            },),
+        ]
+
+        assert doc.xpath("normalize-space(string(//header//*[@class='context']))") == "Barrington's"
+        assert doc.xpath("normalize-space(string(//header//h1))") == "Lemonflavoured soap"
+
+        assert doc.xpath("//p[normalize-space(string())=$expected_text]", expected_text=exp_summ_text)
+
+        assert len(doc.xpath("//*[@class='dummy-diff-table']")) == (1 if fae_response and resultant_diff else 0)
+        assert len(doc.xpath(
+            # an element that has the textual contents $reverted_text but doesn't have any children that have *exactly*
+            # that text (this stops us getting multiple results for a single appearance of the text, because it includes
+            # some of that element's parents - this should therefore select the bottom-most element that completely
+            # contains the target text)
+            "//*[normalize-space(string())=$reverted_text][not(.//*[normalize-space(string())=$reverted_text])]",
+            reverted_text="All changes were reverted.",
+        )) == (1 if fae_response and not resultant_diff else 0)
+        
+
+        if fae_response:
+            assert html_diff_tables_from_sections_iter.call_args_list == [
+                ((), {
+                    "sections": mock.ANY,  # test separately later?
+                    "revision_1": avail_arch_svcs[fae_response[0]["data"]["oldArchivedServiceId"]],
+                    "revision_2": self._mock_get_service_side_effect(svc_status, "151")["services"],
+                    "table_preamble_template": "diff_table/_table_preamble.html",
+                },),
+            ]
+
+            assert doc.xpath(
+                "normalize-space(string(//h3[normalize-space(string())=$oldver_title]/ancestor::" +
+                "*[contains(@class, 'column')]))",
+                oldver_title="Previously acknowledged version",
+            ) == "Previously acknowledged version " + exp_oldver_ctxt_text
+        else:
+            assert not doc.xpath(
+                "//h3[normalize-space(string())=$oldver_title]",
+                oldver_title="Previously acknowledged version",
+            )
+
+        assert doc.xpath(
+            "//*[.//h4[normalize-space(string())=$title]][normalize-space(string())=$full]" +
+            "[.//a[@href=$mailto][normalize-space(string())=$email]]",
+            title="Contact supplier:",
+            full="Contact supplier: sir.jonah.barrington@example.com",
+            mailto="mailto:sir.jonah.barrington@example.com",
+            email="sir.jonah.barrington@example.com",
+        )
+
+        # "status" radios should have the correct current status checked, none others, and also have the correct
+        # associated label text. and of course be in a form pointing at the correct destination.
+        status_forms = doc.xpath("//form[.//button[@type='submit'][normalize-space(string())='Update status']]")
+        assert len(status_forms) == 1
+        assert status_forms[0].method == "POST"
+        assert status_forms[0].action == "/admin/services/status/151"
+        assert sorted(status_forms[0].form_values()) == [
+            ("csrf_token", mock.ANY),
+            ("service_status", self._service_status_labels[svc_status].lower()),
+        ]
+        for radio_elem in status_forms[0].xpath(".//input[@type='radio'][@name='service_status']"):
+            label_elem = radio_elem.label or radio_elem.xpath("ancestor::label")[0]
+            assert label_elem.xpath("normalize-space(string())").lower() == radio_elem.attrib["value"]
+
+        # ensure "published" radio button is not shown if in disabled status
+        assert (svc_status != "disabled") == bool(status_forms[0].xpath(
+            ".//input[@type='radio'][@name='service_status'][@value=$value]",
+            value=self._service_status_labels["published"].lower(),
+        ))

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1028,7 +1028,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             # some of that element's parents - this should therefore select the bottom-most element that completely
             # contains the target text)
             "//*[normalize-space(string())=$reverted_text][not(.//*[normalize-space(string())=$reverted_text])]",
-            reverted_text="All changes were reverted.",
+            reverted_text="All changes were reversed.",
         )) == (1 if fae_response and not resultant_diff else 0)
 
         if fae_response:
@@ -1055,11 +1055,11 @@ class TestServiceUpdates(LoggedInApplicationTest):
                 ("csrf_token", mock.ANY),
             ]
 
-            assert doc.xpath(
+            assert bool(doc.xpath(
                 "normalize-space(string(//h3[normalize-space(string())=$oldver_title]/ancestor::" +
-                "*[contains(@class, 'column')]))",
+                "*[contains(@class, 'column')][1]))",
                 oldver_title="Previously acknowledged version",
-            ) == "Previously acknowledged version " + exp_oldver_ctxt_text
+            ) == "Previously acknowledged version " + exp_oldver_ctxt_text) == bool(resultant_diff)
         else:
             # in this case we want a loose assertion that nothing exists that has anything like any of these properties
             assert not doc.xpath(

--- a/tests/app/test_diff_tool.py
+++ b/tests/app/test_diff_tool.py
@@ -1,112 +1,330 @@
-import unittest
-from app.main.helpers.diff_tools import render_lines
-from flask import Markup
+from collections import OrderedDict
+from itertools import chain
+
+from lxml import html
+import pytest
+from six import next, string_types
+
+from app import content_loader
+from app.main.helpers.diff_tools import html_diff_tables_from_sections_iter
+
+from .helpers import BaseApplicationTest
 
 
-class TestDiffToolsHelpers(unittest.TestCase):
+class TestHtmlDiffTablesFromSections(BaseApplicationTest):
+    _expected_removal_content_column = 1
+    _expected_addition_content_column = 3
 
-    def setup_method(self, method):
-        pass
+    @pytest.mark.parametrize("framework_slug,lot_slug,service_data_a,service_data_b,expected_rem_qs,expected_add_qs", (
+        (
+            # framework_slug
+            "g-cloud-9",
+            # lot_slug
+            "cloud-software",
+            # service_data_a
+            {
+                "serviceName": "Metempsychosis",
+                "serviceDescription": "Only born male transubstantial heir of Rudolf Virag.",
+            },
+            # service_data_b
+            {
+                "serviceName": "Metempsychosis",
+                "serviceDescription": "Only born male transubstantial heir of Rudolf Bloom.",
+            },
+            # expected_rem_qs (question ids expected to create diffs with "added" fragments)
+            ("serviceDescription",),
+            # expected_rem_qs (question ids expected to create diffs with "removed" fragments)
+            ("serviceDescription",),
+        ),
+        (
+            "g-cloud-9",
+            "cloud-support",
+            {
+                "serviceName": "Ellen Higgins, second daughter of Julius Karoly",
+                "serviceDescription": "Fanny Hegarty\nRichard Goulding\nChristina Grier\n",
+            },
+            {
+                "serviceName": "Ellen Higgins, second daughter of Julius Higgins",
+                "serviceDescription": "Fanny Higgins\n\nSimon Dedalus of Cork\nRichard Goulding\nChristina Grier\n",
+            },
+            ("serviceName", "serviceDescription",),
+            ("serviceName", "serviceDescription",),
+        ),
+        (
+            "g-cloud-8",
+            "iaas",
+            {
+                "serviceName": u"GENTLEMEN\u2751OF\u2751THE\u2751PRESS",
+                "serviceSummary": "Grossbooted draymen rolled barrels dullthudding out of Prince's\n" +
+                                  "stores and bumped them up on the brewery float. On the brewery float bumped\n" +
+                                  "dullthudding barrels rolled by grossbooted draymen out of Prince's stores.",
+            },
+            {
+                "serviceName": u"GENTLEMEN \u2751 OF \u2751 THE \u2751 PRESS",
+                "serviceSummary": "Grossbooted draymen rolled barrels dullthudding out of Prince's\n" +
+                                  "stores and bumped them up on the brewery float. On the brewery float bumped\n" +
+                                  "dullthudding barrels rolled by grossbooted draymen out of Prince's stores.",
+            },
+            (),
+            ("serviceName",),
+        ),
+        (
+            "g-cloud-9",
+            "cloud-hosting",
+            {
+                "serviceName": "Infinitely preceding deletion",
+                "serviceDescription": "To reflect that each <del> who enters imagines himself to be the first to\n" +
+                                      "</del> whereas he <ins> always the last term of a preceding series",
+                "serviceFeaturesHostingAndSoftware": [
+                    "Burke",
+                    "Joseph Cuffe",
+                    "Wisdom Hely",
+                    "Alderman John Hooper",
+                    "Dr Francis Brady",
+                ],
+                "somethingIrrelevant": "decomposed vegetable missiles",
+            },
+            {
+                "serviceName": "Infinitely preceding deletion",
+                "serviceDescription": "He is neither first <ins> nor </ins> <del> nor only nor alone in a series\n" +
+                                      "originating in & repeated to </del>.",
+                "serviceFeaturesHostingAndSoftware": [
+                    "Burke",
+                    "Joseph Cuffe",
+                    "Wisdom Hely",
+                    "Alderman John Hooper",
+                    "Dr. Francis Brady",
+                    "Father Sebastian of Mount Argus",
+                    "A bootblack at the General Post Office",
+                ],
+            },
+            ("serviceDescription",),
+            ("serviceDescription", "serviceFeaturesHostingAndSoftware",),
+        ),
+        (
+            "g-cloud-9",
+            "cloud-support",
+            {
+                "serviceName": "An unsatisfactory equation",
+                "serviceDescription": "An exodus and return\n in time\n  through reversible space",
+                "serviceBenefitsSupport": [
+                    "The lateness of the hour,    rendering procrastinatory   ",
+                    "The obscurity of the night, rendering invisible",
+                    "The uncertainty of thoroughfares, rendering perilous",
+                    "The necessity for repose, obviating movement",
+                    "The proximity of an occupied bed, obviating research",
+                    "The anticipation of warmth (human) tempered with coolness (linen)",
+                    "The statue of Narcissus, sound without echo, desired desire",
+                ],
+            },
+            {
+                "serviceName": "An unsatisfactory equation",
+                "serviceDescription": "\nAn exodus and return\n in space\n through irreversible time",
+                "serviceBenefitsSupport": [
+                    "The anticipation of warmth (human) tempered with coolness (linen)",
+                    "The lateness of the hour,    rendering procrastinatory   ",
+                    "The necessity for repose, obviating movement",
+                    "The obscurity of the night, rendering invisible",
+                    "The proximity of an occupied bed, obviating research",
+                    "The statue of Narcissus, sound without echo, desired desire",
+                    "The uncertainty of thoroughfares, rendering perilous",
+                ],
+                "serviceFeaturesSupport": [
+                    "The removal of nocturnal solitude",
+                ],
+            },
+            ("serviceDescription", "serviceBenefitsSupport",),
+            ("serviceDescription", "serviceBenefitsSupport", "serviceFeaturesSupport",),
+        ),
+    ))
+    @pytest.mark.parametrize("table_preamble_template", (None, "diff_table/_table_preamble.html",))
+    def test_common_properties(
+        self,
+        framework_slug,
+        lot_slug,
+        service_data_a,
+        service_data_b,
+        expected_rem_qs,
+        expected_add_qs,
+        table_preamble_template,
+    ):
+        # because there is no single canonical "correct" representation of a diff between two documents, we can't just
+        # test the output verbatim as it would be a fragile test. instead we can test for a bunch of properties that
+        # must always be true of an output we would consider valid
 
-    def teardown_method(self, method):
-        pass
+        service_data_a, service_data_b = (dict(s, lot=lot_slug) for s in (service_data_a, service_data_b,))
+        content_sections = content_loader.get_manifest(
+            framework_slug,
+            'edit_service_as_admin',
+        ).filter(service_data_b).sections
 
-    def _get_original_line_from_revision(self, words):
+        with self.app.app_context():
+            diffs = OrderedDict((q_id, html_diff) for sec_slug, q_id, html_diff in html_diff_tables_from_sections_iter(
+                content_sections,
+                service_data_a,
+                service_data_b,
+                table_preamble_template=table_preamble_template,
+            ))
 
-        return " ".join([word[2:] for word in words])
+        for question_id, html_diff in diffs.items():
+            table_element = html.fragment_fromstring(html_diff)
 
-    def _check_correct_number_of_lines_in_revisions(
-            self, lines, expected_number_of_lines):
-        for key in lines.keys():
-            assert len(lines[key]) == expected_number_of_lines
+            # these should all have been removed
+            assert not table_element.xpath(".//a")
+            assert not table_element.xpath(".//colgroup")
+            assert not table_element.xpath(".//*[@id]")
 
-    def test_correct_number_of_lines(self):
-        revision_1 = """line one""".splitlines()
-        revision_2 = """line one\nline two\nline three""".splitlines()
+            # there should be a non-empty caption tag if and only if table_preamble_template is supplied
+            if table_preamble_template is None:
+                assert not table_element.xpath(".//caption")
+            else:
+                assert table_element.xpath("./caption[normalize-space(string())]")
 
-        self._check_correct_number_of_lines_in_revisions(
-            render_lines(
-                revision_1,
-                revision_2,
-                include_unchanged_lines_in_output=True),
-            3
-        )
+            # all td.line-content.removal elements should appear in the same (expected) column
+            for tr in table_element.xpath(
+                "./tbody/tr[./td[contains(@class, 'line-content')][contains(@class, 'removal')]]"
+            ):
+                assert len(tr.xpath("./td[contains(@class, 'line-content')][contains(@class, 'removal')]")) == 1
+                assert len(tr.xpath(
+                    "./td[contains(@class, 'line-content')][contains(@class, 'removal')]/preceding-sibling::*"
+                )) == self._expected_removal_content_column
+            # all td.line-content.addition elements should appear in the same (expected) column
+            for tr in table_element.xpath(
+                "./tbody/tr[./td[contains(@class, 'line-content')][contains(@class, 'addition')]]"
+            ):
+                assert len(tr.xpath("./td[contains(@class, 'line-content')][contains(@class, 'addition')]")) == 1
+                assert len(tr.xpath(
+                    "./td[contains(@class, 'line-content')][contains(@class, 'addition')]/preceding-sibling::*"
+                )) == self._expected_addition_content_column
 
-        # first line is ignored because it is unchanged
-        self._check_correct_number_of_lines_in_revisions(
-            render_lines(
-                revision_1,
-                revision_2,
-                include_unchanged_lines_in_output=False),
-            2
-        )
+            # the only del elements should appear in td.line-content.removal elements
+            assert len(table_element.xpath(".//del")) == len(
+                table_element.xpath(
+                    "./tbody/tr/td[contains(@class, 'line-content')][contains(@class, 'removal')]/del"
+                )
+            )
+            # and there shouldn't be any td.line-content.removal elements that don't have at least one del element
+            assert not table_element.xpath(
+                ".//td[contains(@class, 'line-content')][contains(@class, 'removal')][not(.//del)]"
+            )
 
-        revision_1 = """line one\nline two\n\nline_four\nline five""".splitlines()  # noqa
-        revision_2 = """line one\nline two\nline three""".splitlines()
+            # the only ins elements should appear in td.line-content.addition elements
+            assert len(table_element.xpath(".//ins")) == len(
+                table_element.xpath(
+                    "./tbody/tr/td[contains(@class, 'line-content')][contains(@class, 'addition')]/ins"
+                )
+            )
+            # and there shouldn't be any td.line-content.addition elements that don't have at least one ins element
+            assert not table_element.xpath(
+                ".//td[contains(@class, 'line-content')][contains(@class, 'addition')][not(.//ins)]"
+            )
 
-        # all lines should be accounted for
-        self._check_correct_number_of_lines_in_revisions(
-            render_lines(
-                revision_1,
-                revision_2,
-                include_unchanged_lines_in_output=True),
-            5
-        )
+            # content should have been purged of all nbsps
+            assert not table_element.xpath(
+                ".//td[contains(@class, 'line-content')][contains(string(), $nbsp)]",
+                nbsp=u"\u00a0",
+            )
 
-        # first and second lines are ignored because they are unchanged
-        self._check_correct_number_of_lines_in_revisions(
-            render_lines(
-                revision_1,
-                revision_2,
-                include_unchanged_lines_in_output=False),
-            3
-        )
+            # yes, this is awfully familiar code from the innards of html_diff_tables_from_sections_iter so there's a
+            # degree to which we're marking our own homework with this, but it's a little difficult to see an
+            # alternative
+            expected_content_a, expected_content_b = (
+                [
+                    (line or " ")  # diff outputs an extraneous space in blank line cases, which is ok by us
+                    for line in (q.splitlines() if isinstance(q, string_types) else q)
+                ]
+                for q in (r.get(question_id, []) for r in (service_data_a, service_data_b,))
+            )
+            # assert some things about the content in each line-content column
+            for expected_content, expected_content_column in (
+                (expected_content_a, self._expected_removal_content_column,),
+                (expected_content_b, self._expected_addition_content_column,),
+            ):
+                # the collapsed string content of the collection of tds from the expected column which have a non-empty
+                # line-number td directly preceding them should equal the expected content. note here we're not giving
+                # any leeway for extra whitespace because the intention is to be able to display this with whitespace-
+                # preserving css. but that could always be relaxed if totally necessary. also note if there were nbsps
+                # in our data this would not work because they are purged unconditionally.
+                assert [
+                    elem.xpath("string()")
+                    for elem in table_element.xpath(
+                        "./tbody/tr/td[$i][contains(@class, 'line-content')]" +
+                        "[normalize-space(string(./preceding-sibling::td[1][contains(@class, 'line-number')]))]",
+                        # xpath's element indexing is 1-based
+                        i=expected_content_column+1,
+                    )
+                ] == expected_content
 
-    def test_rendered_lines_work_for_added_line(self):
-        revision_1 = """line one""".splitlines()
-        revision_2 = """line one\nline two""".splitlines()
-        rendered_lines = render_lines(revision_1, revision_2)
+            # assert some things about each row
+            for tr in table_element.xpath("./tbody/tr"):
+                # note here how xpath's element indexing is 1-based
+                content_rem = tr.xpath("string(./td[$i])", i=self._expected_removal_content_column+1)
+                content_add = tr.xpath("string(./td[$i])", i=self._expected_addition_content_column+1)
 
-        assert rendered_lines['revision_1'][0] == Markup(
-            u"<td class='line-number line-number-empty'>2</td>"
-            u"<td class='line-content empty'></td>"
-        )
-        assert rendered_lines['revision_2'][0] == Markup(
-            u"<td class='line-number line-number-addition'>2</td>"
-            u"<td class='line-content addition'>"
-            u"<strong>line two</strong>"
-            u"</td>"
-        )
+                # all rows should have content on at least one side
+                assert content_add or content_rem
 
-    def test_rendered_lines_work_for_removed_line(self):
-        revision_1 = """line one\nline two""".splitlines()
-        revision_2 = """line one""".splitlines()
-        rendered_lines = render_lines(revision_1, revision_2)
+                # if no content on one side, all content on other side should be in a del/ins
+                if not content_rem:
+                    assert content_add == tr.xpath(
+                        "string(./td[contains(@class, 'line-content')][contains(@class, 'addition')]/ins)"
+                    )
+                if not content_add:
+                    assert content_rem == tr.xpath(
+                        "string(./td[contains(@class, 'line-content')][contains(@class, 'removal')]/del)"
+                    )
 
-        assert rendered_lines['revision_1'][0] == Markup(
-            u"<td class='line-number line-number-removal'>2</td>"
-            u"<td class='line-content removal'>"
-            u"<strong>line two</strong>"
-            u"</td>"
-        )
-        assert rendered_lines['revision_2'][0] == Markup(
-            u"<td class='line-number line-number-empty'>2</td>"
-            u"<td class='line-content empty'></td>"
-        )
+                # line number should be on a side if and only if there is content on that side
+                assert bool(tr.xpath(
+                    "string(./td[contains(@class, 'line-content')][contains(@class, 'removal')])"
+                )) == bool(tr.xpath(
+                    "normalize-space(string(./td[contains(@class, 'line-number')]" +
+                    "[contains(@class, 'line-number-removal')]))"
+                ))
+                assert bool(tr.xpath(
+                    "string(./td[contains(@class, 'line-content')][contains(@class, 'addition')])"
+                )) == bool(tr.xpath(
+                    "normalize-space(string(./td[contains(@class, 'line-number')]" +
+                    "[contains(@class, 'line-number-add')]))"
+                ))
 
-    def test_rendered_lines_work_for_edited_line(self):
-        revision_1 = """line number one has changed""".splitlines()
-        revision_2 = """line one has actually changed""".splitlines()
-        rendered_lines = render_lines(revision_1, revision_2)
-        assert rendered_lines['revision_1'][0] == Markup(
-            u"<td class='line-number line-number-removal'>1</td>"
-            u"<td class='line-content removal'>"
-            u"line <strong>number</strong> one has changed"
-            u"</td>"
-        )
-        assert rendered_lines['revision_2'][0] == Markup(
-            u"<td class='line-number line-number-addition'>1</td>"
-            u"<td class='line-content addition'>"
-            u"line one has <strong>actually</strong> changed"
-            u"</td>"
-        )
+        for question in chain.from_iterable(section.questions for section in content_sections):
+            # check a question we expect to have removals does and ones we expect not to ...doesn't.
+            assert bool((question_id in diffs) and html.fragment_fromstring(diffs[question_id]).xpath(
+                "./tbody/tr/td[contains(@class, 'line-content')][contains(@class, 'removal')]"
+            )) == (question_id in expected_rem_qs)
+            # check a question we expect to have additions does and ones we expect not to ...doesn't.
+            assert bool((question_id in diffs) and html.fragment_fromstring(diffs[question_id]).xpath(
+                "./tbody/tr/td[contains(@class, 'line-content')][contains(@class, 'addition')]"
+            )) == (question_id in expected_add_qs)
+            # check a question we expect to have neither additions or removals to not be present in diffs at all
+            assert (question_id in diffs) == (question_id in expected_rem_qs or question_id in expected_add_qs)
+
+    def test_identical_data(self):
+        # these two should be identical in as far as the data we're concerned about
+        service_data_a = {
+            "lot": "cloud-support",
+            "serviceName": "On the range",
+            "serviceFeaturesSupport": [
+                "A blue enamelled saucepan",
+                "A black iron kettle",
+            ],
+            "irrelevantThing": "Five coiled spring housebells",
+        }
+        service_data_b = {
+            "lot": "cloud-support",
+            "serviceName": "On the range",
+            "serviceFeaturesSupport": [
+                "A blue enamelled saucepan",
+                "A black iron kettle",
+            ],
+            "irrelevantThing": "Six coiled spring housebells",
+            "anotherIrrelevancy": "A curvilinear rope",
+        }
+
+        content_sections = content_loader.get_manifest(
+            "g-cloud-9",
+            'edit_service_as_admin',
+        ).filter(service_data_b).sections
+
+        assert not tuple(html_diff_tables_from_sections_iter(content_sections, service_data_a, service_data_b))

--- a/tests/app/test_diff_tool.py
+++ b/tests/app/test_diff_tool.py
@@ -292,10 +292,18 @@ class TestHtmlDiffTablesFromSections(BaseApplicationTest):
                         "normalize-space(string(./td[contains(@class, 'line-number')]" +
                         "[contains(@class, 'line-number-add')]))"
                     ))
+
+                    # line-content tds which are empty should have line-non-existent class
+                    assert all(
+                        bool("line-non-existent" in td.attrib.get("class", "")) == (not td.xpath("string()"))
+                        for td in tr.xpath("./td[contains(@class, 'line-content')]")
+                    )
                 else:  # but if there aren't any additions/removals...
                     # the content should be equal on both sides
                     assert content_remside == content_addside
 
+                    # there shouldn't be any line-non-existent tds
+                    assert not tr.xpath("./td[contains(@class, 'line-non-existent')]")
 
         for question in chain.from_iterable(section.questions for section in content_sections):
             # check a question we expect to have removals does and ones we expect not to ...doesn't.


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/138031851

In action:
![20170601_service_updates](https://cloud.githubusercontent.com/assets/807447/26685494/359ea6b4-46e2-11e7-82cb-f191a48a071c.png)
![20170601_service_updates_reversed](https://cloud.githubusercontent.com/assets/807447/26685594/78a86b5c-46e2-11e7-8cc5-dc6b5531fb0c.png)

This should probably be rebased after https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/269 is merged and modified to accommodate its changes. (The tests will fail until we've done this patchup because of tests of old views trying to link to the old comparison view)