### PR TITLE
Add acl to communications, deextrapolate get_path

### DIFF
--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -9,17 +9,6 @@ from dmutils import s3  # this style of import so we only have to mock once
 from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
 
 
-def _get_path(framework_slug, path):
-    return '{}/communications/{}'.format(framework_slug, path)
-
-
-def _save_file(bucket, framework_slug, path, the_file, flash_message):
-    path = "{}/{}".format(_get_path(framework_slug, path), the_file.filename)
-    # setting download_filename ensures Content-Disposition: attachment
-    bucket.save(path, the_file, download_filename=the_file.filename)
-    flash(flash_message, 'upload_communication')
-
-
 @main.route('/communications/<framework_slug>', methods=['GET'])
 @role_required('admin', 'admin-ccs-category')
 def manage_communications(framework_slug):
@@ -27,10 +16,10 @@ def manage_communications(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
     clarification = next(iter(communications_bucket.list(
-        _get_path(framework_slug, 'updates/clarifications'), load_timestamps=True
+        '{}/communications/updates/clarifications'.format(framework_slug), load_timestamps=True
     )), None)
     communication = next(iter(communications_bucket.list(
-        _get_path(framework_slug, 'updates/communications'), load_timestamps=True
+        '{}/communications/updates/communications'.format(framework_slug), load_timestamps=True
     )), None)
 
     return render_template(
@@ -53,7 +42,9 @@ def upload_communication(framework_slug):
             errors['communication'] = 'not_open_document_format_or_csv'
 
         if 'communication' not in errors.keys():
-            _save_file(communications_bucket, framework_slug, 'updates/communications', the_file, 'communication')
+            path = "{}/communications/updates/communications/{}".format(framework_slug, the_file.filename)
+            communications_bucket.save(path, the_file, acl='private', download_filename=the_file.filename)
+            flash('communication', 'upload_communication')
 
     if request.files.get('clarification'):
         the_file = request.files['clarification']
@@ -61,7 +52,9 @@ def upload_communication(framework_slug):
             errors['clarification'] = 'not_pdf'
 
         if 'clarification' not in errors.keys():
-            _save_file(communications_bucket, framework_slug, 'updates/clarifications', the_file, 'clarification')
+            path = "{}/communications/updates/clarifications/{}".format(framework_slug, the_file.filename)
+            communications_bucket.save(path, the_file, acl='private', download_filename=the_file.filename)
+            flash('clarification', 'upload_communication')
 
     if len(errors) > 0:
         for category, message in errors.items():

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -91,6 +91,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         self.s3.return_value.save.assert_called_once_with(
             '{}/communications/updates/communications/test-comm.pdf'.format(self.framework_slug),
             mock.ANY,  # werkzeug.datastructures.FileStorage object we are saving to s3
+            acl='private',
             download_filename='test-comm.pdf'
         )
 
@@ -107,5 +108,6 @@ class TestCommunicationsView(LoggedInApplicationTest):
         self.s3.return_value.save.assert_called_once_with(
             '{}/communications/updates/clarifications/test-comm.pdf'.format(self.framework_slug),
             mock.ANY,  # werkzeug.datastructures.FileStorage object we are saving to s3
+            acl='private',
             download_filename='test-comm.pdf'
         )


### PR DESCRIPTION
https://trello.com/c/pZNuiwDv/67-communication-files-in-s3-files-are-public

2nd line fix ticket to save communications and clarifications with S3 private ACL
Remove overly extrapolated code
Add tests