### PR TITLE
Upgrade to Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
+  - "3.6"
 before_install:
   - nvm install 4.2
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:1.0.5
+FROM digitalmarketplace/base-frontend:2.0.2

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ run-app: show-environment virtualenv
 
 .PHONY: virtualenv
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
 
 .PHONY: upgrade-pip
 upgrade-pip: virtualenv


### PR DESCRIPTION
The version 2.X.X series of the docker base image is built with python3.

We drop travis tests for Python 2 and upgrade to Python 3.6 as that's
the version of Python we're using.

We also create virtualenvs with python 3.