### PR TITLE
120 allow admins to view and edit dos services 

### DIFF
--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -3,7 +3,7 @@
 
 {% extends "_base_page.html" %}
 {% block page_title %}
-  {{ service_data['serviceName'] }} – Digital Marketplace admin
+  {{ service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] }} – Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}
@@ -53,7 +53,7 @@
         {%
           with
           context = service_data['supplierName'],
-          heading = service_data['serviceName'],
+          heading = service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'],
           smaller = True
         %}
           {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -82,6 +82,10 @@
         {% call summary.row() %}
           {{ summary.field_name(question.label) }}
           {{ summary[question.type](question.value, question.assurance) }}
+          {% if section.edit_questions %}
+            {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for('.edit', service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+          {% endif %}
+
         {% endcall %}
       {% endcall %}
     {% endfor %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -59,9 +59,11 @@
           {% include "toolkit/page-heading.html" %}
         {% endwith %}
       </div>
-      <div class="service-view">
-        <a href="/g-cloud/services/{{ service_id }}">View service</a>
-      </div>
+      {% if service_data['frameworkFramework'] == 'g-cloud' %}
+        <div class="service-view">
+            <a href="/{{ service_data['frameworkFramework'] }}/services/{{ service_id }}">View service</a>
+        </div>
+      {% endif %}
     </div>
 
     {% for section in sections %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -49,7 +49,13 @@
           field_headings_visible=True
         ) %}
           {% call summary.row() %}
-            {{ summary.service_link(item.serviceName, '/' + item.frameworkFramework + '/services/' + item.id|string) }}
+            {% if item.serviceName %}
+              {{ summary.service_link(item.serviceName, '/' + item.frameworkFramework + '/services/' + item.id|string) }}
+            {% else %}
+              {% call summary.field(first=True, wide=True) %}
+                {{ item.lotName }}
+              {% endcall %}
+            {% endif %}
             {{ summary.text(item.id) }}
             {{ summary.text(item.lotName) }}
             {% call summary.field() %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v8.5.1",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v9.3.0",
     "hogan": "3.0.2",
     "c3": "0.4.10"
   }

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -36,6 +36,7 @@ class TestServiceView(LoggedInApplicationTest):
     def test_service_view_no_features_or_benefits_status_disabled(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-8',
+            'serviceName': 'test',
             'lot': 'iaas',
             'id': "314159265",
             "status": "disabled",
@@ -62,6 +63,7 @@ class TestServiceView(LoggedInApplicationTest):
     def test_service_view_no_features_or_benefits_status_enabled(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-7',
+            'serviceName': 'test',
             'lot': 'iaas',
             'id': "1412",
             "status": "enabled",
@@ -166,6 +168,7 @@ class TestServiceView(LoggedInApplicationTest):
         self.user_role = "admin-ccs-category"
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-7',
+            'serviceName': 'test',
             'id': "271828",
             "status": "published",
         }}
@@ -219,6 +222,7 @@ class TestServiceView(LoggedInApplicationTest):
         data_api_client.get_service.return_value = {'services': {
             'lot': 'SCS',
             'frameworkSlug': 'g-cloud-8',
+            'serviceName': 'test',
             'id': "1",
         }}
         response = self.client.get('/admin/services/1')
@@ -227,6 +231,7 @@ class TestServiceView(LoggedInApplicationTest):
         data_api_client.get_service.return_value = {'services': {
             'lot': 'SaaS',
             'frameworkSlug': 'g-cloud-8',
+            'serviceName': 'test',
             'id': "1",
         }}
         response = self.client.get('/admin/services/1')
@@ -235,6 +240,7 @@ class TestServiceView(LoggedInApplicationTest):
         data_api_client.get_service.return_value = {'services': {
             'lot': 'SCS',
             'frameworkSlug': 'g-cloud-8',
+            'serviceName': 'test',
             'id': "1",
         }}
         response = self.client.get('/admin/services/1')
@@ -244,6 +250,7 @@ class TestServiceView(LoggedInApplicationTest):
     def test_service_status_update_widgets_not_visible_when_not_permitted(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'lot': 'paas',
+            'serviceName': 'test',
             'frameworkSlug': 'g-cloud-8',
             'id': "1",
         }}
@@ -253,7 +260,7 @@ class TestServiceView(LoggedInApplicationTest):
 
 class TestServiceEdit(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
-    def test_edit_dos_service_title(self, data_api_client):
+    def test_edit_dos1_service_title(self, data_api_client):
         service = {
             "id": 123,
             "frameworkSlug": "digital-outcomes-and-specialists",
@@ -274,6 +281,82 @@ class TestServiceEdit(LoggedInApplicationTest):
             "//nav//a[@href='/admin/services/123'][normalize-space(string())=$t]",
             t=service["serviceName"],
         )
+
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_no_link_to_edit_dos2_service_essentials(self, data_api_client):
+        service = {
+            "id": 123,
+            "frameworkSlug": "digital-outcomes-and-specialists-2",
+            "serviceName": "Test",
+            "lot": "digital-outcomes",
+        }
+        data_api_client.get_service.return_value = {'services': service}
+
+        response = self.client.get('/admin/services/123')
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+        all_links_on_page = [i.values()[0] for i in document.xpath('(//body//a)')]
+        assert '/admin/services/123/edit/service-essentials' not in all_links_on_page
+
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_add_link_for_empty_multiquestion(self, data_api_client):
+        service = {
+            "id": 123,
+            "frameworkSlug": "digital-outcomes-and-specialists-2",
+            "serviceName": "Test",
+            "lot": "digital-outcomes",
+            "performanceAnalysisAndData": '',
+        }
+
+        data_api_client.get_service.return_value = {'services': service}
+
+        response = self.client.get('/admin/services/123')
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+        performance_analysis_and_data_link = "/admin/services/123/edit/team-capabilities/performance-analysis-and-data"
+        performance_analysis_and_data_link_text = document.xpath(
+            '//a[contains(@href, "{}")]//text()'.format(performance_analysis_and_data_link)
+        )[0]
+        assert performance_analysis_and_data_link_text == 'Add'
+
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_edit_link_for_populated_multiquestion(self, data_api_client):
+        service = {
+            "id": 123,
+            "frameworkSlug": "digital-outcomes-and-specialists-2",
+            "serviceName": "Test",
+            "lot": "digital-outcomes",
+            "performanceAnalysisTypes": 'some value',
+        }
+
+        data_api_client.get_service.return_value = {'services': service}
+
+        response = self.client.get('/admin/services/123')
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+        performance_analysis_and_data_link = "/admin/services/123/edit/team-capabilities/performance-analysis-and-data"
+        performance_analysis_and_data_link_text = document.xpath(
+            '//a[contains(@href, "{}")]//text()'.format(performance_analysis_and_data_link)
+        )[0]
+        assert performance_analysis_and_data_link_text == 'Edit'
+
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_multiquestion_get_route(self, data_api_client):
+        service = {
+            "id": 123,
+            "frameworkSlug": "digital-outcomes-and-specialists-2",
+            "serviceName": "Test",
+            "lot": "digital-specialists",
+            "performanceAnalysisAndData": '',
+        }
+
+        data_api_client.get_service.return_value = {'services': service}
+        response = self.client.get('/admin/services/123/edit/individual-specialist-roles/business-analyst')
+
+        assert response.status_code == 200
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_edit_documents_get_response(self, data_api_client):
@@ -555,16 +638,39 @@ class TestServiceUpdate(LoggedInApplicationTest):
                 'serviceBenefits': 'foo',
             }
         )
+
         assert data_api_client.update_service.call_args_list == [
             mock.call(
                 '1',
-                {
-                    'serviceFeatures': ['baz'],
-                    'serviceBenefits': ['foo'],
-                },
-                'test@example.com', user_role='admin')
-        ]
+                {'serviceFeatures': ['baz'], 'serviceBenefits': ['foo']},
+                'test@example.com',
+                user_role='admin'
+            )]
         assert response.status_code == 302
+
+    @mock.patch('app.main.views.services.data_api_client')
+    def test_service_update_multiquestion_post_route(self, data_api_client):
+        service = {
+            "id": 123,
+            "frameworkSlug": "digital-outcomes-and-specialists-2",
+            "serviceName": "Test",
+            "lot": "digital-specialists",
+            "businessAnalyst": '',
+        }
+        data_api_client.get_service.return_value = {'services': service}
+
+        data = {
+            'businessAnalystLocations': ["London", "Offsite", "Scotland", "Wales"],
+            'businessAnalystPriceMin': '100',
+            'businessAnalystPriceMax': '150',
+        }
+        response = self.client.post(
+            '/admin/services/123/edit/individual-specialist-roles/business-analyst',
+            data=data
+        )
+
+        assert response.status_code == 302
+        assert data_api_client.update_service.called_once_with('123', data, 'test@example.com')
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_service_update_with_multiquestion_validation_error(self, data_api_client):
@@ -707,13 +813,15 @@ class TestServiceUpdate(LoggedInApplicationTest):
         data_api_client.get_service.assert_called_with('234')
         assert response.status_code == 404
 
+    @pytest.mark.parametrize('framework_slug', ('g-cloud-7', 'digital-outcomes-and-specialists-2'))
     @mock.patch('app.main.views.services.data_api_client')
-    def test_service_update_with_no_section_returns_404(self, data_api_client):
+    def test_service_update_with_no_section_returns_404(self, data_api_client, framework_slug):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
+            'serviceName': 'test',
             'supplierId': 2,
             'lot': 'SCS',
-            'frameworkSlug': 'g-cloud-7',
+            'frameworkSlug': framework_slug,
             'pricingDocumentURL': "http://assets/documents/1/2-pricing.pdf",
             'sfiaRateDocumentURL': None
         }}
@@ -736,6 +844,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_cannot_make_removed_service_public(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
+            'serviceName': 'test',
             'frameworkSlug': 'g-cloud-8',
             'supplierId': 2,
             'status': 'disabled'
@@ -748,6 +857,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_can_make_private_service_public_or_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
+            'serviceName': 'test',
             'frameworkSlug': 'g-cloud-8',
             'supplierId': 2,
             'status': 'enabled'
@@ -760,6 +870,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_can_make_public_service_private_or_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'id': 1,
+            'serviceName': 'test',
             'frameworkSlug': 'g-cloud-8',
             'supplierId': 2,
             'status': 'published'
@@ -772,6 +883,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_status_update_to_removed(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-7',
+            'serviceName': 'test',
         }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'removed'})
@@ -785,6 +897,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_status_update_to_private(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-8',
+            'serviceName': 'test',
         }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'private'})
@@ -798,6 +911,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_status_update_to_published(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'digital-outcomes-and-specialists',
+            'serviceName': 'test',
         }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'public'})
@@ -811,6 +925,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
     def test_bad_status_gives_error_message(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-7',
+            'serviceName': 'test',
         }}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'suspended'})

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -260,7 +260,7 @@ class TestServiceView(LoggedInApplicationTest):
 
 class TestServiceEdit(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
-    def test_edit_dos1_service_title(self, data_api_client):
+    def test_edit_dos_service_title(self, data_api_client):
         service = {
             "id": 123,
             "frameworkSlug": "digital-outcomes-and-specialists",


### PR DESCRIPTION
New manifest:
https://github.com/alphagov/digitalmarketplace-frameworks/pull/479

https://trello.com/c/U2Yd4CGD/120-allow-admin-view-and-edit-dos-services-update-prices-for-digital-specialists

As an admin on a supplier services page, when I click on edit, I should be able to edit all the details of the service except service essentials.

* Pull in new manifest
* Allow for nested dos multiquestion as per supplier edit services (https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/main/views/services.py#L482-L482)
* Remove link to service for DOS as this is not public
* Use framework + lot in template if service has no name
* 'add' link if multi question has no existing data otherwise 'edit'
* Update/ add tests

<img width="1297" alt="screen shot 2017-11-08 at 15 51 44" src="https://user-images.githubusercontent.com/3469840/32558499-c91b49dc-c49c-11e7-974a-f04ff8e0c57e.png">

<img width="1316" alt="screen shot 2017-11-08 at 15 53 39" src="https://user-images.githubusercontent.com/3469840/32558590-086fc20c-c49d-11e7-8045-4cd6a208400b.png">

