### PR TITLE
Mark service updates as by_admin

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -239,7 +239,9 @@ def update(service_id, section_id):
             data_api_client.update_service(
                 service_id,
                 posted_data,
-                current_user.email_address)
+                current_user.email_address,
+                by_admin=True,
+            )
         except HTTPError as e:
             errors = section.get_error_messages(e.message)
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.3.0#egg=digitalmarketplace-apiclient==11.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.4.0#egg=digitalmarketplace-apiclient==11.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.3.0#egg=digitalmarketplace-apiclient==11.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.4.0#egg=digitalmarketplace-apiclient==11.4.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.23.0

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -427,7 +427,7 @@ class TestServiceUpdate(LoggedInApplicationTest):
         data_api_client.update_service.assert_called_with('1', {
             'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-7/documents/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
             'sfiaRateDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-7/documents/2/1-sfia-rate-card-2015-01-01-1200.pdf',  # noqa
-        }, 'test@example.com')
+        }, 'test@example.com', by_admin=True)
 
         assert response.status_code == 302
 
@@ -500,28 +500,23 @@ class TestServiceUpdate(LoggedInApplicationTest):
         assert response.status_code == 400
         data_api_client.get_service.assert_called_with('7654')
         assert data_api_client.update_service.call_args_list == [
-            (
-                (
-                    "7654",
-                    {
-                        "dataProtectionBetweenUserAndService": {
-                            "value": posted_values["dataProtectionBetweenUserAndService"],
-                            "assurance": posted_assurances["dataProtectionBetweenUserAndService--assurance"],
-                        },
-                        "dataProtectionWithinService": {
-                            "assurance": posted_assurances["dataProtectionWithinService--assurance"],
-                        },
-                        "dataProtectionBetweenServices": {
-                            "value": posted_values["dataProtectionBetweenServices"],
-                            "assurance": posted_assurances["dataProtectionBetweenServices--assurance"],
-                        },
+            mock.call(
+                '7654',
+                {
+                    "dataProtectionBetweenUserAndService": {
+                        "value": posted_values["dataProtectionBetweenUserAndService"],
+                        "assurance": posted_assurances["dataProtectionBetweenUserAndService--assurance"],
                     },
-                    "test@example.com",
-                ),
-                {},
-            )
+                    "dataProtectionWithinService": {
+                        "assurance": posted_assurances["dataProtectionWithinService--assurance"],
+                    },
+                    "dataProtectionBetweenServices": {
+                        "value": posted_values["dataProtectionBetweenServices"],
+                        "assurance": posted_assurances["dataProtectionBetweenServices--assurance"],
+                    },
+                },
+                'test@example.com', by_admin=True)
         ]
-
         for key, values in posted_values.items():
             assert sorted(document.xpath("//form//input[@type='checkbox'][@name=$n][@checked]/@value", n=key)) == \
                 sorted(values)
@@ -560,17 +555,15 @@ class TestServiceUpdate(LoggedInApplicationTest):
                 'serviceBenefits': 'foo',
             }
         )
-        assert data_api_client.update_service.call_args_list == [(
-            (
+        assert data_api_client.update_service.call_args_list == [
+            mock.call(
                 '1',
                 {
                     'serviceFeatures': ['baz'],
                     'serviceBenefits': ['foo'],
                 },
-                'test@example.com',
-            ),
-            {},
-        )]
+                'test@example.com', by_admin=True)
+        ]
         assert response.status_code == 302
 
     @mock.patch('app.main.views.services.data_api_client')
@@ -603,17 +596,14 @@ class TestServiceUpdate(LoggedInApplicationTest):
         )
 
         assert response.status_code == 400
-        assert data_api_client.update_service.call_args_list == [(
-            (
+        print("EXPECTED: {}".format(data_api_client.update_service.call_args_list))
+        assert data_api_client.update_service.call_args_list == [
+            mock.call(
                 '1',
-                {
-                    'serviceFeatures': ['one 2 three 4 five 6 seven 8 nine 10 eleven'],
-                    'serviceBenefits': ['11 10 9 8 7 6 5 4 3 2 1'],
-                },
-                'test@example.com',
-            ),
-            {},
-        )]
+                {'serviceFeatures': ['one 2 three 4 five 6 seven 8 nine 10 eleven'],
+                 'serviceBenefits': ['11 10 9 8 7 6 5 4 3 2 1']},
+                'test@example.com', by_admin=True)
+        ]
 
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -660,8 +650,8 @@ class TestServiceUpdate(LoggedInApplicationTest):
                 'interconnectionMethods--assurance': "Service provider assertion",
             },
         )
-        assert data_api_client.update_service.call_args_list == [(
-            (
+        assert data_api_client.update_service.call_args_list == [
+            mock.call(
                 '567',
                 {
                     'onboardingGuidance': {
@@ -673,10 +663,8 @@ class TestServiceUpdate(LoggedInApplicationTest):
                         "assurance": "Service provider assertion",
                     },
                 },
-                'test@example.com',
-            ),
-            {},
-        )]
+                'test@example.com', by_admin=True)
+        ]
         assert response.status_code == 302
 
     @mock.patch('app.main.views.services.data_api_client')


### PR DESCRIPTION
Tests will fail until API client https://github.com/alphagov/digitalmarketplace-apiclient/pull/110 is merged.

Following on from:
 - [ ] https://github.com/alphagov/digitalmarketplace-apiclient/pull/110
 - [ ] https://github.com/alphagov/digitalmarketplace-api/pull/687

This is the final part for ticket: https://trello.com/c/DbYlqSxv/121-exclude-changes-made-by-admin-in-the-approve-edits-section

Updates made by admin users pass the `by_admin=True` flag in so the API knows to use the `update_service_admin` audit event for the update.