### PR TITLE
Backwards compatibility for new Brief statuses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 from dmcontent.errors import ContentNotFoundError
 from flask import Flask, request, redirect

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,13 +1,10 @@
 from flask import abort, current_app, flash, redirect, render_template, request, url_for
 from flask_login import current_user
 from collections import OrderedDict
-from datetime import datetime
 from itertools import chain, dropwhile, islice
-from six import next
 
 from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
-from dmutils.formats import DATETIME_FORMAT
 from dmcontent.formats import format_service_price
 from dmutils.documents import upload_service_documents
 from dmutils import s3  # this style of import so we only have to mock once

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -14,7 +14,7 @@ from .. import main
 from ... import data_api_client
 from ..auth import role_required
 
-CLOSED_BRIEF_STATUSES = ['closed', 'awarded']
+CLOSED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 
 
 @main.route('/users', methods=['GET'])

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -8,7 +8,6 @@ from flask_login import flash
 from datetime import datetime
 from dmutils import csv_generator
 from six import itervalues, iterkeys
-from unicodecsv import DictWriter
 
 from .. import main
 from ... import data_api_client

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -203,6 +203,12 @@ class TestListAgreements(LoggedInApplicationTest):
 
         assert response.status_code == 403
 
+    def test_invalid_status_raises_400(self, data_api_client):
+
+        response = self.client.get('/admin/agreements/g-cloud-7?status=bad')
+
+        assert response.status_code == 400
+
 
 @mock.patch('app.main.views.agreements.data_api_client')
 class TestNextAgreementRedirect(LoggedInApplicationTest):
@@ -337,3 +343,7 @@ class TestNextAgreementRedirect(LoggedInApplicationTest):
             (ca_kwargs.get("with_declarations") is False and not ca_kwargs.get("status"))
             for ca_args, ca_kwargs in data_api_client.find_framework_suppliers.call_args_list
         )
+
+    def test_invalid_status_raises_400(self, data_api_client):
+        response = self.client.get('/admin/suppliers/151/agreements/g-cloud-8/next?status=bad')
+        assert response.status_code == 400

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -23,6 +23,18 @@ class TestStats(LoggedInApplicationTest):
 
         assert response.status_code == 200
 
+    def test_get_stats_page_for_open_framework_includes_framework_stats(self, data_api_client):
+        data_api_client.find_audit_events.return_value = {
+            'auditEvents': []
+        }
+        data_api_client.get_framework.return_value = {
+            'frameworks': {'status': 'open', 'lots': []}
+        }
+        response = self.client.get('/admin/statistics/g-cloud-7')
+
+        assert data_api_client.get_framework_stats.call_args == mock.call('g-cloud-7')
+        assert response.status_code == 200
+
     def test_supplier_counts_on_stats_page(self, data_api_client):
         data_api_client.find_audit_events.return_value = {
             "auditEvents": [

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -14,7 +14,7 @@ class TestStats(LoggedInApplicationTest):
         }
         response = self.client.get('/admin/statistics/g-cloud-7')
 
-        data_api_client.find_audit_events.assert_called_with(
+        data_api_client.find_audit_events.assert_called_once_with(
             audit_type=AuditTypes.snapshot_framework_stats,
             object_type='frameworks',
             object_id='g-cloud-7',
@@ -32,7 +32,7 @@ class TestStats(LoggedInApplicationTest):
         }
         response = self.client.get('/admin/statistics/g-cloud-7')
 
-        assert data_api_client.get_framework_stats.call_args == mock.call('g-cloud-7')
+        data_api_client.get_framework_stats.assert_called_once_with('g-cloud-7')
         assert response.status_code == 200
 
     def test_supplier_counts_on_stats_page(self, data_api_client):
@@ -83,7 +83,7 @@ class TestStats(LoggedInApplicationTest):
 
         response = self.client.get('/admin/statistics/g-cloud-7')
 
-        data_api_client.find_audit_events.assert_called_with(
+        data_api_client.find_audit_events.assert_called_once_with(
             audit_type=AuditTypes.snapshot_framework_stats,
             object_type='frameworks',
             object_id='g-cloud-7',

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -174,6 +174,21 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
     @mock.patch('app.main.views.suppliers.data_api_client')
+    def test_should_call_api_to_activate_user_and_redirect_to_source_if_present(self, data_api_client):
+        data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
+        data_api_client.update_user.return_value = self.load_example_listing("user_response")
+
+        response = self.client.post(
+            '/admin/suppliers/users/999/activate',
+            data={'source': "http://example.com"}
+        )
+
+        data_api_client.update_user.assert_called_with(999, active=True, updater="test@example.com")
+
+        assert response.status_code == 302
+        assert response.location == "http://example.com"
+
+    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_deactivate_user(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
@@ -187,6 +202,21 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
+
+    @mock.patch('app.main.views.suppliers.data_api_client')
+    def test_should_call_api_to_deactivate_user_and_redirect_to_source_if_present(self, data_api_client):
+        data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
+        data_api_client.update_user.return_value = self.load_example_listing("user_response")
+
+        response = self.client.post(
+            '/admin/suppliers/users/999/deactivate',
+            data={'supplier_id': 1000, 'source': "http://example.com"}
+        )
+
+        data_api_client.update_user.assert_called_with(999, active=False, updater="test@example.com")
+
+        assert response.status_code == 302
+        assert response.location == "http://example.com"
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_move_user_to_another_supplier(self, data_api_client):
@@ -216,7 +246,7 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert response.status_code == 404
 
     def test_should_404_if_no_supplier_id_on_services(self):
-        response = self.client.get('/admin/suppliers/users')
+        response = self.client.get('/admin/suppliers/services')
         assert response.status_code == 404
 
     @mock.patch('app.main.views.suppliers.data_api_client')
@@ -742,6 +772,13 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
 
         assert response.status_code == 403
 
+    def test_should_404_if_no_supplier_framework_declaration(self, s3, data_api_client):
+        data_api_client.get_supplier_framework_info.return_value = {
+            'frameworkInterest': {'declaration': None}
+        }
+        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
+        assert response.status_code == 404
+
     def test_should_404_if_document_does_not_exist(self, s3, data_api_client):
         data_api_client.get_supplier_framework_info.return_value = {
             'frameworkInterest': {'declaration': {'SQ1-1a': 'Supplier name'}}
@@ -1102,6 +1139,37 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
         data_api_client.get_framework.assert_called_with('g-cloud-8')
         data_api_client.get_supplier_framework_info.assert_called_with('1234', 'g-cloud-8')
 
+    def test_should_404_if_agreement_has_no_version(self, s3, data_api_client):
+        data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
+        data_api_client.get_framework.return_value = {'frameworks': {}}
+        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
+
+        assert response.status_code == 404
+        data_api_client.get_supplier.assert_called_with('1234')
+        data_api_client.get_framework.assert_called_with('g-cloud-8')
+
+    def _find_services_iter_side_effect(self, *args, **kwargs):
+        assert int(kwargs["supplier_id"]) == 1234
+        assert kwargs["framework"] == "g-cloud-8"
+        # very minimal fake services
+        return iter((
+            {
+                "id": 1111,
+                "lotSlug": "dried-fruit",
+                "lotName": "Raisins & dates",
+            },
+            {
+                "id": 2222,
+                "lotSlug": "salad",
+                "lotName": "Lettuce & cucumber",
+            },
+            {
+                "id": 3333,
+                "lotSlug": "dried-fruit",
+                "lotName": "Raisins & dates",
+            },
+        ))
+
     def test_should_show_agreement_details_on_page(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
@@ -1109,28 +1177,7 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
             'supplier_framework_response'
         )
 
-        def find_services_iter_side_effect(*args, **kwargs):
-            assert int(kwargs["supplier_id"]) == 1234
-            assert kwargs["framework"] == "g-cloud-8"
-            # very minimal fake services
-            return iter((
-                {
-                    "id": 1111,
-                    "lotSlug": "dried-fruit",
-                    "lotName": "Raisins & dates",
-                },
-                {
-                    "id": 2222,
-                    "lotSlug": "salad",
-                    "lotName": "Lettuce & cucumber",
-                },
-                {
-                    "id": 3333,
-                    "lotSlug": "dried-fruit",
-                    "lotName": "Raisins & dates",
-                },
-            ))
-        data_api_client.find_services_iter.side_effect = find_services_iter_side_effect
+        data_api_client.find_services_iter.side_effect = self._find_services_iter_side_effect
 
         with mock.patch('app.main.views.suppliers.get_signed_url') as mock_get_url:
             mock_get_url.return_value = "http://example.com/document/1234.pdf"
@@ -1153,6 +1200,17 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
             # Uploader details
             assert len(document.xpath('//p[contains(text(), "Uploader Name")]')) == 1
             assert len(document.xpath('//span[contains(text(), "uploader@email.com")]')) == 1
+
+    def test_should_404_if_no_signed_url(self, s3, data_api_client):
+        data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
+        data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
+        data_api_client.get_supplier_framework_info.return_value = self.load_example_listing(
+            'supplier_framework_response'
+        )
+        with mock.patch('app.main.views.suppliers.get_signed_url') as mock_get_url:
+            mock_get_url.return_value = None
+            response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
+            assert response.status_code == 404
 
     def test_should_embed_for_pdf_file(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -77,8 +77,8 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         assert response.status_code == 200
 
-        data_api_client.get_supplier.assert_called_with('1000')
-        data_api_client.find_users.assert_called_with('1000')
+        data_api_client.get_supplier.assert_called_once_with('1000')
+        data_api_client.find_users.assert_called_once_with('1000')
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_have_supplier_name_on_page(self, data_api_client):
@@ -156,7 +156,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.post('/admin/suppliers/users/999/unlock')
 
-        data_api_client.update_user.assert_called_with(999, locked=False, updater="test@example.com")
+        data_api_client.update_user.assert_called_once_with(999, locked=False, updater="test@example.com")
 
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
@@ -168,7 +168,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         response = self.client.post('/admin/suppliers/users/999/activate')
 
-        data_api_client.update_user.assert_called_with(999, active=True, updater="test@example.com")
+        data_api_client.update_user.assert_called_once_with(999, active=True, updater="test@example.com")
 
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
@@ -183,7 +183,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             data={'source': "http://example.com"}
         )
 
-        data_api_client.update_user.assert_called_with(999, active=True, updater="test@example.com")
+        data_api_client.update_user.assert_called_once_with(999, active=True, updater="test@example.com")
 
         assert response.status_code == 302
         assert response.location == "http://example.com"
@@ -198,7 +198,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             data={'supplier_id': 1000}
         )
 
-        data_api_client.update_user.assert_called_with(999, active=False, updater="test@example.com")
+        data_api_client.update_user.assert_called_once_with(999, active=False, updater="test@example.com")
 
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
@@ -213,7 +213,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             data={'supplier_id': 1000, 'source': "http://example.com"}
         )
 
-        data_api_client.update_user.assert_called_with(999, active=False, updater="test@example.com")
+        data_api_client.update_user.assert_called_once_with(999, active=False, updater="test@example.com")
 
         assert response.status_code == 302
         assert response.location == "http://example.com"
@@ -229,7 +229,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
             data={'user_to_move_email_address': 'test.user@sme.com'}
         )
 
-        data_api_client.update_user.assert_called_with(
+        data_api_client.update_user.assert_called_once_with(
             999, role='supplier', supplier_id=1000, active=True, updater="test@example.com"
         )
 
@@ -256,8 +256,8 @@ class TestSupplierServicesView(LoggedInApplicationTest):
 
         assert response.status_code == 200
 
-        data_api_client.get_supplier.assert_called_with('1000')
-        data_api_client.find_services.assert_called_with('1000')
+        data_api_client.get_supplier.assert_called_once_with('1000')
+        data_api_client.find_services.assert_called_once_with('1000')
 
     @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_indicate_if_supplier_has_no_services(self, data_api_client):
@@ -377,7 +377,7 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             follow_redirects=True
         )
 
-        data_api_client.get_supplier.assert_called_with(1234)
+        data_api_client.get_supplier.assert_called_once_with(1234)
         assert data_api_client.find_users.called is False
         assert response.status_code == 404
 
@@ -392,8 +392,8 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
             follow_redirects=True
         )
 
-        data_api_client.get_supplier.assert_called_with(1234)
-        data_api_client.find_users.assert_called_with(1234)
+        data_api_client.get_supplier.assert_called_once_with(1234)
+        data_api_client.find_users.assert_called_once_with(1234)
         assert response.status_code == 404
 
     @mock.patch('app.main.views.suppliers.generate_token')
@@ -605,7 +605,7 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
 
         assert response.status_code == 404
-        data_api_client.get_supplier.assert_called_with('1234')
+        data_api_client.get_supplier.assert_called_once_with('1234')
         assert data_api_client.get_framework.called is False
 
     def test_should_404_if_framework_does_not_exist(self, data_api_client):
@@ -626,9 +626,9 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
 
         assert response.status_code == 200
-        data_api_client.get_supplier.assert_called_with('1234')
-        data_api_client.get_framework.assert_called_with('g-cloud-7')
-        data_api_client.get_supplier_declaration.assert_called_with('1234', 'g-cloud-7')
+        data_api_client.get_supplier.assert_called_once_with('1234')
+        data_api_client.get_framework.assert_called_once_with('g-cloud-7')
+        data_api_client.get_supplier_declaration.assert_called_once_with('1234', 'g-cloud-7')
 
     def test_should_show_declaration(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -681,7 +681,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
         assert response.status_code == 404
-        data_api_client.get_supplier.assert_called_with('1234')
+        data_api_client.get_supplier.assert_called_once_with('1234')
         assert data_api_client.get_framework.called is False
 
     def test_should_404_if_framework_does_not_exist(self, data_api_client):
@@ -691,8 +691,8 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
         assert response.status_code == 404
-        data_api_client.get_supplier.assert_called_with('1234')
-        data_api_client.get_framework.assert_called_with('g-cloud-7')
+        data_api_client.get_supplier.assert_called_once_with('1234')
+        data_api_client.get_framework.assert_called_once_with('g-cloud-7')
 
     def test_should_404_if_section_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -711,9 +711,9 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials')
 
         assert response.status_code == 200
-        data_api_client.get_supplier.assert_called_with('1234')
-        data_api_client.get_framework.assert_called_with('g-cloud-7')
-        data_api_client.get_supplier_declaration.assert_called_with('1234', 'g-cloud-7')
+        data_api_client.get_supplier.assert_called_once_with('1234')
+        data_api_client.get_framework.assert_called_once_with('g-cloud-7')
+        data_api_client.get_supplier_declaration.assert_called_once_with('1234', 'g-cloud-7')
 
     def test_should_prefill_form_with_declaration(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -741,7 +741,7 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         declaration['SQ1-3'] = None
         declaration['SQC3'] = None
 
-        data_api_client.set_supplier_declaration.assert_called_with(
+        data_api_client.set_supplier_declaration.assert_called_once_with(
             '1234', 'g-cloud-7', declaration, 'test@example.com')
 
 
@@ -787,7 +787,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 
-        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-foo.pdf')
+        s3.S3.return_value.get_signed_url.assert_called_once_with('g-cloud-7/agreements/1234/1234-foo.pdf')
         assert response.status_code == 404
 
     def test_should_redirect(self, s3, data_api_client):
@@ -800,7 +800,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-7/foo.pdf')
 
-        s3.S3.return_value.get_signed_url.assert_called_with('g-cloud-7/agreements/1234/1234-foo.pdf')
+        s3.S3.return_value.get_signed_url.assert_called_once_with('g-cloud-7/agreements/1234/1234-foo.pdf')
         assert response.status_code == 302
         assert response.location == 'https://example/blah?extra'
 
@@ -815,7 +815,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
             '/admin/suppliers/1234/agreements/g-cloud-7/countersigned-framework-agreement.pdf'
         )
 
-        s3.S3.return_value.get_signed_url.assert_called_with(
+        s3.S3.return_value.get_signed_url.assert_called_once_with(
             'g-cloud-7/agreements/1234/1234-countersigned-framework-agreement.pdf'
         )
         assert response.status_code == 302
@@ -1123,8 +1123,8 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
 
         assert response.status_code == 404
-        data_api_client.get_supplier.assert_called_with('1234')
-        data_api_client.get_framework.assert_called_with('g-cloud-8')
+        data_api_client.get_supplier.assert_called_once_with('1234')
+        data_api_client.get_framework.assert_called_once_with('g-cloud-8')
 
     def test_should_404_if_agreement_not_returned(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -1135,9 +1135,9 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
 
         assert response.status_code == 404
-        data_api_client.get_supplier.assert_called_with('1234')
-        data_api_client.get_framework.assert_called_with('g-cloud-8')
-        data_api_client.get_supplier_framework_info.assert_called_with('1234', 'g-cloud-8')
+        data_api_client.get_supplier.assert_called_once_with('1234')
+        data_api_client.get_framework.assert_called_once_with('g-cloud-8')
+        data_api_client.get_supplier_framework_info.assert_called_once_with('1234', 'g-cloud-8')
 
     def test_should_404_if_agreement_has_no_version(self, s3, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
@@ -1145,14 +1145,17 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
 
         assert response.status_code == 404
-        data_api_client.get_supplier.assert_called_with('1234')
-        data_api_client.get_framework.assert_called_with('g-cloud-8')
+        data_api_client.get_supplier.assert_called_once_with('1234')
+        data_api_client.get_framework.assert_called_once_with('g-cloud-8')
 
-    def _find_services_iter_side_effect(self, *args, **kwargs):
-        assert int(kwargs["supplier_id"]) == 1234
-        assert kwargs["framework"] == "g-cloud-8"
-        # very minimal fake services
-        return iter((
+    def test_should_show_agreement_details_on_page(self, s3, data_api_client):
+        data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
+        data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
+        data_api_client.get_supplier_framework_info.return_value = self.load_example_listing(
+            'supplier_framework_response'
+        )
+
+        data_api_client.find_services_iter.return_value = iter((
             {
                 "id": 1111,
                 "lotSlug": "dried-fruit",
@@ -1169,15 +1172,6 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
                 "lotName": "Raisins & dates",
             },
         ))
-
-    def test_should_show_agreement_details_on_page(self, s3, data_api_client):
-        data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
-        data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
-        data_api_client.get_supplier_framework_info.return_value = self.load_example_listing(
-            'supplier_framework_response'
-        )
-
-        data_api_client.find_services_iter.side_effect = self._find_services_iter_side_effect
 
         with mock.patch('app.main.views.suppliers.get_signed_url') as mock_get_url:
             mock_get_url.return_value = "http://example.com/document/1234.pdf"


### PR DESCRIPTION
First of 5 backwards compatibility PRs to handle the two new Brief statuses `cancelled` and `unsuccessful`.

1) Admin FE
2) Buyer FE https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/588
3) Scripts https://github.com/alphagov/digitalmarketplace-scripts/pull/144
4) Brief Responses FE https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/5
5) Briefs FE https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/17

See https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/292/ for the equivalent changes for the `awarded` status.

As I was unfamiliar with this repo I thought I'd have a look through the tests and include some extra  coverage (mostly straightforward error path checks). I left alone anything even slightly complex 😸 

Finally there's some PEP8 imports cleanup, because why not.