### PR TITLE
Ensure existing behaviour for new 'awarded' brief status

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -14,6 +14,8 @@ from .. import main
 from ... import data_api_client
 from ..auth import role_required
 
+CLOSED_BRIEF_STATUSES = ['closed', 'awarded']
+
 
 @main.route('/users', methods=['GET'])
 @login_required
@@ -132,7 +134,9 @@ def download_buyers_and_briefs():
         (
             "applicationsClosedAtDateIfClosed",
             lambda brief:
-                (brief.get("applicationsClosedAt", "") if brief.get("status") == "closed" else "").partition("T")[0],
+                (
+                    brief.get("applicationsClosedAt", "") if brief.get("status") in CLOSED_BRIEF_STATUSES else ""
+                ).partition("T")[0],
         ),
     ))
 


### PR DESCRIPTION
As part of this trello story - https://trello.com/c/kGVfzXuH/749-3-collect-award-status-on-buyer-dashboard - we are adding a new 'awarded' status for a brief.

This PR ensures the admin app retains all existing functionality when this new status lands.