### PR TITLE
Bugfix validation messages for admin service editing

### DIFF
--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -31,28 +31,19 @@
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
+
   {% if errors %}
-    <div class="validation-masthead">
-      <h2 class="validation-masthead-heading">
-        There were problems with your response to the following questions:
-      </h2>
-      <ul>
-        {% for question in section.questions %}
-          {% if question.id in errors %}
-            <li>
-              <a class="validation-masthead-link" href="#{{ question.id }}">{{ question.question }}</a>
-            </li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-    </div>
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
   {% endif %}
+
   <form method="post" enctype="multipart/form-data">
     <div class="grid-row">
       <div class="column-two-thirds">
         <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
         {% for question in section.questions %}
-          {% if errors and errors[question.id] %}
+          {% if errors and errors[question.id] or question.type == 'multiquestion' %}
             {{ forms[question.type](question, service_data, errors) }}
           {% else %}
             {{ forms[question.type](question, service_data, {}) }}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.8.1#egg=digitalmarketplace-apiclient==10.8.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.3.0#egg=digitalmarketplace-apiclient==11.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.8.1#egg=digitalmarketplace-apiclient==10.8.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.3.0#egg=digitalmarketplace-apiclient==11.3.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.23.0

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -601,6 +601,8 @@ class TestServiceUpdate(LoggedInApplicationTest):
             },
             follow_redirects=True
         )
+
+        assert response.status_code == 400
         assert data_api_client.update_service.call_args_list == [(
             (
                 '1',

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -615,13 +615,23 @@ class TestServiceUpdate(LoggedInApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
 
-        validation_banner = document.xpath("//div[@class='validation-masthead']//text()[normalize-space(.) != '']")
-        validation_banner_text = ' '.join([elem.strip() for elem in validation_banner])
+        validation_banner_h1 = document.xpath("//h1[@class='validation-masthead-heading']//text()")[0].strip()
+        assert validation_banner_h1 == "There was a problem with your answer to:"
+
+        validation_banner_links = [
+            (anchor.text_content(), anchor.get('href')) for anchor in
+            document.xpath("//a[@class='validation-masthead-link']")
+        ]
+        assert validation_banner_links == [
+            ("Service benefits", "#serviceBenefits"),
+            ("Service features", "#serviceFeatures")
+        ]
+
         validation_errors = [error.strip() for error in document.xpath("//span[@class='validation-message']//text()")]
-        assert response.status_code == 400
-        assert validation_banner_text == "There was a problem with your answer to: Service benefits Service features"
-        assert "You can’t write more than 10 words for each feature." in validation_errors
-        assert "You can’t write more than 10 words for each benefit." in validation_errors
+        assert validation_errors == [
+            "You can’t write more than 10 words for each feature.",
+            "You can’t write more than 10 words for each benefit."
+        ]
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_update_with_assurance_questions(self, data_api_client):


### PR DESCRIPTION
The toolkit version of the validation masthead understands how to show errors for multiquestions, so I swapped the template out to use that.
And the bit that shows individual questions also needed to pass errors through to multiquestions to get the bars next to the individual fields.

The xpath stuff in the new test could probably be neater, but it has taken me hours (considerably longer than the fix itself) to get this test working properly, so only suggest changes if you have the **exact code** that would be better - no vague Xpath hints please :p

Also update API client because there were `print` statements in error handling in the currently imported version 😕 

# BEFORE
![screen shot 2017-11-01 at 18 44 29](https://user-images.githubusercontent.com/6525554/32291382-cf747500-bf34-11e7-92ad-e25379d2da95.png)

# AFTER
![screen shot 2017-11-01 at 18 42 25](https://user-images.githubusercontent.com/6525554/32291388-d2c7d74c-bf34-11e7-859e-7f763e6db956.png)
