### PR TITLE
Admin page to add buyer domains

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -15,3 +15,9 @@ class MoveUserForm(Form):
         DataRequired(message="Email can not be empty"),
         Email(message="Please enter a valid email address")
     ])
+
+
+class EmailDomainForm(Form):
+    new_buyer_domain = StripWhitespaceStringField('Add a buyer email domain', validators=[
+        DataRequired(message="Domain can not be empty")
+    ])

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -1,5 +1,8 @@
-from flask import render_template, request, flash
+from dmapiclient import HTTPError
+from flask import flash, redirect, render_template, request, url_for
+from flask_login import current_user
 
+from ..forms import EmailDomainForm
 from .. import main
 from ... import data_api_client
 from ..auth import role_required
@@ -29,3 +32,26 @@ def find_buyer_by_brief_id():
         title=title,
         brief_id=brief_id
     )
+
+
+@main.route('/buyers/add-buyer-domains', methods=['GET', 'POST'])
+@role_required('admin')
+def add_buyer_domains():
+    email_domain_form = EmailDomainForm()
+
+    if email_domain_form.validate_on_submit():
+        try:
+            new_domain = request.form.get('new_buyer_domain')
+            data_api_client.create_buyer_email_domain(new_domain, current_user.email_address)
+            flash('You’ve added {}.'.format(new_domain), 'message')
+            return redirect(url_for('.add_buyer_domains'))
+        except HTTPError as e:
+            if "has already been approved" in e.message:
+                flash('You cannot add this domain because it already exists.', 'error')
+            elif "was not a valid format" in e.message:
+                flash('The domain {} is not a valid format'.format(new_domain), 'error')
+
+    return render_template(
+        "add_buyer_email_domain.html",
+        email_domain_form=email_domain_form
+    ), 400 if email_domain_form.new_buyer_domain.errors else 200

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -38,7 +38,7 @@ def find_buyer_by_brief_id():
 @role_required('admin')
 def add_buyer_domains():
     email_domain_form = EmailDomainForm()
-
+    status_code = 200
     if email_domain_form.validate_on_submit():
         try:
             new_domain = request.form.get('new_buyer_domain')
@@ -46,12 +46,17 @@ def add_buyer_domains():
             flash('You’ve added {}.'.format(new_domain), 'message')
             return redirect(url_for('.add_buyer_domains'))
         except HTTPError as e:
+            status_code = 400
             if "has already been approved" in e.message:
                 flash('You cannot add this domain because it already exists.', 'error')
             elif "was not a valid format" in e.message:
                 flash('The domain {} is not a valid format'.format(new_domain), 'error')
+            else:
+                raise e
+    elif email_domain_form.new_buyer_domain.errors:
+        status_code = 400
 
     return render_template(
         "add_buyer_email_domain.html",
         email_domain_form=email_domain_form
-    ), 400 if email_domain_form.new_buyer_domain.errors else 200
+    ), status_code

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -48,9 +48,13 @@ def add_buyer_domains():
         except HTTPError as e:
             status_code = 400
             if "has already been approved" in e.message:
-                flash('You cannot add this domain because it already exists.', 'error')
+                email_domain_form.new_buyer_domain.errors.append(
+                    'You cannot add this domain because it already exists.'
+                )
             elif "was not a valid format" in e.message:
-                flash('The domain {} is not a valid format'.format(new_domain), 'error')
+                email_domain_form.new_buyer_domain.errors.append(
+                    "‘{}’ is not a valid format.".format(new_domain)
+                )
             else:
                 raise e
     elif email_domain_form.new_buyer_domain.errors:

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -1,0 +1,72 @@
+{% extends "_base_page.html" %}
+{% block page_title %}
+  Add buyer email domains – Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      },
+      {
+        "label": "Add buyer email domains"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+      {% for category, message in messages %}
+          {%
+          with
+              message = message,
+              type = "destructive" if category == 'error' else 'success'
+          %}
+          {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+      {% endfor %}
+  {% endif %}
+  {% endwith %}
+
+  {% with heading = "Add buyer email domains" %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  <form method="post">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+        <p>
+          <a href="https://www.gov.uk/government/publications/public-sector-organisations-eligible-to-use-cloudstore">
+            Check 'Public sector organisations eligible to use Digital Marketplace'
+          </a> before you add a domain.
+        </p>
+
+        {%
+          with
+          question = email_domain_form.new_buyer_domain.label,
+          hint = "For example police.uk",
+          name = email_domain_form.new_buyer_domain.name,
+          value = email_domain_form.new_buyer_domain.data,
+          error = email_domain_form.new_buyer_domain.errors[0]
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {%
+          with
+          type = "save",
+          label = "Add"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -25,14 +25,24 @@
       {% for category, message in messages %}
           {%
           with
-              message = message,
-              type = "destructive" if category == 'error' else 'success'
+            message = message,
+            type = "destructive" if category == 'error' else 'success'
           %}
           {% include "toolkit/notification-banner.html" %}
           {% endwith %}
       {% endfor %}
   {% endif %}
   {% endwith %}
+
+  {% for error in email_domain_form.new_buyer_domain.errors %}
+    {%
+      with
+        message = error,
+        type = "destructive"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  {% endfor %}
 
   {% with heading = "Add a buyer email domain" %}
     {% include "toolkit/page-heading.html" %}
@@ -54,7 +64,7 @@
           hint = "For example police.uk",
           name = email_domain_form.new_buyer_domain.name,
           value = email_domain_form.new_buyer_domain.data,
-          error = email_domain_form.new_buyer_domain.errors[0]
+          error = ""
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -34,7 +34,7 @@
   {% endif %}
   {% endwith %}
 
-  {% with heading = "Add buyer email domains" %}
+  {% with heading = "Add a buyer email domain" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
@@ -50,7 +50,7 @@
 
         {%
           with
-          question = email_domain_form.new_buyer_domain.label,
+          question = "",
           hint = "For example police.uk",
           name = email_domain_form.new_buyer_domain.name,
           value = email_domain_form.new_buyer_domain.data,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -89,6 +89,19 @@
 <div class="grid-row">
     <div class="column-two-thirds">
 
+  {% if current_user.has_role('admin') %}
+      {% with items = [
+          {
+
+              "link": url_for('.add_buyer_domains'),
+              "title": "Add a buyer email domain"
+          },
+      ]
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+  {% endif %}
+
   {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
       {% with
           smaller = True,

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -23,35 +23,30 @@
 {% endblock %}
 
 {% block main_content %}
-
-
-  {% with heading = supplier.name %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
+{% set flash_messages_content = {
+        'user_invited': 'User invited',
+        'user_not_invited': 'Not invited',
+        'user_moved': 'User moved to this supplier',
+        'user_not_moved': 'User not moved to this supplier - please check you entered the address of an existing supplier user'
+    }
+%}
 
   {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
-  {% for category, message in messages %}
-  {% if category == 'error' %}
-    <div class="banner-destructive-without-action">
-  {% elif category == 'success' %}
-    <div class="banner-success-without-action">
+      {% for category, message in messages %}
+          {%
+          with
+              message = flash_messages_content[message],
+              type = "destructive" if category == 'error' else 'success'
+          %}
+          {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+      {% endfor %}
   {% endif %}
-        <p class="banner-message">
-  {% if message == 'user_invited' %}
-      User invited
-  {% elif message == 'user_not_invited' %}
-      Not Invited
-  {% elif message == 'user_moved' %}
-      User moved to this supplier
-  {% elif message == 'user_not_moved' %}
-      User not moved to this supplier - please check you entered the address of an existing supplier user
-  {% endif %}
-        </p>
-    </div>
-  {% endfor %}
-  {% endif %}
+  {% endwith %}
+
+  {% with heading = supplier.name %}
+  {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
   <div class='page-section'>

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -156,24 +156,17 @@
           <div class="grid-row">
               <div class="column-two-thirds">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  {% if invite_form.email_address.errors %}
-                  <div class="validation-wrapper">
-                      {% endif %}
-                      <div class="question">
-                          {{ invite_form.email_address.label(class="question-heading") }}
-                          <p class="hint">
-                              Enter the email address of the person you wish to invite
-                          </p>
-                          {% if invite_form.email_address.errors %}
-                          <p class="validation-message" id="error-email-address-textbox">
-                              {% for error in invite_form.email_address.errors %}{{ error }}{% endfor %}
-                          </p>
-                          {% endif %}
-                          {{ invite_form.email_address(class="text-box", autocomplete="off") }}
-                      </div>
-                      {% if invite_form.email_address.errors %}
-                  </div>
-                  {% endif %}
+                  {%
+                    with
+                    question = invite_form.email_address.label,
+                    hint = "Enter the email address of the person you wish to invite",
+                    name = invite_form.email_address.name,
+                    value = invite_form.email_address.data,
+                    error = invite_form.email_address.errors[0]
+                  %}
+                    {% include "toolkit/forms/textbox.html" %}
+                  {% endwith %}
+
                  <button class="button-save">Send invitation</button>
               </div>
           </div>
@@ -185,24 +178,17 @@
             <div class="grid-row">
                 <div class="column-two-thirds">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                    {% if move_user_form.user_to_move_email_address.errors %}
-                    <div class="validation-wrapper">
-                        {% endif %}
-                        <div class="question">
-                            {{ move_user_form.user_to_move_email_address.label(class="question-heading") }}
-                            <p class="hint">
-                                Enter the email address of the existing user you wish to move to this supplier
-                            </p>
-                            {% if move_user_form.user_to_move_email_address.errors %}
-                            <p class="validation-message" id="error-email-address-textbox">
-                                {% for error in move_user_form.user_to_move_email_address.errors %}{{ error }}{% endfor %}
-                            </p>
-                            {% endif %}
-                            {{ move_user_form.user_to_move_email_address(class="text-box", autocomplete="off") }}
-                        </div>
-                        {% if move_user_form.user_to_move_email_address.errors %}
-                    </div>
-                    {% endif %}
+                    {%
+                      with
+                      question = move_user_form.user_to_move_email_address.label,
+                      hint = "Enter the email address of the existing user you wish to move to this supplier",
+                      name = move_user_form.user_to_move_email_address.name,
+                      value = move_user_form.user_to_move_email_address.data,
+                      error = move_user_form.user_to_move_email_address.errors[0]
+                    %}
+                      {% include "toolkit/forms/textbox.html" %}
+                    {% endwith %}
+
                     <button class="button-save">Move user to this supplier</button>
                 </div>
             </div>

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.13.0#egg=digitalmarketplace-apiclient==8.13.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.8.1#egg=digitalmarketplace-apiclient==10.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.13.0#egg=digitalmarketplace-apiclient==8.13.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.8.1#egg=digitalmarketplace-apiclient==10.8.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.23.0

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -131,7 +131,7 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
                                     data={'new_buyer_domain': 'inv@lid.co'}
                                     )
         assert response.status_code == 400
-        assert "The domain inv@lid.co is not a valid format" in response.get_data(as_text=True)
+        assert "‘inv@lid.co’ is not a valid format" in response.get_data(as_text=True)
         assert data_api_client.create_buyer_email_domain.call_args_list == [mock.call("inv@lid.co", "test@example.com")]
 
     def test_raises_unexpected_api_error(self, data_api_client):

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -1,0 +1,44 @@
+import mock
+import pytest
+
+from ...helpers import LoggedInApplicationTest
+
+
+class TestIndex(LoggedInApplicationTest):
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_index_shows_frameworks_in_standstill_or_live(self, data_api_client):
+        data_api_client.find_frameworks.return_value = {'frameworks': [
+            {'id': 1, 'frameworkAgreementVersion': None, 'name': 'Framework 1', 'slug': 'framework-1',
+             'status': 'standstill'},
+            {'id': 2, 'frameworkAgreementVersion': 'v1.0', 'name': 'Framework 2', 'slug': 'framework-2',
+             'status': 'live'},
+            {'id': 3, 'frameworkAgreementVersion': None, 'name': 'Framework 3', 'slug': 'framework-3',
+             'status': 'open'},
+        ]}
+
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+
+        assert 'Download Framework 1 agreements' in data
+        assert 'Approve Framework 2 agreements for countersigning' in data
+
+        # Agreements should be in reverse-chronological order.
+        assert data.index('Approve Framework 2 agreements for countersigning') < \
+            data.index('Download Framework 1 agreements')
+
+        # Only standstill/live agreements should be listed.
+        assert 'Download Framework 3 agreements' not in data
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", True),
+        ("admin-ccs-category", False),
+        ("admin-ccs-sourcing", False),
+    ])
+    def test_add_buyer_email_domain_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Add a buyer email domain" in data
+
+        assert link_is_visible is link_should_be_visible, \
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -19,32 +19,6 @@ from ...helpers import LoggedInApplicationTest
 from dmutils import s3
 
 
-class TestIndex(LoggedInApplicationTest):
-    @mock.patch('app.main.views.services.data_api_client')
-    def test_index_shows_frameworks_in_standstill_or_live(self, data_api_client):
-        data_api_client.find_frameworks.return_value = {'frameworks': [
-            {'id': 1, 'frameworkAgreementVersion': None, 'name': 'Framework 1', 'slug': 'framework-1',
-             'status': 'standstill'},
-            {'id': 2, 'frameworkAgreementVersion': 'v1.0', 'name': 'Framework 2', 'slug': 'framework-2',
-             'status': 'live'},
-            {'id': 3, 'frameworkAgreementVersion': None, 'name': 'Framework 3', 'slug': 'framework-3',
-             'status': 'open'},
-        ]}
-
-        response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-
-        assert 'Download Framework 1 agreements' in data
-        assert 'Approve Framework 2 agreements for countersigning' in data
-
-        # Agreements should be in reverse-chronological order.
-        assert data.index('Approve Framework 2 agreements for countersigning') < \
-            data.index('Download Framework 1 agreements')
-
-        # Only standstill/live agreements should be listed.
-        assert 'Download Framework 3 agreements' not in data
-
-
 class TestServiceFind(LoggedInApplicationTest):
 
     def test_service_find_redirects_to_view_for_valid_service_id(self):


### PR DESCRIPTION
Trello card: https://trello.com/c/TRYLtlWB/100-allow-admin-to-add-buyer-domain-to-the-digital-marketplace-whitelist

A new page, a link to it from the homepage, with some bits and pieces of tidying up admin page templates thrown in for good measure.

## Homepage link
![screen shot 2017-10-20 at 16 46 45](https://user-images.githubusercontent.com/6525554/31829888-84f70d1c-b5b6-11e7-8c03-5a958ed8c0cd.png)


## New page
![screen shot 2017-10-20 at 16 46 53](https://user-images.githubusercontent.com/6525554/31829893-888abf82-b5b6-11e7-9130-86f5eaa212ad.png)


## Added a domain
![screen shot 2017-10-20 at 16 47 07](https://user-images.githubusercontent.com/6525554/31829896-8bd0270e-b5b6-11e7-9140-8962c11bda58.png)


## Errors
![screen shot 2017-10-20 at 16 47 17](https://user-images.githubusercontent.com/6525554/31829901-8e645fe4-b5b6-11e7-99fb-ae4077049943.png)

![screen shot 2017-10-23 at 11 42 00](https://user-images.githubusercontent.com/6525554/31885099-4431de46-b7e7-11e7-91cf-cd6ec07fbc3c.png)
