### PR TITLE
Show admins who removed a service and when

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -51,6 +51,18 @@ def view(service_id):
         flash({'api_error': service_id}, 'error')
         return redirect(url_for('.index'))
 
+    most_recent_audit_events = data_api_client.find_audit_events(
+        latest_first="true",
+        object_id=service_id,
+        object_type="services",
+        audit_type=AuditTypes.update_service_status
+    )
+    if most_recent_audit_events.get('auditEvents'):
+        last_updated_by = most_recent_audit_events['auditEvents'][0]['user']
+        last_updated_date = most_recent_audit_events['auditEvents'][0]['createdAt']
+    else:
+        last_updated_by = last_updated_date = None
+
     service_data['priceString'] = format_service_price(service_data)
     content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
 
@@ -58,7 +70,9 @@ def view(service_id):
         "view_service.html",
         sections=content.summary(service_data),
         service_data=service_data,
-        service_id=service_id
+        service_id=service_id,
+        last_updated_by=last_updated_by,
+        last_updated_date=last_updated_date,
     )
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -51,7 +51,7 @@ def view(service_id):
         flash({'api_error': service_id}, 'error')
         return redirect(url_for('.index'))
 
-    last_updated_by = last_updated_date = None
+    removed_by = removed_at = None
     if service_data['status'] != 'published':
         most_recent_audit_events = data_api_client.find_audit_events(
             latest_first="true",
@@ -60,8 +60,8 @@ def view(service_id):
             audit_type=AuditTypes.update_service_status
         )
         if most_recent_audit_events.get('auditEvents'):
-            last_updated_by = most_recent_audit_events['auditEvents'][0]['user']
-            last_updated_date = most_recent_audit_events['auditEvents'][0]['createdAt']
+            removed_by = most_recent_audit_events['auditEvents'][0]['user']
+            removed_at = most_recent_audit_events['auditEvents'][0]['createdAt']
 
     service_data['priceString'] = format_service_price(service_data)
     content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
@@ -71,8 +71,8 @@ def view(service_id):
         sections=content.summary(service_data),
         service_data=service_data,
         service_id=service_id,
-        last_updated_by=last_updated_by,
-        last_updated_date=last_updated_date,
+        removed_by=removed_by,
+        removed_at=removed_at,
     )
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -51,17 +51,17 @@ def view(service_id):
         flash({'api_error': service_id}, 'error')
         return redirect(url_for('.index'))
 
-    most_recent_audit_events = data_api_client.find_audit_events(
-        latest_first="true",
-        object_id=service_id,
-        object_type="services",
-        audit_type=AuditTypes.update_service_status
-    )
-    if most_recent_audit_events.get('auditEvents'):
-        last_updated_by = most_recent_audit_events['auditEvents'][0]['user']
-        last_updated_date = most_recent_audit_events['auditEvents'][0]['createdAt']
-    else:
-        last_updated_by = last_updated_date = None
+    last_updated_by = last_updated_date = None
+    if service_data['status'] != 'published':
+        most_recent_audit_events = data_api_client.find_audit_events(
+            latest_first="true",
+            object_id=service_id,
+            object_type="services",
+            audit_type=AuditTypes.update_service_status
+        )
+        if most_recent_audit_events.get('auditEvents'):
+            last_updated_by = most_recent_audit_events['auditEvents'][0]['user']
+            last_updated_date = most_recent_audit_events['auditEvents'][0]['createdAt']
 
     service_data['priceString'] = format_service_price(service_data)
     content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -47,6 +47,20 @@
     {% endif %}
   {% endwith %}
 
+{% if service_data['status'] != 'published' and last_updated_by %}
+<div class="grid-row">
+  <div class="column-one-whole">
+    {%
+      with
+      type = "temporary-message",
+      heading = "Removed by {} on ".format(last_updated_by) + "{}.".format(last_updated_date|dateformat)|nbsp
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  </div>
+</div>
+{% endif %}
+
   {% if service_data %}
     <div class="grid-row">
       <div class="service-title">

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -47,13 +47,13 @@
     {% endif %}
   {% endwith %}
 
-{% if service_data['status'] != 'published' and last_updated_by %}
+{% if service_data['status'] != 'published' and removed_by %}
 <div class="grid-row">
   <div class="column-one-whole">
     {%
       with
       type = "temporary-message",
-      heading = "Removed by {} on ".format(last_updated_by) + "{}.".format(last_updated_date|dateformat)|nbsp
+      heading = "Removed by {} on ".format(removed_by) + "{}.".format(removed_at|dateformat)|nbsp
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ flake8==2.6.2
 flake8-putty==0.4.0
 mock==2.0.0
 pytest==3.2.3
-pytest-cov==2.2.0
+pytest-cov==2.5.1
 python-coveralls==2.5.0
 requests-mock==0.6.0
 watchdog==0.8.3

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -364,6 +364,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             "lot": "digital-outcomes",
         }
         data_api_client.get_service.return_value = {'services': service}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
 
         response = self.client.get('/admin/services/123')
         assert response.status_code == 200
@@ -383,6 +384,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         }
 
         data_api_client.get_service.return_value = {'services': service}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
 
         response = self.client.get('/admin/services/123')
         assert response.status_code == 200
@@ -405,6 +407,7 @@ class TestServiceEdit(LoggedInApplicationTest):
         }
 
         data_api_client.get_service.return_value = {'services': service}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
 
         response = self.client.get('/admin/services/123')
         assert response.status_code == 200
@@ -734,7 +737,9 @@ class TestServiceUpdate(LoggedInApplicationTest):
         )
 
         assert response.status_code == 302
-        assert data_api_client.update_service.called_once_with('123', data, 'test@example.com')
+        assert data_api_client.update_service.call_args_list == [
+            mock.call('123', data, 'test@example.com', user_role='admin')
+        ]
 
     def test_service_update_with_multiquestion_validation_error(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -908,6 +913,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'supplierId': 2,
             'status': 'disabled'
         }}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response = self.client.get('/admin/services/1')
         assert b'<input type="radio" name="service_status" id="service_status_disabled" value="removed" checked="checked" />' in response.data  # noqa
         assert b'<input type="radio" name="service_status" id="service_status_private" value="private"  />' in response.data  # noqa
@@ -921,6 +927,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'supplierId': 2,
             'status': 'enabled'
         }}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response = self.client.get('/admin/services/1')
         assert b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />' in response.data  # noqa
         assert b'<input type="radio" name="service_status" id="service_status_private" value="private" checked="checked" />' in response.data  # noqa
@@ -934,6 +941,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'supplierId': 2,
             'status': 'published'
         }}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response = self.client.get('/admin/services/1')
         assert b'<input type="radio" name="service_status" id="service_status_disabled" value="removed"  />' in response.data  # noqa
         assert b'<input type="radio" name="service_status" id="service_status_private" value="private"  />' in response.data  # noqa
@@ -945,6 +953,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'serviceName': 'test',
             'supplierId': 1000,
         }}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'removed'})
         data_api_client.update_service_status.assert_called_with(
@@ -960,6 +969,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'serviceName': 'test',
             'supplierId': 1000,
         }}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'private'})
         data_api_client.update_service_status.assert_called_with(
@@ -975,6 +985,8 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'serviceName': 'test',
             'supplierId': 1000,
         }}
+
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'public'})
         data_api_client.update_service_status.assert_called_with(
@@ -990,6 +1002,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'serviceName': 'test',
             'supplierId': 1000,
         }}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response1 = self.client.post('/admin/services/status/1',
                                      data={'service_status': 'suspended'})
         assert response1.status_code == 302

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -211,6 +211,7 @@ class TestServiceView(LoggedInApplicationTest):
             'serviceName': 'test',
             'lot': 'iaas',
             'id': "314159265",
+            'supplierId': 1000,
             "status": service_status,
         }}
         data_api_client.find_audit_events.return_value = self.find_audit_events_api_response
@@ -222,6 +223,14 @@ class TestServiceView(LoggedInApplicationTest):
         assert len(document.xpath("//div[@class='banner-temporary-message-without-action']/h2")) == 1
         # Xpath doesn't handle non-breaking spaces well, so assert against page_content
         assert 'Removed by anne.admin@example.com on Friday&nbsp;17&nbsp;November&nbsp;2017.' in page_content
+        assert data_api_client.find_audit_events.call_args_list == [
+            mock.call(
+                latest_first="true",
+                object_id='314159265',
+                object_type="services",
+                audit_type=AuditTypes.update_service_status
+            )
+        ]
 
     def test_service_view_does_not_show_info_banner_for_public_services(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
@@ -229,6 +238,7 @@ class TestServiceView(LoggedInApplicationTest):
             'serviceName': 'test',
             'lot': 'iaas',
             'id': "314159265",
+            'supplierId': 1000,
             "status": 'published',
         }}
         data_api_client.find_audit_events.return_value = self.find_audit_events_api_response
@@ -237,6 +247,7 @@ class TestServiceView(LoggedInApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
         assert len(document.xpath("//div[@class='banner-temporary-message-without-action']/h2")) == 0
+        assert data_api_client.find_audit_events.called is False
 
     @pytest.mark.parametrize('service_status', ['disabled', 'enabled', 'published'])
     def test_service_view_hides_information_banner_if_no_audit_events(self, data_api_client, service_status):
@@ -245,6 +256,7 @@ class TestServiceView(LoggedInApplicationTest):
             'serviceName': 'test',
             'lot': 'iaas',
             'id': "314159265",
+            'supplierId': 1000,
             "status": service_status,
         }}
         data_api_client.find_audit_events.return_value = {'auditEvents': []}
@@ -292,6 +304,7 @@ class TestServiceView(LoggedInApplicationTest):
             'serviceName': 'test',
             'supplierId': 1000,
             'id': "1",
+            'status': 'published'
         }}
         response = self.client.get('/admin/services/1')
         assert b'Termination cost' in response.data
@@ -302,6 +315,7 @@ class TestServiceView(LoggedInApplicationTest):
             'serviceName': 'test',
             'supplierId': 1000,
             'id': "1",
+            'status': 'published'
         }}
         response = self.client.get('/admin/services/1')
         assert b'Termination cost' not in response.data
@@ -312,6 +326,7 @@ class TestServiceView(LoggedInApplicationTest):
             'serviceName': 'test',
             'supplierId': 1000,
             'id': "1",
+            'status': 'published'
         }}
         response = self.client.get('/admin/services/1')
         assert b'Termination cost' in response.data
@@ -323,6 +338,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'g-cloud-8',
             'id': "1",
+            'status': 'published'
         }}
         data_api_client.find_audit_events.return_value = self.find_audit_events_api_response
         response = self.client.get('/admin/services/1')
@@ -362,6 +378,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             "serviceName": "Test",
             "supplierId": 1000,
             "lot": "digital-outcomes",
+            'status': 'published'
         }
         data_api_client.get_service.return_value = {'services': service}
         data_api_client.find_audit_events.return_value = {'auditEvents': []}
@@ -381,6 +398,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             "supplierId": 1000,
             "lot": "digital-outcomes",
             "performanceAnalysisAndData": '',
+            'status': 'published'
         }
 
         data_api_client.get_service.return_value = {'services': service}
@@ -404,6 +422,7 @@ class TestServiceEdit(LoggedInApplicationTest):
             "supplierId": 1000,
             "lot": "digital-outcomes",
             "performanceAnalysisTypes": 'some value',
+            'status': 'published'
         }
 
         data_api_client.get_service.return_value = {'services': service}
@@ -952,6 +971,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'frameworkSlug': 'g-cloud-7',
             'serviceName': 'test',
             'supplierId': 1000,
+            'status': 'published',
         }}
         data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response1 = self.client.post('/admin/services/status/1',
@@ -968,6 +988,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'frameworkSlug': 'g-cloud-8',
             'serviceName': 'test',
             'supplierId': 1000,
+            'status': 'published',
         }}
         data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response1 = self.client.post('/admin/services/status/1',
@@ -984,6 +1005,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'frameworkSlug': 'digital-outcomes-and-specialists',
             'serviceName': 'test',
             'supplierId': 1000,
+            'status': 'enabled',
         }}
 
         data_api_client.find_audit_events.return_value = {'auditEvents': []}
@@ -1001,6 +1023,7 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
             'frameworkSlug': 'g-cloud-7',
             'serviceName': 'test',
             'supplierId': 1000,
+            'status': 'published',
         }}
         data_api_client.find_audit_events.return_value = {'auditEvents': []}
         response1 = self.client.post('/admin/services/status/1',


### PR DESCRIPTION
Trello ticket: https://trello.com/c/ytFyrbql/144-show-admins-who-removed-a-service-and-when

When a service has been removed (either by an admin user, or the supplier themselves), a banner is displayed in the admin saying who removed it and when. The date in the banner should have non-breaking spaces.

For a visible (Public) service there is no change:
![service-admin-info-banner-public](https://user-images.githubusercontent.com/3492540/32953738-062b0aca-cba9-11e7-9ca2-2ca259bf6331.png)

For removed/private services, we show the same banner whether it's been removed by the supplier or by an admin:
![service-admin-info-banner-private](https://user-images.githubusercontent.com/3492540/32953806-41d75682-cba9-11e7-99ef-164313e80fcf.png)
![service-admin-info-banner-removed](https://user-images.githubusercontent.com/3492540/32953847-5954f288-cba9-11e7-9ee8-c40feae4c5f5.png)

Happily there is a separate audit event for status changes, so finding the right event is straightforward.


