### PR TITLE
149 split service lists by frameworks

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,4 +1,6 @@
 from collections import OrderedDict
+from itertools import groupby
+from operator import itemgetter
 
 from flask import render_template, request, redirect, url_for, abort, current_app
 from flask_login import current_user, flash
@@ -498,12 +500,19 @@ def find_supplier_services():
     if not request.args.get('supplier_id'):
         abort(404)
 
+    frameworks = data_api_client.find_frameworks()
     supplier = data_api_client.get_supplier(request.args['supplier_id'])
     services = data_api_client.find_services(request.args.get("supplier_id"))
+    frameworks_services = {
+        framework_slug: list(framework_services)
+        for framework_slug, framework_services in
+        groupby(sorted(services['services'], key=itemgetter('frameworkSlug')), key=itemgetter('frameworkSlug'))
+    }
 
     return render_template(
         "view_supplier_services.html",
-        services=services["services"],
+        frameworks=frameworks['frameworks'],
+        frameworks_services=frameworks_services,
         supplier=supplier["suppliers"]
     )
 

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -25,39 +25,50 @@
   {% with heading = "Services" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
-  {% call(item) summary.list_table(
-    services,
-    caption="Services",
-    empty_message="This supplier has no services on the Digital Marketplace",
-    field_headings=[
-      'Name',
-      'Service ID',
-      'Framework',
-      'Lot',
-      'Status',
-      summary.hidden_field_heading("Action")
-    ],
-    field_headings_visible=True
-  ) %}
-    {% call summary.row() %}
-      {{ summary.service_link(item.serviceName, '/' + item.frameworkFramework + '/services/' + item.id|string) }}
-      {{ summary.text(item.id) }}
-      {{ summary.text(item.frameworkName) }}
-      {{ summary.text(item.lotName) }}
-      {% call summary.field() %}
-        <span class="service-status-{{ item.status }}">
-          {% if item.status == "published" %}
-            Public
-          {% elif item.status == "enabled" %}
-            Private
-          {% elif item.status == "disabled" %}
-            Removed
-          {% else %}
-            {{ item.status|title }}
-          {% endif %}
-        </span>
-      {% endcall %}
-      {{ summary.edit_link('Edit', url_for('.view', service_id=item.id)) }}
-    {% endcall %}
-  {% endcall %}
+  {% if not frameworks_services %}
+    {% call(item) summary.list_table(
+      empty_message="This supplier has no services on the Digital Marketplace."
+    )
+    %}{% endcall %}
+  {% else %}
+    {% for framework in frameworks | sort(attribute='id', reverse=True) %}
+      {% if framework['slug'] in frameworks_services %}
+
+        {{ summary.heading(framework['name'], id="{}_services".format(framework['slug'])) }}
+        {% call(item) summary.list_table(
+          frameworks_services[framework['slug']],
+          caption="Services",
+          empty_message="This supplier has no services on the {} framework.".format(framework['name']),
+          field_headings=[
+            'Name',
+            'ID',
+            'Lot',
+            'Status',
+            summary.hidden_field_heading("Action")
+          ],
+          field_headings_visible=True
+        ) %}
+          {% call summary.row() %}
+            {{ summary.service_link(item.serviceName, '/' + item.frameworkFramework + '/services/' + item.id|string) }}
+            {{ summary.text(item.id) }}
+            {{ summary.text(item.lotName) }}
+            {% call summary.field() %}
+              <span class="service-status-{{ item.status }}">
+                {% if item.status == "published" %}
+                  Public
+                {% elif item.status == "enabled" %}
+                  Private
+                {% elif item.status == "disabled" %}
+                  Removed
+                {% else %}
+                  {{ item.status|title }}
+                {% endif %}
+              </span>
+            {% endcall %}
+            {{ summary.edit_link('Edit', url_for('.view', service_id=item.id)) }}
+          {% endcall %}
+        {% endcall %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 {% endblock %}

--- a/example_responses/services_response.json
+++ b/example_responses/services_response.json
@@ -71,8 +71,9 @@
         "assurance": "Service provider assertion",
         "value": true
       },
-      "frameworkName": "G-Cloud 6",
+      "frameworkName": "G-Cloud 8",
       "frameworkFramework": "g-cloud",
+      "frameworkSlug": "g-cloud-8",
       "freeOption": false,
       "governanceFramework": {
         "assurance": "Independent validation of assertion",


### PR DESCRIPTION

https://trello.com/c/nMkNMPhI/149-split-service-lists-by-frameworks

Separate long list of services into one table per framework
* Pass all frameworks to service list template (for ordering)
  * Update tests (give `data_api_client.find_frameworks` a return value)
* Iterate over frameworks, creating table for framework if services exist on framework
* Remove framework name column
* Change 'Service ID' column to 'ID'
* Provision for empty services list (will remain as before if no services)
* Change test services data to 'G Cloud 8' to match test frameworks data
  * Update tests
* New test ensuring tables exist in page and are in correct order


![screen shot 2017-11-15 at 15 51 32](https://user-images.githubusercontent.com/3469840/32845579-f52e609c-ca1c-11e7-9fa1-2950a1cdf794.png)
![screen shot 2017-11-15 at 15 51 52](https://user-images.githubusercontent.com/3469840/32845581-f8304dfa-ca1c-11e7-9c4d-db16de840128.png)