### PR TITLE
New "list of admins" page for "admin managers"

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -4,7 +4,7 @@ from flask_login import current_user, login_required
 
 main = Blueprint('main', __name__)
 
-from .views import agreements, communications, service_updates, services, suppliers, stats, users, buyers
+from .views import agreements, communications, service_updates, services, suppliers, stats, users, buyers, admin_manager
 from app.main import errors
 
 

--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -1,0 +1,30 @@
+from flask import render_template
+
+from ... import data_api_client
+from .. import main
+
+from ..auth import role_required
+
+
+@main.route('/admin-users', methods=['GET'])
+@role_required('admin-manager')
+def manage_admin_users():
+    # The API doesn't support filtering users by multiple roles at once, and it's not worth adding that feature
+    # just for this one view that (currently, and for the foreseeable future) will be very rarely used.
+    # In future, if we have many many admin users and/or this page is heavily used we should:
+    # (1) Fix the API to allow fetching all relevant user roles with a single call
+    # (2) Stop using the _iter method and properly paginate this page
+
+    support_users = data_api_client.find_users_iter(role='admin')
+    category_users = data_api_client.find_users_iter(role='admin-ccs-category')
+    sourcing_users = data_api_client.find_users_iter(role='admin-ccs-sourcing')
+
+    # We want to sort so all Active users are above all Suspended users, and alphabetical by name within these groups.
+    # In Python False < True (False is zero, True is one) so sorting on "active is False" puts Active users first.
+    admin_users = sorted(
+        list(support_users) + list(category_users) + list(sourcing_users),
+        key=lambda k: (k['active'] is False, k['name'])
+    )
+
+    return render_template("view_admin_users.html",
+                           admin_users=admin_users)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -19,7 +19,7 @@ from ..helpers.diff_tools import html_diff_tables_from_sections_iter
 
 
 @main.route('', methods=['GET'])
-@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-manager')
 def index():
     frameworks = data_api_client.find_frameworks()
     frameworks = [fw for fw in frameworks['frameworks'] if fw['status'] in ('standstill', 'live')]

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -30,134 +30,130 @@
   {% endwith %}
 
   {% if current_user.has_role('admin-manager') %}
-      {% with items = [
-          {
-
-              "link": url_for('.manage_admin_users'),
-              "title": "Manage users"
-          },
-      ]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
+    {% with items = [
+      {
+        "link": url_for('.manage_admin_users'),
+        "title": "Manage users"
+      },
+    ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
   {% endif %}
 
   {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
-      <div class="grid-row">
-          <div class="column-two-thirds">
-              {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-              <form action="{{ url_for('.find') }}" method="get" class="question">
-                  <label class="question-heading" for="service_id">Find a service by service ID</label>
-                  <p class='hint'>
-                    eg 1234567890123456
-                  </p>
-                  <input type="text" name="service_id" id="service_id" class="text-box">
-                  <input type="submit" value="Search" class="button-save">
-              </form>
-              {% endif %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+        <form action="{{ url_for('.find') }}" method="get" class="question">
+          <label class="question-heading" for="service_id">Find a service by service ID</label>
+          <p class='hint'>
+            eg 1234567890123456
+          </p>
+          <input type="text" name="service_id" id="service_id" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+        </form>
+        {% endif %}
 
-              <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-                <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
-                <p class="hint">
-                  eg searching for c would give all suppliers starting with c
-                </p>
-                <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
-                <input type="submit" value="Search" class="button-save">
-              </form>
+        <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
+          <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
+          <p class="hint">
+            eg searching for c would give all suppliers starting with c
+          </p>
+          <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+        </form>
 
-              <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-                <label class="question-heading" for="supplier_duns_number">Find suppliers by DUNS number</label>
-                <p class="hint">
-                  DUNS numbers are usually 9 digits long, eg 234554321
-                </p>
-                <input type="text" name="supplier_duns_number" id="supplier_duns_number" class="text-box">
-                <input type="submit" value="Search" class="button-save">
-              </form>
+        <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
+          <label class="question-heading" for="supplier_duns_number">Find suppliers by DUNS number</label>
+          <p class="hint">
+            DUNS numbers are usually 9 digits long, eg 234554321
+          </p>
+          <input type="text" name="supplier_duns_number" id="supplier_duns_number" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+        </form>
 
-              {% if current_user.has_any_role('admin') %}
+        {% if current_user.has_any_role('admin') %}
 
-              <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-                  <label class="question-heading" for="email_address">Find users by email address</label>
-                  <p class='hint'>
-                    eg john@smokeyjoes.com
-                  </p>
-                  <input type="text" name="email_address" id="email_address" class="text-box">
-                  <input type="submit" value="Search" class="button-save">
-              </form>
+        <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
+          <label class="question-heading" for="email_address">Find users by email address</label>
+          <p class='hint'>
+            eg john@smokeyjoes.com
+          </p>
+          <input type="text" name="email_address" id="email_address" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+        </form>
 
-              <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-                  <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
-                  <p class='hint'>
-                    You can find this number at the end of the opportunities’ URL.
-                  </p>
-                  <input type="text" name="brief_id" id="brief_id" class="text-box">
-                  <input type="submit" value="Search" class="button-save">
-              </form>
+        <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+          <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
+          <p class='hint'>
+            You can find this number at the end of the opportunities’ URL.
+          </p>
+          <input type="text" name="brief_id" id="brief_id" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+        </form>
 
-              {% endif %}
-          </div>
+        {% endif %}
       </div>
+    </div>
   {% endif %}
 
 <div class="grid-row">
     <div class="column-two-thirds">
 
   {% if current_user.has_role('admin') %}
-      {% with items = [
-          {
-
-              "link": url_for('.add_buyer_domains'),
-              "title": "Add a buyer email domain"
-          },
-      ]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
+    {% with items = [
+      {
+        "link": url_for('.add_buyer_domains'),
+        "title": "Add a buyer email domain"
+      },
+    ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
   {% endif %}
 
   {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-      {% with
-          smaller = True,
-          heading = "Service edits"
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-      {% with items = [
-          {
-
-              "link": url_for('.service_update_audits'),
-              "title": "Check edits to services"
-          },
-      ]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
+    {% with
+      smaller = True,
+      heading = "Service edits"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    {% with items = [
+      {
+        "link": url_for('.service_update_audits'),
+        "title": "Check edits to services"
+      },
+    ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
   {% endif %}
 
-   {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
-      {% with
-          smaller = True,
-          heading = "Statistics"
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-      {% with items = [
-          {
-              "body": "View G-Cloud 9 statistics",
-              "link": "/admin/statistics/g-cloud-9",
-              "title": "G-Cloud 9 statistics"
-          }
-      ]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
-
-   {% endif %}
+  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
+    {% with
+      smaller = True,
+      heading = "Statistics"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    {% with items = [
+      {
+        "body": "View G-Cloud 9 statistics",
+        "link": "/admin/statistics/g-cloud-9",
+        "title": "G-Cloud 9 statistics"
+      }
+    ]
+    %}
+     {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+  {% endif %}
 
   {% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
     {% with
-        smaller = True,
-        heading = "Agreements"
+      smaller = True,
+      heading = "Agreements"
     %}
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
@@ -179,22 +175,22 @@
 
   {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
     {% set items = [
-        {
-          "body": "Manage G-Cloud 8 communications",
-          "link": url_for(".manage_communications", framework_slug="g-cloud-8"),
-          "title": "G-Cloud 8 communications"
-        },
-        {
-          "body": "Manage Digital Outcomes and Specialists 2 communications",
-          "link": url_for(".manage_communications", framework_slug="digital-outcomes-and-specialists-2"),
-          "title": "Digital Outcomes and Specialists 2 communications"
-        },
-        {
-          "body": "Manage G-Cloud 9 communications",
-          "link": url_for(".manage_communications", framework_slug="g-cloud-9"),
-          "title": "G-Cloud 9 communications"
-        }
-      ]
+      {
+        "body": "Manage G-Cloud 8 communications",
+        "link": url_for(".manage_communications", framework_slug="g-cloud-8"),
+        "title": "G-Cloud 8 communications"
+      },
+      {
+        "body": "Manage Digital Outcomes and Specialists 2 communications",
+        "link": url_for(".manage_communications", framework_slug="digital-outcomes-and-specialists-2"),
+        "title": "Digital Outcomes and Specialists 2 communications"
+      },
+      {
+        "body": "Manage G-Cloud 9 communications",
+        "link": url_for(".manage_communications", framework_slug="g-cloud-9"),
+        "title": "G-Cloud 9 communications"
+      }
+    ]
     %}
 
     {% if current_user.has_role('admin') %}
@@ -208,8 +204,8 @@
     {% endif %}
 
     {% with
-        smaller = True,
-        heading = "Communications"
+      smaller = True,
+      heading = "Communications"
     %}
       {% include "toolkit/page-heading.html" %}
     {% endwith %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -29,6 +29,19 @@
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
+  {% if current_user.has_role('admin-manager') %}
+      {% with items = [
+          {
+
+              "link": url_for('.manage_admin_users'),
+              "title": "Manage users"
+          },
+      ]
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+  {% endif %}
+
   {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
       <div class="grid-row">
           <div class="column-two-thirds">
@@ -121,22 +134,25 @@
       {% endwith %}
   {% endif %}
 
-  {% with
-      smaller = True,
-      heading = "Statistics"
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-  {% with items = [
-      {
-          "body": "View G-Cloud 9 statistics",
-          "link": "/admin/statistics/g-cloud-9",
-          "title": "G-Cloud 9 statistics"
-      }
-  ]
-  %}
-    {% include "toolkit/browse-list.html" %}
-  {% endwith %}
+   {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
+      {% with
+          smaller = True,
+          heading = "Statistics"
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+      {% with items = [
+          {
+              "body": "View G-Cloud 9 statistics",
+              "link": "/admin/statistics/g-cloud-9",
+              "title": "G-Cloud 9 statistics"
+          }
+      ]
+      %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
+
+   {% endif %}
 
   {% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
     {% with

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -1,0 +1,62 @@
+{% import "toolkit/summary-table.html" as summary %}
+
+{% extends "_base_page.html" %}
+
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+      {% for category, message in messages %}
+          {%
+          with
+              message = message,
+              type = "destructive" if category == 'error' else 'success'
+          %}
+          {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+      {% endfor %}
+  {% endif %}
+  {% endwith %}
+
+  {% with heading = "Manage users" %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+<div class="page-section">
+  {% set role_descriptors = {
+      "admin": "Support",
+      "admin-ccs-category": "Category",
+      "admin-ccs-sourcing": "Sourcing",
+    }
+  %}
+
+  {% call(item) summary.list_table(
+    admin_users,
+    caption="Admin users",
+    empty_message="No suppliers were found",
+    field_headings=["Name", "Email", "Permissions", "Status", summary.hidden_field_heading("Action")],
+    field_headings_visible=True)
+  %}
+    {% call summary.row() %}
+      {{ summary.field_name(item.name) }}
+      {{ summary.text(item.emailAddress) }}
+      {{ summary.text(role_descriptors[item.role]) }}
+      {{ summary.text("Active" if item.active else "Suspended") }}
+      {{ summary.edit_link("Edit", "http://url_for(....)") }}
+    {% endcall %}
+  {% endcall %}
+</div>
+{% endblock %}

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -1,0 +1,110 @@
+import mock
+import pytest
+
+from dmapiclient import HTTPError
+from lxml import html
+
+from ...helpers import LoggedInApplicationTest, Response
+
+
+@mock.patch("app.main.views.admin_manager.data_api_client")
+class TestAdminManagerListView(LoggedInApplicationTest):
+
+    SUPPORT_USERS = [
+        {"active": True,
+         "emailAddress": "support-1@example.com",
+         "name": "Rashguy Support",
+         "role": "admin",
+         },
+        {"active": True,
+         "emailAddress": "support-2@example.com",
+         "name": "Extra Support",
+         "role": "admin",
+         },
+    ]
+    CATEGORY_USERS = [
+        {"active": True,
+         "emailAddress": "category-support@example.com",
+         "name": "CCS Category Support",
+         "role": "admin-ccs-category",
+         },
+        {"active": False,
+         "emailAddress": "retired-category-support@example.com",
+         "name": "CCS Category Support - Retired",
+         "role": "admin-ccs-category",
+         },
+    ]
+    SOURCING_USERS = [
+        {"active": False,
+         "emailAddress": "old-sourcing-support@example.com",
+         "name": "Has-been Sourcing Support",
+         "role": "admin-ccs-sourcing",
+         },
+        {"active": True,
+         "emailAddress": "sourcing-support@example.com",
+         "name": "Sourcing Support",
+         "role": "admin-ccs-sourcing",
+         },
+    ]
+
+    @pytest.mark.parametrize("role_not_allowed", ["admin", "admin-ccs-category", "admin-ccs-sourcing"])
+    def test_should_403_forbidden_user_roles(self, data_api_client, role_not_allowed):
+        self.user_role = role_not_allowed
+        response = self.client.get("/admin/admin-users")
+        assert response.status_code == 403
+
+    def test_should_raise_http_error_from_api(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.find_users_iter.side_effect = HTTPError(Response(404))
+        response = self.client.get("/admin/admin-users")
+        assert response.status_code == 404
+
+    def test_should_list_admin_users(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.find_users_iter.side_effect = [
+            iter(self.SUPPORT_USERS),
+            iter(self.CATEGORY_USERS),
+            iter(self.SOURCING_USERS)
+        ]
+        response = self.client.get("/admin/admin-users")
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert response.status_code == 200
+        assert len(document.cssselect(".summary-item-row")) == 6
+
+    def test_should_list_alphabetically_with_all_suspended_users_below_active_users(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.find_users_iter.side_effect = [
+            iter(self.SUPPORT_USERS),
+            iter(self.CATEGORY_USERS),
+            iter(self.SOURCING_USERS)
+        ]
+        response = self.client.get("/admin/admin-users")
+        document = html.fromstring(response.get_data(as_text=True))
+
+        rows = document.cssselect(".summary-item-row")
+        # Active users in alphabetical order
+        assert "Active" in rows[0].text_content()
+        assert "Suspended" not in rows[0].text_content()
+        assert "CCS Category Support" in rows[0].text_content()
+
+        assert "Active" in rows[1].text_content()
+        assert "Suspended" not in rows[1].text_content()
+        assert "Extra Support" in rows[1].text_content()
+
+        assert "Active" in rows[2].text_content()
+        assert "Suspended" not in rows[2].text_content()
+        assert "Rashguy Support" in rows[2].text_content()
+
+        assert "Active" in rows[3].text_content()
+        assert "Suspended" not in rows[3].text_content()
+        assert "Sourcing Support" in rows[3].text_content()
+
+        # Deactivated users in alphabetical order
+        assert "Active" not in rows[4].text_content()
+        assert "Suspended" in rows[4].text_content()
+        assert "CCS Category Support - Retired" in rows[4].text_content()
+
+        assert "Active" not in rows[5].text_content()
+        assert "Suspended" in rows[5].text_content()
+        assert "Has-been Sourcing Support" in rows[5].text_content()

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -23,8 +23,10 @@ class TestIndex(LoggedInApplicationTest):
         assert 'Approve Framework 2 agreements for countersigning' in data
 
         # Agreements should be in reverse-chronological order.
-        assert data.index('Approve Framework 2 agreements for countersigning') < \
+        assert (
+            data.index('Approve Framework 2 agreements for countersigning') <
             data.index('Download Framework 1 agreements')
+        )
 
         # Only standstill/live agreements should be listed.
         assert 'Download Framework 3 agreements' not in data
@@ -40,8 +42,9 @@ class TestIndex(LoggedInApplicationTest):
         data = response.get_data(as_text=True)
         link_is_visible = "Add a buyer email domain" in data
 
-        assert link_is_visible is link_should_be_visible, \
+        assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", False),
@@ -55,5 +58,6 @@ class TestIndex(LoggedInApplicationTest):
         data = response.get_data(as_text=True)
         link_is_visible = "Manage users" in data
 
-        assert link_is_visible is link_should_be_visible, \
+        assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -42,3 +42,18 @@ class TestIndex(LoggedInApplicationTest):
 
         assert link_is_visible is link_should_be_visible, \
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", False),
+        ("admin-ccs-category", False),
+        ("admin-ccs-sourcing", False),
+        ("admin-manager", True),
+    ])
+    def test_manage_admin_users_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Manage users" in data
+
+        assert link_is_visible is link_should_be_visible, \
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")


### PR DESCRIPTION
For this ticket: https://trello.com/c/TmnwfAWT/147-super-admin-can-view-admins-their-role-and-status

The ticket says "No links yet, just a list", but I put the links in here - pointing to nothing - to get the structure of the table right.

Filling in the right links can then be done as part of the story to make the edit page (that @CrystalPea is currently working on).  I also added the flash message rendering to the top of the template for this page, so with luck that should just work when flash is set when admins are updated.

## Admins list page:
![screen shot 2017-11-22 at 16 59 11](https://user-images.githubusercontent.com/6525554/33139931-860e43d2-cfa6-11e7-8223-e45f0f217caa.png)


## Admin manager home page:
![screen shot 2017-11-22 at 17 00 04](https://user-images.githubusercontent.com/6525554/33139968-a0244442-cfa6-11e7-9102-c74e2e4d067d.png)
