### PR TITLE
Dockerfile: bump base image to 1.0.5 for libxml2-dev and libxslt-dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:1.0.3
+FROM digitalmarketplace/base-frontend:1.0.5


### PR DESCRIPTION
This will allow us to deploy service update acknowledgement to paas without issues.