### PR TITLE
Nest supplier agreements table to apply custom scss only there

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -95,15 +95,12 @@ $path: "/admin/static/images/";
   margin-bottom: 40px;
 }
 
-.summary-item-field-first {
-  width: 15%;
-}
-
-.summary-item-field {
-  width: 15%;
+.summary-item-field-heading, .summary-item-field {
   padding-left: 10px;
 }
 
-.summary-item-field-heading {
-  padding-left: 10px;
+.six-columns-fixed-width-table {
+  .summary-item-field-first, .summary-item-field {
+    width: 16.666%;
+  }
 }

--- a/app/templates/_view_suppliers_agreements.html
+++ b/app/templates/_view_suppliers_agreements.html
@@ -1,3 +1,4 @@
+<div class="six-columns-fixed-width-table">
 {% set field_headings = [
   "Name",
   "G-Cloud 7",
@@ -75,3 +76,4 @@
     {% endcall %}
   {% endcall %}
 {% endcall %}
+</div>


### PR DESCRIPTION
Looks like the main scss `summary-item-field-*` classes were overridden in order to style a single table.
I've nested this table and applied the scss styles only to that nestings child elements. This seems like a better way for now and won't affect every single summary table in the admin.

Before:

![screen shot 2017-11-07 at 16 24 45](https://user-images.githubusercontent.com/3469840/32504673-532f08cc-c3d8-11e7-9289-8ac1c39dbf1e.png)


After:

![screen shot 2017-11-07 at 16 25 35](https://user-images.githubusercontent.com/3469840/32504686-5a24b6f4-c3d8-11e7-9867-26b3303ba6a8.png)
