### PR TITLE
Adjust Support and Category role permissions

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -30,7 +30,7 @@ def _get_supplier_frameworks(framework_slug, status=None):
 
 
 @main.route('/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin', 'admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing')
 def list_agreements(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
@@ -56,7 +56,7 @@ def list_agreements(framework_slug):
 
 
 @main.route('/suppliers/<int:supplier_id>/agreements/<framework_slug>/next', methods=('GET',))
-@role_required('admin', 'admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing')
 def next_agreement(supplier_id, framework_slug):
     status = request.args.get("status")
     if status and status not in status_labels:

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -2,14 +2,14 @@ from dmapiclient import HTTPError
 from flask import flash, redirect, render_template, request, url_for
 from flask_login import current_user
 
-from ..forms import EmailDomainForm
 from .. import main
-from ... import data_api_client
 from ..auth import role_required
+from ..forms import EmailDomainForm
+from ... import data_api_client
 
 
 @main.route('/buyers', methods=['GET'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def find_buyer_by_brief_id():
     brief_id = request.args.get('brief_id')
 

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -1,3 +1,5 @@
+from dmutils import s3  # this style of import so we only have to mock once
+from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
 from flask import render_template, redirect, url_for, current_app, \
     request, flash
 
@@ -5,12 +7,9 @@ from .. import main
 from ..auth import role_required
 from ... import data_api_client
 
-from dmutils import s3  # this style of import so we only have to mock once
-from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
-
 
 @main.route('/communications/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-category')
+@role_required('admin-framework-manager')
 def manage_communications(framework_slug):
     communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
     framework = data_api_client.get_framework(framework_slug)['frameworks']
@@ -31,7 +30,7 @@ def manage_communications(framework_slug):
 
 
 @main.route('/communications/<framework_slug>', methods=['POST'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-framework-manager')
 def upload_communication(framework_slug):
     communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
     errors = {}

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -10,7 +10,7 @@ from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_fo
 
 
 @main.route('/communications/<framework_slug>', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def manage_communications(framework_slug):
     communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
     framework = data_api_client.get_framework(framework_slug)['frameworks']

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -48,7 +48,7 @@ def service_status_update_audits(day=None, page=1):
 
 
 @main.route('/services/updates/unapproved', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def service_update_audits():
     audit_events_response = data_api_client.find_audit_events(
         audit_type=AuditTypes.update_service,

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,21 +1,19 @@
-from flask import abort, current_app, flash, redirect, render_template, request, url_for
-from flask_login import current_user
 from collections import OrderedDict
 from itertools import chain, dropwhile, islice
 
 from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
 from dmcontent.formats import format_service_price
-from dmutils.documents import upload_service_documents
 from dmutils import s3  # this style of import so we only have to mock once
+from dmutils.documents import upload_service_documents
+from flask import abort, current_app, flash, redirect, render_template, request, url_for
+from flask_login import current_user
 
-
-from ... import data_api_client
-from ... import content_loader
 from .. import main
-
 from ..auth import role_required
 from ..helpers.diff_tools import html_diff_tables_from_sections_iter
+from ... import content_loader
+from ... import data_api_client
 
 
 @main.route('', methods=['GET'])
@@ -39,7 +37,7 @@ def find():
 
 
 @main.route('/services/<service_id>', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def view(service_id):
     try:
         service = data_api_client.get_service(service_id)
@@ -77,7 +75,7 @@ def view(service_id):
 
 
 @main.route('/services/status/<string:service_id>', methods=['POST'])
-@role_required('admin')
+@role_required('admin-ccs-category')
 def update_service_status(service_id):
     frontend_status = request.form['service_status']
 
@@ -111,7 +109,7 @@ def update_service_status(service_id):
 
 @main.route('/services/<service_id>/edit/<section_id>', methods=['GET'])
 @main.route('/services/<service_id>/edit/<section_id>/<question_slug>', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def edit(service_id, section_id, question_slug=None):
     service_data = data_api_client.get_service(service_id)['services']
 
@@ -229,7 +227,7 @@ def service_updates(service_id):
 
 @main.route('/services/<service_id>/edit/<section_id>', methods=['POST'])
 @main.route('/services/<service_id>/edit/<section_id>/<question_slug>', methods=['POST'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def update(service_id, section_id, question_slug=None):
     service = data_api_client.get_service(service_id)
     if service is None:

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -135,7 +135,7 @@ def edit(service_id, section_id, question_slug=None):
 
 
 @main.route('/services/<service_id>/updates', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def service_updates(service_id):
     service_response = data_api_client.get_service(service_id)
     if service_response is None:

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -12,7 +12,7 @@ from ..auth import role_required
 
 
 @main.route('/statistics/<string:framework_slug>', methods=['GET'])
-@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing')
 def view_statistics(framework_slug):
 
     snapshots = data_api_client.find_audit_events(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -90,7 +90,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin', 'admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing')
 def view_signed_agreement(supplier_id, framework_slug):
     # not properly validating this - all we do is pass it through
     next_status = request.args.get("next_status")
@@ -206,7 +206,7 @@ def download_signed_agreement_file(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>/<document_name>', methods=['GET'])
-@role_required('admin', 'admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing')
 def download_agreement_file(supplier_id, framework_slug, document_name):
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
     if supplier_framework is None or not supplier_framework.get("declaration"):

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,24 +2,24 @@ from collections import OrderedDict
 from itertools import groupby
 from operator import itemgetter
 
-from flask import render_template, request, redirect, url_for, abort, current_app
-from flask_login import current_user, flash
 from dateutil.parser import parse as parse_date
-
-from .. import main
-from ... import data_api_client, content_loader
-from ..forms import EmailAddressForm, MoveUserForm
-from ..auth import role_required
 from dmapiclient import HTTPError, APIError
 from dmapiclient.audit import AuditTypes
-from dmutils.email import send_user_account_email
+from dmutils import s3
 from dmutils.documents import (
     AGREEMENT_FILENAME, COUNTERPART_FILENAME,
     file_is_pdf, get_document_path, get_extension, get_signed_url,
     generate_timestamped_document_upload_path, degenerate_document_path_and_return_doc_name,
     generate_download_filename)
-from dmutils import s3
+from dmutils.email import send_user_account_email
 from dmutils.formats import datetimeformat
+from flask import render_template, request, redirect, url_for, abort, current_app
+from flask_login import current_user, flash
+
+from .. import main
+from ..auth import role_required
+from ..forms import EmailAddressForm, MoveUserForm
+from ... import data_api_client, content_loader
 
 
 @main.route('/suppliers', methods=['GET'])
@@ -494,7 +494,7 @@ def move_user_to_new_supplier(supplier_id):
 
 
 @main.route('/suppliers/<int:supplier_id>/services', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def find_supplier_services(supplier_id):
     remove_services_for_framework_slug = request.args.get('remove', None)
 
@@ -531,7 +531,7 @@ def find_supplier_services(supplier_id):
 
 
 @main.route('/suppliers/<int:supplier_id>/services', methods=['POST'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin-ccs-category')
 def disable_supplier_services(supplier_id):
     remove_services_for_framework = request.args.get('remove')
     if not remove_services_for_framework:

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,23 +1,23 @@
 from __future__ import unicode_literals
 
-from itertools import chain
 from collections import OrderedDict
+from datetime import datetime
+from itertools import chain
 
+from dmutils import csv_generator
 from flask import render_template, request, Response
 from flask_login import flash
-from datetime import datetime
-from dmutils import csv_generator
 from six import itervalues, iterkeys
 
 from .. import main
-from ... import data_api_client
 from ..auth import role_required
+from ... import data_api_client
 
 CLOSED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 
 
 @main.route('/users', methods=['GET'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def find_user_by_email_address():
     template = "view_users.html"
     users = None

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -42,7 +42,7 @@ def find_user_by_email_address():
 
 
 @main.route('/users/download', methods=['GET'])
-@role_required('admin')
+@role_required('admin-framework-manager')
 def list_frameworks_with_users(errors=None):
     bad_statuses = ['coming', 'expired']
     frameworks = [framework for framework in data_api_client.find_frameworks()['frameworks']

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -2,9 +2,12 @@
   "Name",
   summary.hidden_field_heading("Change name"),
   summary.hidden_field_heading("Users"),
-  summary.hidden_field_heading("Services"),
 ]
 %}
+
+{% if current_user.has_role('admin-ccs-category') %}
+  {% set field_headings = field_headings + [summary.hidden_field_heading("Services")] %}
+{% endif %}
 
 {% call(item) summary.list_table(
   suppliers,
@@ -18,7 +21,9 @@
     {{ summary.field_name(item.name) }}
     {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
     {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
-    {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
+    {% if current_user.has_role('admin-ccs-category') %}
+      {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
+    {% endif %}
   {% endcall %}
 
 {% endcall %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -73,7 +73,7 @@
           <input type="submit" value="Search" class="button-save">
         </form>
 
-        {% if current_user.has_any_role('admin') %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
         <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
           <label class="question-heading" for="email_address">Find users by email address</label>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -173,7 +173,7 @@
     {% endfor %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+  {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
     {% set items = [
       {
         "body": "Manage G-Cloud 8 communications",
@@ -193,7 +193,7 @@
     ]
     %}
 
-    {% if current_user.has_role('admin') %}
+    {% if current_user.has_role('admin-framework-manager') %}
       {% set items = items + [
         {
           "body": "Download a list of users for frameworks that are open, pending or live",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -131,7 +131,7 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin-ccs-category', 'admin-ccs-sourcing') %}
+  {% if current_user.has_any_role('admin-ccs-sourcing') %}
     {% with
       smaller = True,
       heading = "Statistics"
@@ -173,7 +173,7 @@
     {% endfor %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
+  {% if current_user.has_role('admin-framework-manager') %}
     {% set items = [
       {
         "body": "Manage G-Cloud 8 communications",
@@ -189,19 +189,14 @@
         "body": "Manage G-Cloud 9 communications",
         "link": url_for(".manage_communications", framework_slug="g-cloud-9"),
         "title": "G-Cloud 9 communications"
-      }
+      },
+      {
+        "body": "Download a list of users for frameworks that are open, pending or live",
+        "link": url_for(".list_frameworks_with_users"),
+        "title": "Download user lists"
+      },
     ]
     %}
-
-    {% if current_user.has_role('admin-framework-manager') %}
-      {% set items = items + [
-        {
-          "body": "Download a list of users for frameworks that are open, pending or live",
-          "link": url_for(".list_frameworks_with_users"),
-          "title": "Download user lists"
-        }]
-      %}
-    {% endif %}
 
     {% with
       smaller = True,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -113,7 +113,7 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+  {% if current_user.has_any_role('admin-ccs-category') %}
     {% with
       smaller = True,
       heading = "Service edits"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -131,7 +131,7 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
+  {% if current_user.has_any_role('admin-ccs-category', 'admin-ccs-sourcing') %}
     {% with
       smaller = True,
       heading = "Statistics"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -150,7 +150,7 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin', 'admin-ccs-sourcing') %}
+  {% if current_user.has_any_role('admin-ccs-sourcing') %}
     {% with
       smaller = True,
       heading = "Agreements"

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -102,7 +102,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           <br>
           {{ supplier_framework.countersignedAt|datetimeformat }}
         </p>
-        {% if supplier_framework.agreementStatus == 'approved' and current_user.role == 'admin-ccs-sourcing' %}
+        {% if supplier_framework.agreementStatus == 'approved' %}
         <form action="{{ url_for('.unapprove_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
@@ -115,7 +115,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           {% endwith %}
         </form>
         {% endif %}
-      {% elif current_user.role == 'admin-ccs-sourcing' %}
+      {% else %}
         <form action="{{ url_for('.approve_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -83,7 +83,7 @@
 
     {% for section in sections %}
       {{ summary.heading(section.name) }}
-      {% if section.editable and current_user.has_any_role('admin', 'admin-ccs-category') %}
+      {% if section.editable %}
         {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section_id=section.id)) }}
       {% endif %}
       {% call(question) summary.list_table(
@@ -107,31 +107,29 @@
       {% endcall %}
     {% endfor %}
 
-    {% if current_user.has_role('admin') %}
-      <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
-          <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
-          <fieldset class="question">
-              <legend class="question-heading">
-                  Service status
-              </legend>
-              <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service_data['status'] == 'disabled' %}checked="checked"{% endif %} />
-                  Removed
-              </label>
-              <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
-                  Private
-              </label>
-              {% if service_data.status != 'disabled' %}
-              <label class="selection-button">
-                  <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
-                  Public
-              </label>
-              {% endif %}
-          </fieldset>
-          <button type="submit" class="button-save">Update status</button>
-      </form>
-    {% endif %}
+    <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
+        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+        <fieldset class="question">
+            <legend class="question-heading">
+                Service status
+            </legend>
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service_data['status'] == 'disabled' %}checked="checked"{% endif %} />
+                Removed
+            </label>
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
+                Private
+            </label>
+            {% if service_data.status != 'disabled' %}
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
+                Public
+            </label>
+            {% endif %}
+        </fieldset>
+        <button type="submit" class="button-save">Update status</button>
+    </form>
 
   {% else %}
     <h1>Error</h1>

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -212,7 +212,7 @@ class TestListAgreements(LoggedInApplicationTest):
 
 @mock.patch('app.main.views.agreements.data_api_client')
 class TestNextAgreementRedirect(LoggedInApplicationTest):
-    user_role = 'admin'
+    user_role = 'admin-ccs-sourcing'
 
     @property
     def dummy_supplier_frameworks(self):

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -79,7 +79,7 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
         self.user_role = role
         response = self.client.get('/admin/buyers/add-buyer-domains')
         actual_code = response.status_code
-        assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 302),
@@ -94,7 +94,7 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
                                     }
                                     )
         actual_code = response.status_code
-        assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     def test_admin_user_can_add_a_new_buyer_domain(self, data_api_client):
         response1 = self.client.post('/admin/buyers/add-buyer-domains',

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -1,15 +1,25 @@
 import mock
 import pytest
-
 from dmapiclient import HTTPError
+from lxml import html
 
 from tests.app.main.helpers.flash_tester import assert_flashes
 from ...helpers import LoggedInApplicationTest
-from lxml import html
 
 
 @mock.patch('app.main.views.buyers.data_api_client')
 class TestBuyersView(LoggedInApplicationTest):
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 200),
+        ("admin-ccs-category", 200),
+        ("admin-ccs-sourcing", 403),
+        ("admin-manager", 403),
+    ])
+    def test_find_buyers_page_is_only_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+        self.user_role = role
+        response = self.client.get('/admin/buyers?brief_id=1')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     def test_should_be_a_404_if_no_brief_found(self, data_api_client):
         data_api_client.get_brief.return_value = None

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -26,7 +26,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         self.user_role = role
         response = self.client.get("/admin/communications/{}".format(self.framework_slug))
         actual_code = response.status_code
-        assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     @pytest.mark.parametrize("allowed_role", ["admin", "admin-ccs-category"])
     def test_post_documents_for_framework(self, data_api_client, allowed_role):

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -7,6 +7,7 @@ from ...helpers import LoggedInApplicationTest
 class TestIndex(LoggedInApplicationTest):
     @mock.patch('app.main.views.services.data_api_client')
     def test_index_shows_frameworks_in_standstill_or_live(self, data_api_client):
+        self.user_role = 'admin-ccs-sourcing'
         data_api_client.find_frameworks.return_value = {'frameworks': [
             {'id': 1, 'frameworkAgreementVersion': None, 'name': 'Framework 1', 'slug': 'framework-1',
              'status': 'standstill'},

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -36,6 +36,7 @@ class TestIndex(LoggedInApplicationTest):
         ("admin", True),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),
+        ("admin-manager", False),
     ])
     def test_add_buyer_email_domain_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
         self.user_role = role
@@ -58,6 +59,22 @@ class TestIndex(LoggedInApplicationTest):
         response = self.client.get('/admin')
         data = response.get_data(as_text=True)
         link_is_visible = "Manage users" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", False),
+        ("admin-ccs-category", True),
+        ("admin-ccs-sourcing", False),
+        ("admin-manager", False),
+    ])
+    def test_check_service_edits_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Check edits to services" in data
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -22,7 +22,7 @@ class TestStats(LoggedInApplicationTest):
         self.user_role = role
         response = self.client.get('/admin/statistics/g-cloud-7')
         actual_code = response.status_code
-        assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     def test_get_stats_page(self, data_api_client):
         data_api_client.find_audit_events.return_value = {

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 
 from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
@@ -7,6 +8,21 @@ from ...helpers import LoggedInApplicationTest
 
 @mock.patch('app.main.views.stats.data_api_client')
 class TestStats(LoggedInApplicationTest):
+    def setup_method(self, method, *args, **kwargs):
+        super(TestStats, self).setup_method(method, *args, **kwargs)
+        self.user_role = 'admin-ccs-sourcing'
+
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 403),
+        ("admin-ccs-category", 200),
+        ("admin-ccs-sourcing", 200),
+        ("admin-manager", 403),
+    ])
+    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+        self.user_role = role
+        response = self.client.get('/admin/statistics/g-cloud-7')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
 
     def test_get_stats_page(self, data_api_client):
         data_api_client.find_audit_events.return_value = {

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1652,7 +1652,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         self.set_mocks(s3, get_signed_url, data_api_client, agreement_status='signed')
         response = self.client.get("/admin/suppliers/1234/agreements/g-cloud-8")
         actual_code = response.status_code
-        assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     @pytest.mark.parametrize("next_status", (None, "on-hold", "approved,countersigned",))
     def test_buttons_shown_if_ccs_admin_and_agreement_signed(self, s3, get_signed_url, data_api_client, next_status):

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -253,6 +253,7 @@ class TestUsersExport(LoggedInApplicationTest):
 
     ##########################################################################
     def test_get_form_with_valid_framework(self, data_api_client):
+        self.user_role = 'admin-framework-manager'
         frameworks = [self._valid_framework]
         response = self._return_get_user_export_response(data_api_client, frameworks)
         assert response.status_code == 200


### PR DESCRIPTION
Changes required for these TWO tickets:
https://trello.com/c/GKq9PcC0/161-edit-permissions-for-dm-admins-support
https://trello.com/c/0iWPAKel/162-edit-permissions-for-category

These are rolled together because some permissions have moved from Support to Category and it was nice to be able to continue to test these functions rather than disable/comment out tests for actions that no user could perform.  For the same reason - to keep functionality testable - I have added the `admin-framework-manager` role to some routes, even though in theory we don't have this role defined yet (will be part of https://trello.com/c/iUS9D0ll/163-add-new-framework-manager-role).

I also added some extra test coverage where things didn't break when I expected them to.  (I haven't gone all-out on new tests for the index page yet though, as big changes so close on the horizon, we may as well sort out full coverage for that as the new design gets implemented.)

**Reviewer(s) note**: It might be easier to see how the view changes relate to test changes by looking through individual commits rather than the changeset as a whole.