### PR TITLE
163 Add new 'admin-framework-manager' role

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -70,6 +70,7 @@ class EditAdminUserForm(Form):
 
     permissions_choices = [
         ("admin-ccs-category", "Category"),
+        ('admin-framework-manager', 'Framework Manager'),
         ("admin-ccs-sourcing", "Sourcing"),
         ("admin", "Support"),
     ]

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -39,6 +39,7 @@ class EmailDomainForm(Form):
 class InviteAdminForm(Form):
     role_choices = [
         ('admin-ccs-category', 'Category'),
+        ('admin-framework-manager', 'Framework Manager'),
         ('admin-ccs-sourcing', 'Sourcing'),
         ('admin', 'Support'),
     ]

--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -24,11 +24,12 @@ def manage_admin_users():
     support_users = data_api_client.find_users_iter(role='admin')
     category_users = data_api_client.find_users_iter(role='admin-ccs-category')
     sourcing_users = data_api_client.find_users_iter(role='admin-ccs-sourcing')
+    framework_manager_users = data_api_client.find_users_iter(role='admin-framework-manager')
 
     # We want to sort so all Active users are above all Suspended users, and alphabetical by name within these groups.
     # In Python False < True (False is zero, True is one) so sorting on "active is False" puts Active users first.
     admin_users = sorted(
-        list(support_users) + list(category_users) + list(sourcing_users),
+        list(support_users) + list(category_users) + list(sourcing_users) + list(framework_manager_users),
         key=lambda k: (k['active'] is False, k['name'])
     )
 

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -56,7 +56,7 @@ def list_agreements(framework_slug):
 
 
 @main.route('/suppliers/<int:supplier_id>/agreements/<framework_slug>/next', methods=('GET',))
-@role_required('admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
 def next_agreement(supplier_id, framework_slug):
     status = request.args.get("status")
     if status and status not in status_labels:

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -30,7 +30,7 @@ def _get_supplier_frameworks(framework_slug, status=None):
 
 
 @main.route('/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing', 'admin-framework-manager')
 def list_agreements(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
@@ -56,7 +56,7 @@ def list_agreements(framework_slug):
 
 
 @main.route('/suppliers/<int:supplier_id>/agreements/<framework_slug>/next', methods=('GET',))
-@role_required('admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing', 'admin-framework-manager')
 def next_agreement(supplier_id, framework_slug):
     status = request.args.get("status")
     if status and status not in status_labels:

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -30,7 +30,7 @@ def _get_supplier_frameworks(framework_slug, status=None):
 
 
 @main.route('/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
 def list_agreements(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -17,7 +17,7 @@ from ... import data_api_client
 
 
 @main.route('', methods=['GET'])
-@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-manager')
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-manager')
 def index():
     frameworks = data_api_client.find_frameworks()
     frameworks = [fw for fw in frameworks['frameworks'] if fw['status'] in ('standstill', 'live')]

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -28,7 +28,7 @@ def index():
 
 
 @main.route('/services', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
 def find():
     if request.args.get("service_id") is None:
         return render_template("index.html"), 404
@@ -37,7 +37,7 @@ def find():
 
 
 @main.route('/services/<service_id>', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
 def view(service_id):
     try:
         service = data_api_client.get_service(service_id)

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -11,7 +11,7 @@ from ... import data_api_client
 
 
 @main.route('/statistics/<string:framework_slug>', methods=['GET'])
-@role_required('admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing', 'admin-framework-manager')
 def view_statistics(framework_slug):
 
     snapshots = data_api_client.find_audit_events(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -494,7 +494,7 @@ def move_user_to_new_supplier(supplier_id):
 
 
 @main.route('/suppliers/<int:supplier_id>/services', methods=['GET'])
-@role_required('admin-ccs-category')
+@role_required('admin-ccs-category', 'admin-framework-manager')
 def find_supplier_services(supplier_id):
     remove_services_for_framework_slug = request.args.get('remove', None)
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -23,7 +23,7 @@ from ... import data_api_client, content_loader
 
 
 @main.route('/suppliers', methods=['GET'])
-@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing')
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
 def find_suppliers():
     if request.args.get("supplier_id"):
         suppliers = [data_api_client.get_supplier(request.args.get("supplier_id"))['suppliers']]

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -494,7 +494,7 @@ def move_user_to_new_supplier(supplier_id):
 
 
 @main.route('/suppliers/<int:supplier_id>/services', methods=['GET'])
-@role_required('admin-ccs-category', 'admin-framework-manager')
+@role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
 def find_supplier_services(supplier_id):
     remove_services_for_framework_slug = request.args.get('remove', None)
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -90,7 +90,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
 def view_signed_agreement(supplier_id, framework_slug):
     # not properly validating this - all we do is pass it through
     next_status = request.args.get("next_status")
@@ -197,7 +197,7 @@ def unapprove_agreement_for_countersignature(agreement_id):
 
 
 @main.route('/suppliers/<supplier_id>/agreement/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
 def download_signed_agreement_file(supplier_id, framework_slug):
     # This route is used for pre-G-Cloud-8 agreement document downloads
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
@@ -206,7 +206,7 @@ def download_signed_agreement_file(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>/<document_name>', methods=['GET'])
-@role_required('admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
 def download_agreement_file(supplier_id, framework_slug, document_name):
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
     if supplier_framework is None or not supplier_framework.get("declaration"):

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -90,7 +90,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing', 'admin-framework-manager')
 def view_signed_agreement(supplier_id, framework_slug):
     # not properly validating this - all we do is pass it through
     next_status = request.args.get("next_status")
@@ -197,7 +197,7 @@ def unapprove_agreement_for_countersignature(agreement_id):
 
 
 @main.route('/suppliers/<supplier_id>/agreement/<framework_slug>', methods=['GET'])
-@role_required('admin', 'admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing', 'admin-framework-manager')
 def download_signed_agreement_file(supplier_id, framework_slug):
     # This route is used for pre-G-Cloud-8 agreement document downloads
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
@@ -206,7 +206,7 @@ def download_signed_agreement_file(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>/<document_name>', methods=['GET'])
-@role_required('admin-ccs-sourcing')
+@role_required('admin-ccs-sourcing', 'admin-framework-manager')
 def download_agreement_file(supplier_id, framework_slug, document_name):
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
     if supplier_framework is None or not supplier_framework.get("declaration"):

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -404,7 +404,7 @@ def update_supplier_declaration_section(supplier_id, framework_slug, section_id)
 
 
 @main.route('/suppliers/users', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
 def find_supplier_users():
 
     if not request.args.get('supplier_id'):

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -42,7 +42,7 @@ def find_user_by_email_address():
 
 
 @main.route('/users/download', methods=['GET'])
-@role_required('admin-framework-manager')
+@role_required('admin', 'admin-framework-manager')
 def list_frameworks_with_users(errors=None):
     bad_statuses = ['coming', 'expired']
     frameworks = [framework for framework in data_api_client.find_frameworks()['frameworks']
@@ -60,7 +60,7 @@ def list_frameworks_with_users(errors=None):
 
 
 @main.route('/users/download/<framework_slug>', methods=['GET'])
-@role_required('admin')
+@role_required('admin', 'admin-framework-manager')
 def download_users(framework_slug):
     supplier_rows = data_api_client.export_users(framework_slug).get('users', [])
     supplier_headers = [
@@ -90,7 +90,7 @@ def download_users(framework_slug):
 
 
 @main.route('/users/download/buyers', methods=['GET'])
-@role_required('admin')
+@role_required('admin', 'admin-framework-manager')
 def download_buyers_and_briefs():
     users = {user["id"]: dict(user, briefs=[]) for user in data_api_client.find_users_iter(role="buyer")}
 

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -2,14 +2,11 @@
   "Name",
   summary.hidden_field_heading("Change name"),
   summary.hidden_field_heading("Users"),
+  summary.hidden_field_heading("Services")
 ]
 %}
 
-{% if current_user.has_role('admin-ccs-category') %}
-  {% set field_headings = field_headings + [summary.hidden_field_heading("Services")] %}
-{% endif %}
-
-{% if current_user.has_any_role('admin', 'admin-framework-manager') %}
+{% if current_user.has_role('admin-framework-manager') %}
   {% set field_headings = [
       "Name",
       summary.hidden_field_heading("Users"),
@@ -28,7 +25,7 @@
 
   {% call summary.row() %}
     {{ summary.field_name(item.name) }}
-    {% if current_user.has_role('admin-ccs-category') %}
+    {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
       {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
     {% endif %}
     {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -32,9 +32,7 @@
       {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
     {% endif %}
     {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
-    {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
-      {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
-    {% endif %}
+    {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
   {% endcall %}
 
 {% endcall %}

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -9,6 +9,15 @@
   {% set field_headings = field_headings + [summary.hidden_field_heading("Services")] %}
 {% endif %}
 
+{% if current_user.has_role('admin-framework-manager') %}
+  {% set field_headings = [
+      "Name",
+      summary.hidden_field_heading("Users"),
+      summary.hidden_field_heading("Services")
+    ]
+  %}
+{% endif %}
+
 {% call(item) summary.list_table(
   suppliers,
   caption="Suppliers",
@@ -19,9 +28,11 @@
 
   {% call summary.row() %}
     {{ summary.field_name(item.name) }}
-    {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
-    {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
     {% if current_user.has_role('admin-ccs-category') %}
+      {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
+    {% endif %}
+    {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
+    {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
       {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
     {% endif %}
   {% endcall %}

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -9,7 +9,7 @@
   {% set field_headings = field_headings + [summary.hidden_field_heading("Services")] %}
 {% endif %}
 
-{% if current_user.has_role('admin-framework-manager') %}
+{% if current_user.has_any_role('admin', 'admin-framework-manager') %}
   {% set field_headings = [
       "Name",
       summary.hidden_field_heading("Users"),
@@ -32,7 +32,7 @@
       {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
     {% endif %}
     {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
-    {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
+    {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
       {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
     {% endif %}
   {% endcall %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,10 +41,10 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing') %}
+  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager') %}
     <div class="grid-row">
       <div class="column-two-thirds">
-        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
         <form action="{{ url_for('.find') }}" method="get" class="question">
           <label class="question-heading" for="service_id">Find a service by service ID</label>
           <p class='hint'>
@@ -131,7 +131,7 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin-ccs-sourcing') %}
+  {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
     {% with
       smaller = True,
       heading = "Statistics"
@@ -150,7 +150,7 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin-ccs-sourcing') %}
+  {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
     {% with
       smaller = True,
       heading = "Agreements"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -150,7 +150,7 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
+  {% if current_user.has_any_role('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager') %}
     {% with
       smaller = True,
       heading = "Agreements"

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -102,7 +102,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           <br>
           {{ supplier_framework.countersignedAt|datetimeformat }}
         </p>
-        {% if supplier_framework.agreementStatus == 'approved' %}
+        {% if current_user.has_role('admin-ccs-sourcing') and supplier_framework.agreementStatus == 'approved' %}
         <form action="{{ url_for('.unapprove_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
@@ -115,7 +115,7 @@ Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration
           {% endwith %}
         </form>
         {% endif %}
-      {% else %}
+      {% elif current_user.has_role('admin-ccs-sourcing') %}
         <form action="{{ url_for('.approve_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -40,6 +40,7 @@
       "admin": "Support",
       "admin-ccs-category": "Category",
       "admin-ccs-sourcing": "Sourcing",
+      "admin-framework-manager": "Framework Manager",
     }
   %}
 

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -21,6 +21,8 @@
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
+  {% if current_user.has_role('admin-ccs-sourcing') %}
+  {# ### Don't show instructions for read-only users ### #}
   <div class="grid-row">
     <div class="column-two-thirds dmspeak">
       <div class="lead">
@@ -34,6 +36,7 @@
       </div>
     </div>
   </div>
+  {% endif %}
 
   <div class="grid-row">
     <div class="column-one-third search-page-filters">

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -147,33 +147,6 @@
         {% endcall %}
       {% endcall %}
     {% endfor %}
-
-    {% if current_user.has_role('admin-ccs-category') %}
-    <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
-        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
-        <fieldset class="question">
-            <legend class="question-heading">
-                Service status
-            </legend>
-            <label class="selection-button">
-                <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service_data['status'] == 'disabled' %}checked="checked"{% endif %} />
-                Removed
-            </label>
-            <label class="selection-button">
-                <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
-                Private
-            </label>
-            {% if service_data.status != 'disabled' %}
-            <label class="selection-button">
-                <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
-                Public
-            </label>
-            {% endif %}
-        </fieldset>
-        <button type="submit" class="button-save">Update status</button>
-    </form>
-    {% endif %}
-
   {% else %}
     <h1>Error</h1>
     <p>

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -124,7 +124,7 @@
 
     {% for section in sections %}
       {{ summary.heading(section.name) }}
-      {% if section.editable %}
+      {% if section.editable and current_user.has_role('admin-ccs-category') %}
         {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section_id=section.id)) }}
       {% endif %}
       {% call(question) summary.list_table(
@@ -140,13 +140,40 @@
         {% call summary.row() %}
           {{ summary.field_name(question.label) }}
           {{ summary[question.type](question.value, question.assurance) }}
-          {% if section.edit_questions %}
+          {% if section.edit_questions and current_user.has_role('admin-ccs-category') %}
             {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for('.edit', service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
           {% endif %}
 
         {% endcall %}
       {% endcall %}
     {% endfor %}
+
+    {% if current_user.has_role('admin-ccs-category') %}
+    <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="post">
+        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+        <fieldset class="question">
+            <legend class="question-heading">
+                Service status
+            </legend>
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_disabled" value="removed" {% if service_data['status'] == 'disabled' %}checked="checked"{% endif %} />
+                Removed
+            </label>
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_private" value="private" {% if service_data['status'] == 'enabled' %}checked="checked"{% endif %} />
+                Private
+            </label>
+            {% if service_data.status != 'disabled' %}
+            <label class="selection-button">
+                <input type="radio" name="service_status" id="service_status_published" value="public" {% if service_data['status'] == 'published' %}checked="checked"{% endif %} />
+                Public
+            </label>
+            {% endif %}
+        </fieldset>
+        <button type="submit" class="button-save">Update status</button>
+    </form>
+    {% endif %}
+
   {% else %}
     <h1>Error</h1>
     <p>

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -71,15 +71,11 @@
           {{ summary.top_link("Remove services", url_for(".find_supplier_services", supplier_id=supplier.id, remove=framework.slug)) }}
         {% endif %}
 
-        {% set field_headings = ['Name', 'ID', 'Lot', 'Status'] %}
-        {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
-          {% set field_headings = field_headings + [summary.hidden_field_heading("Action")] %}
-        {% endif %}
         {% call(item) summary.list_table(
           frameworks_services[framework['slug']],
           caption="Services",
           empty_message="This supplier has no services on the {} framework.".format(framework['name']),
-          field_headings=field_headings,
+          field_headings=['Name', 'ID', 'Lot', 'Status', summary.hidden_field_heading("Action")],
           field_headings_visible=True
         ) %}
           {% call summary.row() %}
@@ -105,11 +101,11 @@
                 {% endif %}
               </span>
             {% endcall %}
-            {% if current_user.has_role('admin-ccs-category') %}
-              {{ summary.edit_link('Edit', url_for('.view', service_id=item.id)) }}
-            {% elif current_user.has_any_role('admin', 'admin-framework-manager') %}
-              {{ summary.edit_link('View', url_for('.view', service_id=item.id)) }}
-            {% endif %}
+            {{ summary.edit_link(
+                 'Edit' if current_user.has_role('admin-ccs-category') else 'View',
+                 url_for('.view', service_id=item.id)
+               )
+            }}
           {% endcall %}
         {% endcall %}
       {% endif %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -67,20 +67,19 @@
       {% if framework['slug'] in frameworks_services %}
 
         {{ summary.heading(framework['name'], id="{}_services".format(framework['slug'])) }}
-        {% if 'published' in frameworks_services[framework['slug']]|map(attribute='status')|list %}
+        {% if 'published' in frameworks_services[framework['slug']]|map(attribute='status')|list and current_user.has_role('admin-ccs-category') %}
           {{ summary.top_link("Remove services", url_for(".find_supplier_services", supplier_id=supplier.id, remove=framework.slug)) }}
+        {% endif %}
+
+        {% set field_headings = ['Name', 'ID', 'Lot', 'Status'] %}
+        {% if current_user.has_role('admin-ccs-category') %}
+          {% set field_headings = field_headings + [summary.hidden_field_heading("Action")] %}
         {% endif %}
         {% call(item) summary.list_table(
           frameworks_services[framework['slug']],
           caption="Services",
           empty_message="This supplier has no services on the {} framework.".format(framework['name']),
-          field_headings=[
-            'Name',
-            'ID',
-            'Lot',
-            'Status',
-            summary.hidden_field_heading("Action")
-          ],
+          field_headings=field_headings,
           field_headings_visible=True
         ) %}
           {% call summary.row() %}
@@ -106,7 +105,9 @@
                 {% endif %}
               </span>
             {% endcall %}
-            {{ summary.edit_link('Edit', url_for('.view', service_id=item.id)) }}
+            {% if current_user.has_role('admin-ccs-category') %}
+              {{ summary.edit_link('Edit', url_for('.view', service_id=item.id)) }}
+            {% endif %}
           {% endcall %}
         {% endcall %}
       {% endif %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -72,7 +72,7 @@
         {% endif %}
 
         {% set field_headings = ['Name', 'ID', 'Lot', 'Status'] %}
-        {% if current_user.has_role('admin-ccs-category') %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
           {% set field_headings = field_headings + [summary.hidden_field_heading("Action")] %}
         {% endif %}
         {% call(item) summary.list_table(
@@ -107,6 +107,8 @@
             {% endcall %}
             {% if current_user.has_role('admin-ccs-category') %}
               {{ summary.edit_link('Edit', url_for('.view', service_id=item.id)) }}
+            {% elif current_user.has_any_role('admin', 'admin-framework-manager') %}
+              {{ summary.edit_link('View', url_for('.view', service_id=item.id)) }}
             {% endif %}
           {% endcall %}
         {% endcall %}

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -235,7 +235,7 @@ class TestInviteAdminUserView(LoggedInApplicationTest):
         assert res.location == "http://localhost/admin/admin-users"
 
     @mock.patch('app.main.views.admin_manager.send_user_account_email')
-    @pytest.mark.parametrize('role', ('admin', 'admin-ccs-sourcing', 'admin-ccs-category'))
+    @pytest.mark.parametrize('role', ('admin', 'admin-ccs-sourcing', 'admin-ccs-category', 'admin-framework-manager'))
     def test_post_is_successful_for_valid_roles(self, send_user_account_email, data_api_client, role):
         data_api_client.email_is_valid_for_admin_user.return_value = True
         res = self.client.post('/admin/admin-users/invite', data={'role': role, 'email_address': 'test@test.com'})

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -357,7 +357,7 @@ class TestNextAgreementRedirect(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 403),
-        ("admin-ccs-category", 403),
+        ("admin-ccs-category", 302),
         ("admin-ccs-sourcing", 302),
         ("admin-framework-manager", 302),
         ("admin-manager", 403),

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -199,7 +199,7 @@ class TestListAgreements(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 403),
-        ("admin-ccs-category", 403),
+        ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 200),
         ("admin-framework-manager", 200),
         ("admin-manager", 403),

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -4,6 +4,7 @@ import mock
 from lxml import html
 from six import iteritems, iterkeys
 from six.moves.urllib.parse import urlparse, parse_qs
+import pytest
 
 from app.main.views.agreements import status_labels
 from ...helpers import LoggedInApplicationTest
@@ -196,12 +197,18 @@ class TestListAgreements(LoggedInApplicationTest):
             status_labels[chosen_status_key].lower()
         )
 
-    def test_unauthorised_roles_are_rejected_access(self, data_api_client):
-        self.user_role = 'admin-ccs-category'
-
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 403),
+        ("admin-ccs-category", 403),
+        ("admin-ccs-sourcing", 200),
+        ("admin-framework-manager", 200),
+        ("admin-manager", 403),
+    ])
+    def test_list_agreements_is_only_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+        self.user_role = role
         response = self.client.get('/admin/agreements/g-cloud-7')
-
-        assert response.status_code == 403
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     def test_invalid_status_raises_400(self, data_api_client):
 
@@ -347,3 +354,17 @@ class TestNextAgreementRedirect(LoggedInApplicationTest):
     def test_invalid_status_raises_400(self, data_api_client):
         response = self.client.get('/admin/suppliers/151/agreements/g-cloud-8/next?status=bad')
         assert response.status_code == 400
+
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 403),
+        ("admin-ccs-category", 403),
+        ("admin-ccs-sourcing", 302),
+        ("admin-framework-manager", 302),
+        ("admin-manager", 403),
+    ])
+    def test_next_agreement_redirect_only_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+        self.user_role = role
+        data_api_client.find_framework_suppliers.return_value = self.dummy_supplier_frameworks
+        response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8/next')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -36,6 +36,7 @@ class TestIndex(LoggedInApplicationTest):
         ("admin", True),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
         ("admin-manager", False),
     ])
     def test_add_buyer_email_domain_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
@@ -52,6 +53,7 @@ class TestIndex(LoggedInApplicationTest):
         ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
         ("admin-manager", True),
     ])
     def test_manage_admin_users_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
@@ -68,6 +70,7 @@ class TestIndex(LoggedInApplicationTest):
         ("admin", False),
         ("admin-ccs-category", True),
         ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
         ("admin-manager", False),
     ])
     def test_check_service_edits_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
@@ -75,6 +78,74 @@ class TestIndex(LoggedInApplicationTest):
         response = self.client.get('/admin')
         data = response.get_data(as_text=True)
         link_is_visible = "Check edits to services" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", False),
+        ("admin-ccs-category", False),
+        ("admin-ccs-sourcing", True),
+        ("admin-framework-manager", True),
+        ("admin-manager", False),
+    ])
+    def test_statistics_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Statistics" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", False),
+        ("admin-ccs-category", False),
+        ("admin-ccs-sourcing", True),
+        ("admin-framework-manager", True),
+        ("admin-manager", False),
+    ])
+    def test_view_agreements_links_are_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Agreements" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", False),
+        ("admin-ccs-category", False),
+        ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", True),
+        ("admin-manager", False),
+    ])
+    def test_view_communications_links_are_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Communications" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", False),
+        ("admin-ccs-category", False),
+        ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", True),
+        ("admin-manager", False),
+    ])
+    def test_download_user_lists_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Download user lists" in data
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -102,7 +102,7 @@ class TestIndex(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", False),
-        ("admin-ccs-category", False),
+        ("admin-ccs-category", True),
         ("admin-ccs-sourcing", True),
         ("admin-framework-manager", True),
         ("admin-manager", False),

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -604,6 +604,27 @@ class TestServiceView(LoggedInApplicationTest):
 class TestServiceEdit(LoggedInApplicationTest):
     user_role = 'admin-ccs-category'
 
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 403),
+        ("admin-ccs-category", 200),
+        ("admin-ccs-sourcing", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
+    ])
+    def test_edit_service_is_only_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+        self.user_role = role
+        service = {
+            "id": 123,
+            "frameworkSlug": "digital-outcomes-and-specialists",
+            "serviceName": "Larry O'Rourke's",
+            "supplierId": 1000,
+            "lot": "user-research-studios",
+        }
+        data_api_client.get_service.return_value = {'services': service}
+        response = self.client.get('/admin/services/123/edit/description')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
     def test_edit_dos_service_title(self, data_api_client):
         service = {
             "id": 123,

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -16,6 +16,7 @@ class TestStats(LoggedInApplicationTest):
         ("admin", 403),
         ("admin-ccs-category", 403),
         ("admin-ccs-sourcing", 200),
+        ("admin-framework-manager", 200),
         ("admin-manager", 403),
     ])
     def test_get_page_should_only_be_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1037,7 +1037,7 @@ class TestDownloadAgreementFile(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, expected_code", [
         ("admin", 403),
-        ("admin-ccs-category", 403),
+        ("admin-ccs-category", 302),
         ("admin-ccs-sourcing", 302),
         ("admin-framework-manager", 302),
         ("admin-manager", 403),
@@ -1521,7 +1521,7 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, expected_code", [
         ("admin", 403),
-        ("admin-ccs-category", 403),
+        ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 200),
         ("admin-framework-manager", 200),
         ("admin-manager", 403),
@@ -1780,8 +1780,9 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 403),
-        ("admin-ccs-category", 403),
+        ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 200),
+        ("admin-framework-manager", 200),
         ("admin-manager", 403),
     ])
     def test_get_page_should_only_be_accessible_to_specific_user_roles(

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -76,19 +76,18 @@ class TestSuppliersListView(LoggedInApplicationTest):
         data_api_client.get_supplier.assert_called_once_with("12345")
 
 
+@mock.patch('app.main.views.suppliers.data_api_client')
 class TestSupplierUsersView(LoggedInApplicationTest):
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_404_if_no_supplier_does_not_exist(self, data_api_client):
         data_api_client.get_supplier.side_effect = HTTPError(Response(404))
         response = self.client.get('/admin/suppliers/users?supplier_id=999')
         assert response.status_code == 404
 
-    def test_should_404_if_no_supplier_id(self):
+    def test_should_404_if_no_supplier_id(self, data_api_client):
         response = self.client.get('/admin/suppliers/users')
         assert response.status_code == 404
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_apis_with_supplier_id(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
@@ -98,7 +97,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         data_api_client.get_supplier.assert_called_once_with('1000')
         data_api_client.find_users.assert_called_once_with('1000')
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_have_supplier_name_on_page(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
@@ -106,7 +104,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 200
         assert "Supplier Name" in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_indicate_if_there_are_no_users(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.find_users.return_value = {'users': {}}
@@ -116,7 +113,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 200
         assert "This supplier has no users on the Digital Marketplace" in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_user_details_on_page(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.find_users.return_value = self.load_example_listing("users_response")
@@ -139,7 +135,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert '<form action="/admin/suppliers/1234/move-existing-user" method="post">' in \
             response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_unlock_button_if_user_locked(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
 
@@ -153,7 +148,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert '<form action="/admin/suppliers/users/999/unlock" method="post">' in response.get_data(as_text=True)
         assert '<input type="submit" class="button-secondary"  value="Unlock" />' in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_activate_button_if_user_deactivated(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
 
@@ -167,7 +161,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert '<form action="/admin/suppliers/users/999/activate" method="post">' in response.get_data(as_text=True)
         assert '<input type="submit" class="button-secondary"  value="Activate" />' in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_unlock_user(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
@@ -179,7 +172,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_activate_user(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
@@ -191,7 +183,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_activate_user_and_redirect_to_source_if_present(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
@@ -206,7 +197,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 302
         assert response.location == "http://example.com"
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_deactivate_user(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
@@ -221,7 +211,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_deactivate_user_and_redirect_to_source_if_present(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.update_user.return_value = self.load_example_listing("user_response")
@@ -236,7 +225,6 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 302
         assert response.location == "http://example.com"
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_api_to_move_user_to_another_supplier(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.get_user.return_value = self.load_example_listing("user_response")
@@ -255,20 +243,19 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
 
+@mock.patch('app.main.views.suppliers.data_api_client')
 class TestSupplierServicesView(LoggedInApplicationTest):
     user_role = 'admin-ccs-category'
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_404_if_supplier_does_not_exist_on_services(self, data_api_client):
         data_api_client.get_supplier.side_effect = HTTPError(Response(404))
         response = self.client.get('/admin/suppliers/999/services')
         assert response.status_code == 404
 
-    def test_should_404_if_no_supplier_id_on_services(self):
+    def test_should_404_if_no_supplier_id_on_services(self, data_api_client):
         response = self.client.get('/admin/suppliers/services')
         assert response.status_code == 404
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_call_service_apis_with_supplier_id(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         response = self.client.get('/admin/suppliers/1000/services')
@@ -278,7 +265,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         data_api_client.get_supplier.assert_called_once_with(1000)
         data_api_client.find_services.assert_called_once_with(1000)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_indicate_if_supplier_has_no_services(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.find_services.return_value = {'services': []}
@@ -287,7 +273,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert response.status_code == 200
         assert "This supplier has no services on the Digital Marketplace" in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_have_supplier_name_on_services_page(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.find_services.return_value = {'services': []}
@@ -297,7 +282,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert response.status_code == 200
         assert "Supplier Name" in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_service_details_on_page(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.find_services.return_value = self.load_example_listing("services_response")
@@ -317,7 +301,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert '<a href="/admin/services/5687123785023488">' in response.get_data(as_text=True)
         assert "Edit" in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_correct_fields_for_disabled_service(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.find_frameworks.return_value = {
@@ -334,7 +317,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert "Removed" in response.get_data(as_text=True)
         assert "Edit" in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_correct_fields_for_enabled_service(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
         data_api_client.find_frameworks.return_value = {
@@ -351,7 +333,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert "Private" in response.get_data(as_text=True)
         assert "Edit" in response.get_data(as_text=True)
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_should_show_separate_tables_for_frameworks_if_supplier_has_service_on_framework(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing("supplier_response")
 
@@ -385,7 +366,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         gcloud11_table_index = response_data.find('g-cloud-11_services')
         assert gcloud11_table_index < gcloud8_table_index < dos_table_index
 
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_remove_all_services_link_if_supplier_has_a_published_service_on_framework(self, data_api_client):
         data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         data_api_client.find_frameworks.return_value = {
@@ -409,7 +389,6 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert expected_link.text == expected_link_text
 
     @pytest.mark.parametrize('service_status', ['enabled', 'disabled', 'a_new_status'])
-    @mock.patch('app.main.views.suppliers.data_api_client')
     def test_no_remove_all_services_link_if_supplier_service_not_published(self, data_api_client, service_status):
         service = self.load_example_listing('services_response')['services'][0]
         service["status"] = service_status

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -834,7 +834,7 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
 
 
 @mock.patch('app.main.views.suppliers.data_api_client')
-class TestUpdatintSupplierName(LoggedInApplicationTest):
+class TestUpdatingSupplierName(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("allowed_role", ["admin", "admin-ccs-category"])
     def test_admin_and_ccs_category_roles_can_update_supplier_name(self, data_api_client, allowed_role):

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -35,6 +35,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", True),
+        ("admin-framework-manager", True),
     ])
     def test_services_link_is_shown_to_users_with_right_roles(self, data_api_client, role, link_should_be_visible):
         self.user_role = role
@@ -44,6 +45,24 @@ class TestSuppliersListView(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
         data = response.get_data(as_text=True)
         link_is_visible = "Services" in data and "/admin/suppliers/12345/services" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", False),
+        ("admin-ccs-category", True),
+        ("admin-framework-manager", False),
+    ])
+    def test_change_name_link_is_shown_to_users_with_right_roles(self, data_api_client, role, link_should_be_visible):
+        self.user_role = role
+        data_api_client.find_suppliers.return_value = {
+            "suppliers": [{"id": "12345"}]
+        }
+        response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Change name" in data and "/admin/suppliers/12345/edit/name" in data
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -52,7 +52,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
         )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
-        ("admin", False),
+        ("admin", True),
         ("admin-ccs-category", True),
         ("admin-framework-manager", False),
     ])

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -16,6 +16,22 @@ from ...helpers import LoggedInApplicationTest, Response
 @mock.patch('app.main.views.suppliers.data_api_client')
 class TestSuppliersListView(LoggedInApplicationTest):
 
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 200),
+        ("admin-ccs-category", 200),
+        ("admin-ccs-sourcing", 200),
+        ("admin-framework-manager", 200),
+        ("admin-manager", 403),
+    ])
+    def test_supplier_list_is_shown_to_users_with_right_roles(self, data_api_client, role, expected_code):
+        self.user_role = role
+        data_api_client.find_suppliers.return_value = {
+            "suppliers": [{"id": "12345"}]
+        }
+        response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", True),

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -33,8 +33,9 @@ class TestSuppliersListView(LoggedInApplicationTest):
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
-        ("admin", False),
+        ("admin", True),
         ("admin-ccs-category", True),
+        ("admin-ccs-sourcing", False),
         ("admin-framework-manager", True),
     ])
     def test_services_link_is_shown_to_users_with_right_roles(self, data_api_client, role, link_should_be_visible):
@@ -315,7 +316,7 @@ class TestSupplierServicesView(LoggedInApplicationTest):
     user_role = 'admin-ccs-category'
 
     @pytest.mark.parametrize("role, expected_code", [
-        ("admin", 403),
+        ("admin", 200),
         ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 403),
         ("admin-framework-manager", 200),
@@ -330,6 +331,7 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     @pytest.mark.parametrize("role, can_edit", [
+        ("admin", False),
         ("admin-ccs-category", True),
         ("admin-framework-manager", False),
     ])
@@ -348,6 +350,8 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert len(remove_all_links) == (1 if can_edit else 0)
         edit_service_links = document.xpath('.//a[contains(text(), "Edit")]')
         assert len(edit_service_links) == (1 if can_edit else 0)
+        view_service_links = document.xpath('.//a[contains(text(), "View")]')
+        assert len(view_service_links) == (0 if can_edit else 1)
 
     def test_should_404_if_supplier_does_not_exist_on_services(self, data_api_client):
         data_api_client.get_supplier.side_effect = HTTPError(Response(404))


### PR DESCRIPTION
Trello: https://trello.com/c/iUS9D0ll/163-add-new-framework-manager-role

An admin framework manager can:
- View application statistics
- Find suppliers by name and DUNS number (then view lists of that supplier's services and users)
- Find services by service ID (but not edit)
- View agreements (but not approve or countersign)
- Download agreement files
- Download user lists
- Upload communications sent to suppliers (already available)
- Publish clarification questions (already available)

An admin manager can:
- See users with the `admin-framework-manager` role in the admin list view
![manage-users-framework-manager](https://user-images.githubusercontent.com/3492540/33555805-9699977c-d8f9-11e7-9a2a-3492bc963355.png)

- Invite a new admin user with the `admin-framework-manager` role
![framework-manager-invite](https://user-images.githubusercontent.com/3492540/33555849-c8c4636c-d8f9-11e7-84b1-f4e8304d54a4.png)

- Existing admin users can be edited to assign/remove the `admin-framework-manager` role
![framework-manager-edit-user](https://user-images.githubusercontent.com/3492540/33555830-b699bbb0-d8f9-11e7-99a9-efc23694f562.png)

Also includes fixes for the support role being able to:
- view (but not edit) service pages
- view the list of services for a supplier (but not remove/edit)