### PR TITLE
Pull in Javascript to clear local anchor from links following error

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 //= include ../../../bower_components/d3/d3.js
 //= include ../../../bower_components/c3/c3.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js


### PR DESCRIPTION
Fixes this issue found in QA:
If a page has two separate sections that both have a validation error. User clicks on the link at the top to take them to the section that is in error, corrects the error then attempts save the change, instead of being returned to the top of the page to show the user what is still wrong on the page, the page remains where it is.
