### PR TITLE
Fix 502 response for 404 pages failing to render base template

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -13,7 +13,7 @@
 {% block proposition_header %}
   {% with items = [
       {"label": "Service status changes", "link": url_for('main.service_status_update_audits')}
-  ] if current_user.has_role('admin') or current_user.has_role('admin-ccs-category') else [] %}
+  ] if current_user.is_authenticated() and (current_user.has_role('admin') or current_user.has_role('admin-ccs-category')) else [] %}
     {% include "toolkit/proposition-header.html" %}
   {% endwith %}
 {% endblock %}


### PR DESCRIPTION
FlaskLogin Anonymous users don't have `.has_role` method, and since
the _base_page templated is used by 404 pages we need to make sure
it can be rendered without a logged in user.

Checking for authenticated user before checking roles should fix the
issue.