### PR TITLE
155 allow admin manager to invite new admin users

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,5 +1,5 @@
 from flask.ext.wtf import Form
-from wtforms import validators
+from wtforms import RadioField, validators
 
 from dmutils.forms import StripWhitespaceStringField
 
@@ -34,3 +34,29 @@ class EmailDomainForm(Form):
     new_buyer_domain = StripWhitespaceStringField('Add a buyer email domain', validators=[
         validators.DataRequired(message="The domain field can not be empty.")
     ])
+
+
+class InviteAdminForm(Form):
+    role_choices = [
+        ('admin-ccs-category', 'Category'),
+        ('admin-ccs-sourcing', 'Sourcing'),
+        ('admin', 'Support'),
+    ]
+
+    email_address = StripWhitespaceStringField(
+        'Email address',
+        validators=[
+            validators.DataRequired(message='You must provide an email address'),
+            validators.Email(message='Please enter a valid email address'),
+            AdminEmailAddressValidator(message='The email address must belong to an approved domain')
+        ]
+    )
+    role = RadioField(
+        'Permissions',
+        validators=[validators.InputRequired(message='You must choose a permission')],
+        choices=role_choices
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(InviteAdminForm, self).__init__(*args, **kwargs)
+        self.role.toolkit_macro_options = [{'value': i[0], 'label': i[1]} for i in self.role_choices]

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,23 +1,24 @@
 from flask_wtf import Form
-from wtforms.validators import DataRequired, Email
+from wtforms import validators
+
 from dmutils.forms import StripWhitespaceStringField
 
 
 class EmailAddressForm(Form):
     email_address = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="Email can not be empty"),
-        Email(message="Please enter a valid email address")
+        validators.DataRequired(message="Email can not be empty"),
+        validators.Email(message="Please enter a valid email address")
     ])
 
 
 class MoveUserForm(Form):
     user_to_move_email_address = StripWhitespaceStringField('Move an existing user to this supplier', validators=[
-        DataRequired(message="Email can not be empty"),
-        Email(message="Please enter a valid email address")
+        validators.DataRequired(message="Email can not be empty"),
+        validators.Email(message="Please enter a valid email address")
     ])
 
 
 class EmailDomainForm(Form):
     new_buyer_domain = StripWhitespaceStringField('Add a buyer email domain', validators=[
-        DataRequired(message="The domain field can not be empty.")
+        validators.DataRequired(message="The domain field can not be empty.")
     ])

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -3,6 +3,18 @@ from wtforms import validators
 
 from dmutils.forms import StripWhitespaceStringField
 
+from .. import data_api_client
+
+
+class AdminEmailAddressValidator(object):
+
+    def __init__(self, message=None):
+        self.message = message
+
+    def __call__(self, form, field):
+        if not data_api_client.email_is_valid_for_admin_user(field.data):
+            raise validators.StopValidation(self.message)
+
 
 class EmailAddressForm(Form):
     email_address = StripWhitespaceStringField('Email address', validators=[

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,4 +1,4 @@
-from flask_wtf import Form
+from flask.ext.wtf import Form
 from wtforms import validators
 
 from dmutils.forms import StripWhitespaceStringField

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -1,0 +1,72 @@
+{% extends "_base_page.html" %}
+
+{% import "toolkit/forms/macros/forms.html" as forms %}
+{% set page_name = 'Invite a new admin user' %}
+{% block page_title %}{{ page_name }} – Digital Marketplace admin{% endblock %}
+{% block breadcrumb %}
+  {%
+    with items = [
+      {"link": url_for('.index'), "label": "Admin home"},
+      {"link": url_for('main.manage_admin_users'), "label": "Manage users"},
+      {"label": "Invite a new admin user"}
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+
+{% block main_content %}
+
+  {% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% with
+        heading = page_name,
+        smaller=True
+      %}
+      {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
+
+      <form method="POST" action="{{ url_for('.invite_admin_user') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {%
+              with
+              name = "email_address",
+              question = form.email_address.label.text,
+              type = "textbox",
+              value = form.email_address.data,
+              error = errors.get('email_address', {}).get('message', None)
+              %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+        {%
+              with
+              name = "role",
+              question = form.role.label.text,
+              type = "radio",
+              options = form.role.toolkit_macro_options,
+              value = form.role.data,
+              error = errors.get('role', {}).get('message', None)
+              %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+        {% block save_button %}
+          {%
+            with
+            label="Invite user",
+            name="submit",
+            type="save"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        {% endblock %}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -43,6 +43,7 @@
     }
   %}
 
+  {{ summary.top_link("Invite user", url_for(".invite_admin_user")) }}
   {% call(item) summary.list_table(
     admin_users,
     caption="Admin users",

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.4.0#egg=digitalmarketplace-apiclient==11.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.1.0#egg=digitalmarketplace-apiclient==12.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.4.0#egg=digitalmarketplace-apiclient==11.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.1.0#egg=digitalmarketplace-apiclient==12.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.23.0

--- a/tests/app/main/test_form_validators.py
+++ b/tests/app/main/test_form_validators.py
@@ -1,0 +1,34 @@
+import mock
+import pytest
+
+from flask.ext.wtf import Form
+from wtforms.fields.core import Field
+from wtforms.validators import StopValidation
+
+from app.main.forms import AdminEmailAddressValidator
+
+
+@mock.patch('app.main.forms.data_api_client')
+class TestAdminEmailAddressValidator(object):
+
+    def setup_method(self):
+        self.form_mock = mock.MagicMock(Form)
+        self.field_mock = mock.MagicMock(Field, data='the_email_address')
+
+        self.validator = AdminEmailAddressValidator(message='The message passed to validator')
+
+    def test_admin_email_address_validator_calls_api(self, data_api_client):
+        self.validator(self.form_mock, self.field_mock)
+        data_api_client.email_is_valid_for_admin_user.assert_called_once_with('the_email_address')
+
+    def test_admin_email_address_validator_raises_with_invalid_response(self, data_api_client):
+
+        data_api_client.email_is_valid_for_admin_user.return_value = False
+
+        with pytest.raises(StopValidation, match='The message passed to validator'):
+            self.validator(self.form_mock, self.field_mock)
+
+    def test_admin_email_address_validator_passes_with_valid_response(self, data_api_client):
+        data_api_client.email_is_valid_for_admin_user.return_value = True
+
+        assert self.validator(self.form_mock, self.field_mock) is None

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -110,6 +110,19 @@ class TestAdminManagerListView(LoggedInApplicationTest):
         assert "Suspended" in rows[5].text_content()
         assert "Has-been Sourcing Support" in rows[5].text_content()
 
+    def test_should_have_invite_user_link(self, data_api_client):
+        self.user_role = "admin-manager"
+        response = self.client.get("/admin/admin-users")
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert response.status_code == 200
+
+        expected_link_text = "Invite user"
+        expected_href = '/admin/admin-users/invite'
+        expected_link = document.xpath('.//a[contains(@href,"{}")]'.format(expected_href))[0]
+
+        assert expected_link.text == expected_link_text
+
 
 @mock.patch('app.main.forms.data_api_client', autospec=True)
 class TestInviteAdminUserView(LoggedInApplicationTest):


### PR DESCRIPTION

Trello:
https://trello.com/c/2Uc2WMl2/155-allow-super-admin-invite-new-admin-users
Prototype:
https://docs.google.com/document/d/1MjvYx9aQWgcbryiaGrRLOPt_lVm8gIbqOH3vmkKx_fo/edit#


* Refactor imports in `app/main/forms.py` to indicate function of imported classes
* Update `flask_wtf` import in app/main/forms.py to use newer `flask.ext.wtf`
* Up `dmapiclient` `11.4.0` > `12.1.0` to get new `email_is_valid_for_admin_user` method
* Add new validator in `app/main/forms.py` that applies `data_api_client.email_is_valid_for_admin_user` to a given field
* Add a new form `InviteAdminForm` with `email_address` and `role` fields
* Add new `GET`/`POST` route to invite a new admin user `app/main/views/admin_manager.py::invite_admin_user`
* Add new template `invite_admin_user.html` to display invite admin form
* Import new view into `app/main` so views are applied to app
* Add tests for new validator `app.main.forms.AdminEmailAddressValidator`
* Add tests for new view `app.main.views.admin_manager.invite_admin_user`


![manageusers](https://user-images.githubusercontent.com/3469840/33207661-70aca2fc-d106-11e7-968e-b339e20c4093.png)
![errors](https://user-images.githubusercontent.com/3469840/33207658-705fcedc-d106-11e7-9310-5dc9ea4a0626.png)
![invite](https://user-images.githubusercontent.com/3469840/33207660-7091d63e-d106-11e7-8606-db005bd6caf8.png)
![done](https://user-images.githubusercontent.com/3469840/33207659-7078f38a-d106-11e7-89e8-7f8bc23daab1.png)
