### PR TITLE
152-admin-can-toggles-service-status-public-removed

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -37,7 +37,7 @@ def find():
 
 
 @main.route('/services/<service_id>', methods=['GET'])
-@role_required('admin-ccs-category')
+@role_required('admin', 'admin-ccs-category')
 def view(service_id):
     try:
         service = data_api_client.get_service(service_id)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -71,6 +71,8 @@ def view(service_id):
         service_id=service_id,
         removed_by=removed_by,
         removed_at=removed_at,
+        remove=request.args.get('remove', None),
+        publish=request.args.get('publish', None),
     )
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -84,7 +84,6 @@ def update_service_status(service_id):
     translate_frontend_to_api = {
         'removed': 'disabled',
         'public': 'published',
-        'private': 'enabled'
     }
 
     if frontend_status in translate_frontend_to_api.keys():

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -107,31 +107,6 @@
         {% endcall %}
       {% endcall %}
     {% endfor %}
-
-    <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
-        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
-        <fieldset class="question">
-            <legend class="question-heading">
-                Service status
-            </legend>
-            <label class="selection-button">
-                <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service_data['status'] == 'disabled' %}checked="checked"{% endif %} />
-                Removed
-            </label>
-            <label class="selection-button">
-                <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
-                Private
-            </label>
-            {% if service_data.status != 'disabled' %}
-            <label class="selection-button">
-                <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
-                Public
-            </label>
-            {% endif %}
-        </fieldset>
-        <button type="submit" class="button-save">Update status</button>
-    </form>
-
   {% else %}
     <h1>Error</h1>
     <p>

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -71,15 +71,16 @@
       {% include "toolkit/page-heading.html" %}
     {% endwith %}
 
-    {% if service_data['frameworkFramework'] == 'g-cloud' %}
-      {%
-        with
-        url = "/{}/services/{}".format(service_data['frameworkFramework'], service_id),
-        text = "View service"
-      %}
-        {% include "toolkit/secondary-action-link.html" %}
-      {% endwith %}
-    {% endif %}
+    {# links #}
+    <ul class="list-no-bullet">
+      {% if service_data['frameworkFramework'] == 'g-cloud' %}
+        <li><a href="{{ "/{}/services/{}".format(service_data['frameworkFramework'], service_id) }}">View service</a></li>
+      {% endif %}
+      {% if current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
+        <li><a href="{{ url_for('.view', service_id=service_id, remove=True) }}">Remove service</a></li>
+      {% endif %}
+    </ul>
+    {# endlinks #}
 
     {% for section in sections %}
       {{ summary.heading(section.name) }}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -25,41 +25,81 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        {% if category == 'error' %}
-            <div class="banner-destructive-without-action">
-        {% else %}
-            <div class="banner-success-without-action">
-        {% endif %}
-        <p class="banner-message">
-          {% if message['bad_status'] %}
-            Not a valid status: '{{ message['bad_status'] }}'
-          {% elif message['status_error'] %}
-            Error trying to update status of service: {{ message['status_error'] }}
-          {% elif message['status_updated'] %}
-            Service status has been updated to: {{ message['status_updated']|title }}
-          {% endif %}
-        </p>
-      {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% block before_heading %}
 
-{% if service_data['status'] != 'published' and removed_by %}
-<div class="grid-row">
-  <div class="column-one-whole">
-    {%
-      with
-      type = "temporary-message",
-      heading = "Removed by {} on ".format(removed_by) + "{}.".format(removed_at|dateformat)|nbsp
-    %}
-      {% include "toolkit/notification-banner.html" %}
+    {# banners #}
+    {% if publish and current_user.has_role('admin-ccs-category') and service_data['status'] != 'published' %}
+        <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          <input type="hidden" name="service_status" value="public" />
+          {%
+            with
+            message = "Are you sure you want to publish ‘{}’?".format(
+              service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName']
+            ),
+            type = "destructive",
+            action = '<button type="submit" class="button-destructive banner-action">Publish</button>'|safe
+          %}
+            {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+        </form>
+    {% endif %}
+
+    {% if remove and current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
+      <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="hidden" name="service_status" value="removed" />
+        {%
+          with
+          message = "Are you sure you want to remove ‘{}’?".format(
+            service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName']
+          ),
+          type = "destructive",
+          action = '<button type="submit" class="button-destructive banner-action">Remove</button>'|safe
+        %}
+          {% include "toolkit/notification-banner.html" %}
+        {% endwith %}
+      </form>
+    {% endif %}
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        {% with message = message, type = "destructive" if category == 'error' else 'success' %}
+          {% if message['status_updated'] %}
+            {% if message['status_updated'] == 'public' %}
+              {% set message = "You published ‘{}’.".format(service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName']) %}
+              {% include "toolkit/notification-banner.html" %}
+            {% endif %}
+          {% elif message['bad_status'] %}
+            {% set message = "Not a valid status: {}".format(message['bad_status']) %}
+            {% include "toolkit/notification-banner.html" %}
+          {% elif message['status_error'] %}
+            {% set message = "Error trying to update status of service: ".format(message['status_error']) %}
+            {% include "toolkit/notification-banner.html" %}
+          {% else %}
+            {% include "toolkit/notification-banner.html" %}
+          {% endif %}
+        {% endwith %}
+      {% endfor %}
     {% endwith %}
-  </div>
-</div>
-{% endif %}
+
+    {% if service_data['status'] != 'published' and removed_by %}
+      {%
+        with
+        type = "temporary-message",
+        heading = "Removed by {} on ".format(removed_by) + "{}.".format(removed_at|dateformat)|nbsp,
+        message = (
+          ("<a href='{}'>Publish service</a>"|safe).format(url_for('.view', service_id=service_id, publish=True))
+          if current_user.has_role('admin-ccs-category') else ""
+        )
+      %}
+        {% include "toolkit/notification-banner.html" %}
+      {% endwith %}
+    {% endif %}
+    {# endbanners #}
+
+  {% endblock %}
+
 
   {% if service_data %}
     {%


### PR DESCRIPTION
Trello:
https://trello.com/c/sco9Pz3H/152-admin-can-toggles-service-status-public-removed

Prototype:
https://docs.google.com/document/d/1lRu5a4hx6ZLy77eiVKtjhKvrFdBzR1iiRlUGWlyVXYE/edit

* Allow `publish` and `remove` query params on view service view
  * Propagate these back to template
* Remove old update status form on bottom of page
  * Update tests for this
* Add 'Remove service' link for admins if service not `published`
* Add 'Publish service' link for admins if service not `published`
  * Link on 'This service was removed by' banner
* Add new 'Are you sure you want to publish' banner, with action to puplish
* Add new 'Are you sure you want to remove' banner with action to remove
* Tests, including updates to existing

![screen shot 2017-11-30 at 14 54 04](https://user-images.githubusercontent.com/3469840/33436947-63bdc15c-d5de-11e7-9789-846ca0d18c52.png)


<img width="737" alt="screen shot 2017-11-29 at 17 14 20" src="https://user-images.githubusercontent.com/3469840/33388918-361e302a-d529-11e7-837c-0a1b143abbef.png">


![screen shot 2017-11-29 at 17 14 29](https://user-images.githubusercontent.com/3469840/33388922-3a1b6c06-d529-11e7-96af-ab3cb0844897.png)


<img width="739" alt="screen shot 2017-11-29 at 17 14 40" src="https://user-images.githubusercontent.com/3469840/33388926-3dedcd74-d529-11e7-95ed-b7b18ad01124.png">


![screen shot 2017-11-29 at 17 14 51](https://user-images.githubusercontent.com/3469840/33388931-41c11ea6-d529-11e7-9652-fcd935482ee6.png)

