### PR TITLE
145 allow admins remove all services remove supplier from framework

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -530,6 +530,28 @@ def find_supplier_services(supplier_id):
     )
 
 
+@main.route('/suppliers/<int:supplier_id>/services', methods=['POST'])
+@role_required('admin', 'admin-ccs-category')
+def disable_supplier_services(supplier_id):
+    remove_services_for_framework = request.args.get('remove')
+    if not remove_services_for_framework:
+        abort(400, 'Invalid framework')
+
+    services = data_api_client.find_services(
+        supplier_id=supplier_id,
+        framework=remove_services_for_framework,
+        status='published'
+    )['services']
+    if not services:
+        abort(400, 'No published services on framework')
+
+    for service in services:
+        data_api_client.update_service_status(service['id'], 'disabled', current_user.email_address)
+
+    flash("You removed all of {}'s '{}' services".format(services[0]['supplierName'], services[0]['frameworkName']))
+    return redirect(url_for('.find_supplier_services', supplier_id=supplier_id))
+
+
 @main.route('/suppliers/<int:supplier_id>/invite-user', methods=['POST'])
 @role_required('admin')
 def invite_user(supplier_id):

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -35,6 +35,9 @@
       {% if framework['slug'] in frameworks_services %}
 
         {{ summary.heading(framework['name'], id="{}_services".format(framework['slug'])) }}
+        {% if 'published' in frameworks_services[framework['slug']]|map(attribute='status')|list %}
+          {{ summary.top_link("Remove services", url_for(".find_supplier_services", supplier_id=supplier.id, remove=framework.slug)) }}
+        {% endif %}
         {% call(item) summary.list_table(
           frameworks_services[framework['slug']],
           caption="Services",

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -22,9 +22,32 @@
   {% endwith %}
 {% endblock %}
 {% block main_content %}
-  {% with heading = "Services" %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+
+  {% block before_heading %}
+    {% if remove_services_for_framework %}
+      <div class="column-one-whole">
+        <form action="{{ url_for('main.disable_supplier_services', supplier_id=supplier.id, remove=remove_services_for_framework.slug) }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {%
+            with
+            message = "Are you sure you want to remove {}'s '{}' services?".format(supplier.name, remove_services_for_framework.name ),
+            type = "destructive",
+            action = '<button type="submit" class="button-destructive banner-action">Remove all services</button>'|safe
+          %}
+            {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+        </form>
+      </div>
+    {% endif %}
+
+  <div class="grid-row">
+    <div class="column-one-whole">
+      {% with heading = "Services" %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+    </div>
+  </div>
+
   {% if not frameworks_services %}
     {% call(item) summary.list_table(
       empty_message="This supplier has no services on the Digital Marketplace."

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -40,6 +40,15 @@
       </div>
     {% endif %}
 
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        {% with message = message, type = "destructive" if category == 'error' else 'success' %}
+          {% include "toolkit/notification-banner.html" %}
+        {% endwith %}
+      {% endfor %}
+    {% endwith %}
+  {% endblock %}
+
   <div class="grid-row">
     <div class="column-one-whole">
       {% with heading = "Services" %}


### PR DESCRIPTION
### Allow admins to remove supplier from framework 
#### (ie. set all `'published'` services to `'disabled'`)


* Add query parameter to GET route indicating framework to remove supplier from
  * Fail if the supplier has no published services on this framework
  * Otherwise return framework object to template
* Update template to include 'Remove all services link'
  * Do not show this if none of the services on a given framework are published
  * Otherwise link with param to same page
* Update template to  show 'Are you sure?' form in destructive banner if passed a framework
* Create POST route to disable all published services for a given supplier on a given framework
  * Fail if not passed a framework
  * Fail if the supplier has no published services on this framework
  * Otherwise set all published services for given supplier on given framework to disabled
  * Flash success message
* Update template to accept flash messages
* Tests



Trello:
https://trello.com/c/iMTKjWip/145-allow-admins-remove-all-services-remove-supplier-from-framework

Prototype:
https://docs.google.com/document/d/1OxIzuR9YGWEYuItYQoaMPF2q7uIyOlX1_eMP_OrbtRU/edit

Screenshots:
![supplier_services](https://user-images.githubusercontent.com/3469840/32959883-ece5da4c-cbba-11e7-873c-483d6061a3c4.png)
![supplier_services_remove](https://user-images.githubusercontent.com/3469840/32959882-ecc7e744-cbba-11e7-9c8d-cf722b9ff6bf.png)
![supplier_services_remove_success](https://user-images.githubusercontent.com/3469840/32959881-eca57eca-cbba-11e7-9724-a7ba1434acfe.png)


