### PR TITLE
Use notify for supplier invite emails

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,9 +60,11 @@ def create_app(config_name):
     application.permanent_session_lifetime = timedelta(hours=1)
     from .main import main as main_blueprint
     from .status import status as status_blueprint
+    from dmutils.external import external as external_blueprint
 
     application.register_blueprint(status_blueprint, url_prefix='/admin')
     application.register_blueprint(main_blueprint, url_prefix='/admin')
+    application.register_blueprint(external_blueprint)
     login_manager.login_view = '/user/login'
     main_blueprint.config = application.config.copy()
 

--- a/config.py
+++ b/config.py
@@ -46,11 +46,11 @@ class Config(object):
     SHARED_EMAIL_KEY = None
     INVITE_EMAIL_SALT = 'InviteEmailSalt'
 
-    DM_MANDRILL_API_KEY = None
-    INVITE_EMAIL_NAME = 'Digital Marketplace Admin'
-    INVITE_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
-    INVITE_EMAIL_SUBJECT = 'Your Digital Marketplace invitation'
-    CREATE_USER_PATH = 'suppliers/create-user'
+    DM_NOTIFY_API_KEY = None
+
+    NOTIFY_TEMPLATES = {
+        'invite_contributor': '1cca85e8-d647-46e6-9c0d-6af90b9e69b0'
+    }
 
     @staticmethod
     def init_app(app):
@@ -73,7 +73,7 @@ class Test(Config):
     DM_LOG_LEVEL = 'CRITICAL'
     SHARED_EMAIL_KEY = 'KEY'
     INVITE_EMAIL_SALT = 'SALT'
-    DM_MANDRILL_API_KEY = "MANDRILL"
+    DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
 
 
 class Development(Config):
@@ -89,7 +89,7 @@ class Development(Config):
     DM_DATA_API_URL = "http://localhost:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
     SECRET_KEY = "verySecretKey"
-    DM_MANDRILL_API_KEY = "not_a_real_key"
+    DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
     SHARED_EMAIL_KEY = "very_secret"
 
 
@@ -97,6 +97,10 @@ class Live(Config):
     DEBUG = False
     AUTHENTICATION = True
     DM_HTTP_PROTO = 'https'
+
+    NOTIFY_TEMPLATES = {
+        'invite_contributor': '5eefe42d-1694-4388-8908-991cdfba0a71'
+    }
 
 
 configs = {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.5.0#egg=digitalmarketplace-utils==28.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.13.0#egg=digitalmarketplace-apiclient==8.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,24 +8,23 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.5.0#egg=digitalmarketplace-utils==28.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.13.0#egg=digitalmarketplace-apiclient==8.13.0
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.22.0
+asn1crypto==0.23.0
 backoff==1.0.7
 boto3==1.4.4
-botocore==1.5.82
-cffi==1.10.0
+botocore==1.5.95
+cffi==1.11.0
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
-docutils==0.13.1
-enum34==1.1.6
+docutils==0.14
 Flask-FeatureFlags==0.6
 Flask-Script==2.0.5
 future==0.16.0
-idna==2.5
+idna==2.6
 inflection==0.3.1
 itsdangerous==0.24
 Jinja2==2.9.6
@@ -37,13 +36,13 @@ MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
 pycparser==2.18
-PyJWT==1.5.2
+PyJWT==1.5.3
 python-dateutil==2.6.1
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.7.0
-s3transfer==0.1.10
+s3transfer==0.1.11
 six==1.10.0
 unicodecsv==0.14.1
 Werkzeug==0.12.2

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -109,13 +109,13 @@ class TestListAgreements(LoggedInApplicationTest):
                 "/admin/suppliers/11112/agreements/g-cloud-8",
                 {},
                 "My other supplier",
-                "Submitted: Friday 30 October 2015 at 01:01",
+                "Submitted: Friday 30 October 2015 at 1:01am",
             ),
             (
                 "/admin/suppliers/11111/agreements/g-cloud-8",
                 {},
                 "My Supplier",
-                "Submitted: Sunday 1 November 2015 at 01:01",
+                "Submitted: Sunday 1 November 2015 at 1:01am",
             ),
         )
 
@@ -161,13 +161,13 @@ class TestListAgreements(LoggedInApplicationTest):
                 "/admin/suppliers/11111/agreements/g-cloud-8",
                 {"next_status": [chosen_status_key]},
                 "My Supplier",
-                "Submitted: Sunday 1 November 2015 at 01:01",
+                "Submitted: Sunday 1 November 2015 at 1:01am",
             ),
             (
                 "/admin/suppliers/11112/agreements/g-cloud-8",
                 {"next_status": [chosen_status_key]},
                 "My other supplier",
-                "Submitted: Friday 30 October 2015 at 01:01",
+                "Submitted: Friday 30 October 2015 at 1:01am",
             ),
         )
 

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -901,7 +901,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
                     # svc_status (service status)
                     "disabled",
                     # exp_oldver_ctxt_text (expected oldversion title context text)
-                    "Changed on Wednesday 3 February 2010 at 10:11",
+                    "Changed on Wednesday 3 February 2010 at 10:11am",
                     # sets of (fae_page_len, exp_summ_text) combinations to be flattened and joined against the above
                     # parameters^. this lets us reuse a long-winded description of the "universe" against many different
                     # implicit page_len values to test it with
@@ -961,7 +961,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
                         },
                     },
                     "published",
-                    "Changed on Tuesday 3 February 2015 at 20:11",
+                    "Changed on Tuesday 3 February 2015 at 8:11pm",
                     (
                         (
                             5,
@@ -1022,7 +1022,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
                         },
                     },
                     "enabled",
-                    "Changed on Saturday 30 June 2012 at 21:01",
+                    "Changed on Saturday 30 June 2012 at 9:01pm",
                     (
                         (
                             5,
@@ -1096,7 +1096,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
                         },
                     },
                     "enabled",
-                    "Changed on Saturday 12 November 2005 at 15:01",
+                    "Changed on Saturday 12 November 2005 at 3:01pm",
                     (
                         (
                             5,


### PR DESCRIPTION
Part of this ticket: https://trello.com/c/HlSz9QZZ

### Pull in utils 28.5.0
It contains code for sending supplier invites with Notify.

### Pull in utils 28.5.0
It contains code for sending supplier invites with Notify.

### Update tests to use DM date formatting
The new version of utils updaated the date format being used by the
admin frontend to be in line with Digital Marketplace styles.