### PR TITLE
Enable admin manager to edit admin users

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,12 +1,6 @@
-<<<<<<< HEAD
-from flask.ext.wtf import Form
 from wtforms import RadioField, validators
-
-=======
-from flask_wtf import Form
-from wtforms.validators import DataRequired, Email
-from wtforms.fields import SelectField
->>>>>>> Create form for editing admin user details - still needs default selection
+from flask.ext.wtf import Form
+from wtforms.validators import DataRequired
 from dmutils.forms import StripWhitespaceStringField
 
 from .. import data_api_client
@@ -73,13 +67,26 @@ class EditAdminUserForm(Form):
         DataRequired(message="You must provide a name.")
     ])
 
-    edit_admin_permissions = SelectField('Permissions', choices=[
-        {"label": "Category", "value": "admin-ccs-category"},
-        {"label": "Sourcing", "value": "admin-ccs-sourcing"},
-        {"label": "Support", "value": "admin"},
-    ])
+    permissions_choices = [
+        ("admin-ccs-category", "Category"),
+        ("admin-ccs-sourcing", "Sourcing"),
+        ("admin", "Support"),
+    ]
 
-    edit_admin_status = SelectField('Status', choices=[
-        {"label": "Active", "value": "True"},
-        {"label": "Suspended", "value": "False"},
-    ])
+    edit_admin_permissions = RadioField('Permissions', choices=permissions_choices)
+
+    status_choices = [
+        ("True", "Active"),
+        ("False", "Suspended"),
+    ]
+
+    edit_admin_status = RadioField('Status', choices=status_choices)
+
+    def __init__(self, *args, **kwargs):
+        super(EditAdminUserForm, self).__init__(*args, **kwargs)
+        self.edit_admin_permissions.toolkit_macro_options = [
+            {'value': choice[0], 'label': choice[1]} for choice in self.permissions_choices
+        ]
+        self.edit_admin_status.toolkit_macro_options = [
+            {'value': choice[0], 'label': choice[1]} for choice in self.status_choices
+        ]

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,6 +1,12 @@
+<<<<<<< HEAD
 from flask.ext.wtf import Form
 from wtforms import RadioField, validators
 
+=======
+from flask_wtf import Form
+from wtforms.validators import DataRequired, Email
+from wtforms.fields import SelectField
+>>>>>>> Create form for editing admin user details - still needs default selection
 from dmutils.forms import StripWhitespaceStringField
 
 from .. import data_api_client
@@ -60,3 +66,20 @@ class InviteAdminForm(Form):
     def __init__(self, *args, **kwargs):
         super(InviteAdminForm, self).__init__(*args, **kwargs)
         self.role.toolkit_macro_options = [{'value': i[0], 'label': i[1]} for i in self.role_choices]
+
+
+class EditAdminUserForm(Form):
+    edit_admin_name = StripWhitespaceStringField('Name', validators=[
+        DataRequired(message="You must provide a name.")
+    ])
+
+    edit_admin_permissions = SelectField('Permissions', choices=[
+        {"label": "Category", "value": "admin-ccs-category"},
+        {"label": "Sourcing", "value": "admin-ccs-sourcing"},
+        {"label": "Support", "value": "admin"},
+    ])
+
+    edit_admin_status = SelectField('Status', choices=[
+        {"label": "Active", "value": "True"},
+        {"label": "Suspended", "value": "False"},
+    ])

--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -5,9 +5,10 @@ from dmutils.email.user_account_email import send_user_account_email
 
 from ... import data_api_client
 from .. import main
-from ..forms import InviteAdminForm
-from ..auth import role_required
 
+from ..forms import InviteAdminForm
+from dmapiclient import HTTPError, APIError
+from ..auth import role_required
 
 @main.route('/admin-users', methods=['GET'])
 @role_required('admin-manager')
@@ -63,3 +64,15 @@ def invite_admin_user():
         form=form,
         errors=errors,
     ), 200 if not errors else 400
+
+
+
+@role_required('admin')
+@main.route('/admin-users/<string:admin_user_id>/edit', methods=['GET'])
+@role_required('admin-manager')
+def edit_admin_users(admin_user_id):
+    admin_user = data_api_client.get_user(admin_user_id)
+    return render_template(
+        "edit_admin_user.html",
+        admin_user=admin_user["users"],
+    )

--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -9,6 +9,7 @@ from .. import main
 from ..forms import InviteAdminForm
 from dmapiclient import HTTPError, APIError
 from ..auth import role_required
+from ..forms import EditAdminUserForm
 
 @main.route('/admin-users', methods=['GET'])
 @role_required('admin-manager')
@@ -67,12 +68,21 @@ def invite_admin_user():
 
 
 
-@role_required('admin')
-@main.route('/admin-users/<string:admin_user_id>/edit', methods=['GET'])
+
+@main.route('/admin-users/<string:admin_user_id>/edit', methods=['GET', 'POST'])
 @role_required('admin-manager')
 def edit_admin_users(admin_user_id):
-    admin_user = data_api_client.get_user(admin_user_id)
+    admin_user = (data_api_client.get_user(admin_user_id))["users"]
+    edit_admin_user_form = EditAdminUserForm()
+
+    for choice in edit_admin_user_form.edit_admin_permissions.choices:
+        choice["input_value"] = admin_user["role"]
+
+    for choice in edit_admin_user_form.edit_admin_status.choices:
+        choice["input_value"] = str(admin_user["active"])
+
     return render_template(
         "edit_admin_user.html",
-        admin_user=admin_user["users"],
+        admin_user=admin_user,
+        edit_admin_user_form=edit_admin_user_form,
     )

--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -9,7 +9,7 @@ from .. import main
 from ..forms import InviteAdminForm, EditAdminUserForm
 from dmapiclient import HTTPError
 from ..auth import role_required
-from ..helpers.common_helpers import string_to_bool
+from distutils.util import strtobool
 
 
 @main.route('/admin-users', methods=['GET'])
@@ -70,8 +70,8 @@ def invite_admin_user():
 
 @main.route("/admin-users/<string:admin_user_id>/edit", methods=["GET", "POST"])
 @role_required("admin-manager")
-def edit_admin_users(admin_user_id):
-    admin_user = (data_api_client.get_user(admin_user_id))["users"]
+def edit_admin_user(admin_user_id):
+    admin_user = data_api_client.get_user(admin_user_id)["users"]
     status_code = 200
     edit_admin_user_form = EditAdminUserForm(
         edit_admin_name=admin_user["name"],
@@ -82,7 +82,7 @@ def edit_admin_users(admin_user_id):
         try:
             edited_admin_name = request.form.get("edit_admin_name")
             edited_admin_permissions = request.form.get("edit_admin_permissions")
-            edited_admin_status = string_to_bool(request.form.get("edit_admin_status"))
+            edited_admin_status = strtobool(request.form.get("edit_admin_status"))
 
             data_api_client.update_user(
                 admin_user_id,

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -18,10 +18,36 @@
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
 {% endblock %}
+
 {% block main_content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+      {% for category, message in messages %}
+          {%
+          with
+            message = message,
+            type = "destructive" if category == 'error' else 'success'
+          %}
+          {% include "toolkit/notification-banner.html" %}
+          {% endwith %}
+      {% endfor %}
+  {% endif %}
+  {% endwith %}
+
+  {% for error in edit_admin_user_form.edit_admin_name.errors %}
+    {%
+      with
+        message = error,
+        type = "destructive"
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  {% endfor %}
+
   {% with heading = admin_user.emailAddress %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
+
   <form method="post">
     <div class="grid-row">
       <div class="column-two-thirds">
@@ -30,7 +56,7 @@
           with
           question = "Name",
           name = edit_admin_user_form.edit_admin_name.name,
-          value = admin_user.name,
+          value = edit_admin_user_form.edit_admin_name.data,
           error = ""
         %}
           {% include "toolkit/forms/textbox.html" %}
@@ -41,7 +67,8 @@
           question = "Permissions",
           type = "radio",
           name = edit_admin_user_form.edit_admin_permissions.name,
-          options = edit_admin_user_form.edit_admin_permissions.choices
+          value = edit_admin_user_form.edit_admin_permissions.data,
+          options = edit_admin_user_form.edit_admin_permissions.toolkit_macro_options
         %}
           {% include "toolkit/forms/selection-buttons.html" %}
         {% endwith %}
@@ -51,7 +78,8 @@
           question = "Status",
           type = "radio",
           name = edit_admin_user_form.edit_admin_status.name,
-          options = edit_admin_user_form.edit_admin_status.choices
+          value = edit_admin_user_form.edit_admin_status.data,
+          options = edit_admin_user_form.edit_admin_status.toolkit_macro_options
         %}
           {% include "toolkit/forms/selection-buttons.html" %}
         {% endwith %}

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -1,3 +1,69 @@
-<body>
-{{ admin_user.name }}
-</body>
+{% extends "_base_page.html" %}
+{% block page_title %}
+  Edit details of admin user: {{ admin_user.emailAddress }} – Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      },
+      {
+        "label": "Edit an admin user"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+{% block main_content %}
+  {% with heading = admin_user.emailAddress %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+  <form method="post">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+        {%
+          with
+          question = "Name",
+          name = edit_admin_user_form.edit_admin_name.name,
+          value = admin_user.name,
+          error = ""
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {%
+          with
+          question = "Permissions",
+          type = "radio",
+          name = edit_admin_user_form.edit_admin_permissions.name,
+          options = edit_admin_user_form.edit_admin_permissions.choices
+        %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+
+        {%
+          with
+          question = "Status",
+          type = "radio",
+          name = edit_admin_user_form.edit_admin_status.name,
+          options = edit_admin_user_form.edit_admin_status.choices
+        %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+
+        {%
+          with
+          type = "save",
+          label = "Update user"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -1,0 +1,3 @@
+<body>
+{{ admin_user.name }}
+</body>

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -56,7 +56,7 @@
       {{ summary.text(item.emailAddress) }}
       {{ summary.text(role_descriptors[item.role]) }}
       {{ summary.text("Active" if item.active else "Suspended") }}
-      {{ summary.edit_link("Edit", "http://url_for(....)") }}
+      {{ summary.edit_link("Edit", url_for(".edit_admin_user", admin_user_id=item.id)) }}
     {% endcall %}
   {% endcall %}
 </div>

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.1.0#egg=digitalmarketplace-apiclient==12.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.0.0#egg=digitalmarketplace-apiclient==13.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.1.0#egg=digitalmarketplace-apiclient==12.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.0.0#egg=digitalmarketplace-apiclient==13.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.23.0

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -234,6 +234,10 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
         assert "Auditor of Reality" in document.text_content()
+        assert document.xpath('//span[@class="question-heading"]')[0].text.strip() == "Name"
+        assert document.xpath('//span[@class="question-heading"]')[1].text.strip() == "Permissions"
+        assert document.xpath('//span[@class="question-heading"]')[2].text.strip() == "Status"
+        assert document.xpath('//input[@class="button-save"]')[0].value.strip() == "Update user"
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin-manager", 200),

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 from lxml import html
 import mock
 import pytest
-from lxml import html
 
 from dmapiclient import HTTPError
 
@@ -200,7 +199,6 @@ class TestInviteAdminUserView(LoggedInApplicationTest):
             personalisation={'name': 'tester'}
         )
 
-
     @mock.patch('app.main.views.admin_manager.send_user_account_email')
     def test_successful_post_flashes(self, data_api_client, send_user_account_email):
         data_api_client.email_is_valid_for_admin_user.return_value = True
@@ -209,13 +207,13 @@ class TestInviteAdminUserView(LoggedInApplicationTest):
         assert_flashes(self, 'An invitation has been sent to test@test.com.', 'success')
 
 
-@mock.patch('app.main.views.admin_manager.data_api_client')
+@mock.patch("app.main.views.admin_manager.data_api_client")
 class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
 
     admin_user_to_edit = {
         "users": {
             "active": True,
-            "emailAddress": "@digital.cabinet-office.gov.uk",
+            "emailAddress": "reality.auditor@digital.cabinet-office.gov.uk",
             "id": 2345,
             "locked": False,
             "name": "Auditor of Reality",
@@ -224,20 +222,66 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
         }
     }
 
-    def test_should_load_edit_admin_users_page_correctly(self, data_api_client):
+    def test_should_load_edit_admin_users_page_heading_correctly(self, data_api_client):
         self.user_role = "admin-manager"
-        admin_user_id = 2345
         data_api_client.get_user.return_value = self.admin_user_to_edit
 
-        response = self.client.get('/admin/admin-users/2345/edit')
+        response = self.client.get("/admin/admin-users/2345/edit")
         assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
-        assert "Auditor of Reality" in document.text_content()
-        assert document.xpath('//span[@class="question-heading"]')[0].text.strip() == "Name"
-        assert document.xpath('//span[@class="question-heading"]')[1].text.strip() == "Permissions"
-        assert document.xpath('//span[@class="question-heading"]')[2].text.strip() == "Status"
+
+        assert document.xpath('//h1')[0].text.strip() == "reality.auditor@digital.cabinet-office.gov.uk"
         assert document.xpath('//input[@class="button-save"]')[0].value.strip() == "Update user"
+
+    def test_should_correctly_load_and_prefill_edit_name_question(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.get_user.return_value = self.admin_user_to_edit
+
+        response = self.client.get("/admin/admin-users/2345/edit")
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert document.xpath('//span[@class="question-heading"]')[0].text.strip() == "Name"
+        assert document.cssselect('#input-edit_admin_name')[0].value == "Auditor of Reality"
+
+    def test_should_correctly_load_and_prefill_edit_permissions_question(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.get_user.return_value = self.admin_user_to_edit
+
+        response = self.client.get("/admin/admin-users/2345/edit")
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert document.xpath('//span[@class="question-heading"]')[1].text.strip() == "Permissions"
+
+        assert document.cssselect('#input-edit_admin_permissions-1')[0].label.text.strip() == "Category"
+        assert document.cssselect('#input-edit_admin_permissions-1')[0].checked
+
+        assert document.cssselect('#input-edit_admin_permissions-2')[0].label.text.strip() == "Sourcing"
+        assert not document.cssselect('#input-edit_admin_permissions-2')[0].checked
+
+        assert document.cssselect('#input-edit_admin_permissions-3')[0].label.text.strip() == "Support"
+        assert not document.cssselect('#input-edit_admin_permissions-3')[0].checked
+
+    def test_should_correctly_load_and_prefill_edit_status_question(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.get_user.return_value = self.admin_user_to_edit
+
+        response = self.client.get("/admin/admin-users/2345/edit")
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert document.xpath('//span[@class="question-heading"]')[2].text.strip() == "Status"
+
+        assert document.cssselect('#input-edit_admin_status-1')[0].label.text.strip() == "Active"
+        assert document.cssselect('#input-edit_admin_status-1')[0].checked
+
+        assert document.cssselect('#input-edit_admin_status-2')[0].label.text.strip() == "Suspended"
+        assert not document.cssselect('#input-edit_admin_status-2')[0].checked
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin-manager", 200),
@@ -247,24 +291,57 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
     ])
     def test_get_page_should_only_be_accessible_to_admin_manager(self, data_api_client, role, expected_code):
         self.user_role = role
-        admin_user_id = 2345
         data_api_client.get_user.return_value = self.admin_user_to_edit
 
-        response = self.client.get('/admin/admin-users/2345/edit')
+        response = self.client.get("/admin/admin-users/2345/edit")
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
 
     @pytest.mark.parametrize("role,expected_code", [
-        ("admin-manager", 200),
+        ("admin-manager", 302),
         ("admin", 403),
         ("admin-ccs-category", 403),
         ("admin-ccs-sourcing", 403),
     ])
     def test_post_page_should_only_be_accessible_to_admin_manager(self, data_api_client, role, expected_code):
         self.user_role = role
-        admin_user_id = 2345
         data_api_client.get_user.return_value = self.admin_user_to_edit
 
         response = self.client.post('/admin/admin-users/2345/edit')
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
+
+    def test_admin_manager_can_edit_admin_user_details(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.get_user.return_value = self.admin_user_to_edit
+        response1 = self.client.post(
+            "/admin/admin-users/2345/edit",
+            data={
+                "edit_admin_name": "Lady Myria Lejean",
+                "edit_admin_permissions": "admin",
+                "edit_admin_status": "False"
+            }
+        )
+        assert response1.status_code == 302
+        assert_flashes(self, "reality.auditor@digital.cabinet-office.gov.uk has been updated", "message")
+        assert data_api_client.update_user.call_args_list == [mock.call(
+            "2345", name="Lady Myria Lejean", role="admin", active=False
+        )]
+
+        response2 = self.client.get(response1.location)
+        assert "reality.auditor@digital.cabinet-office.gov.uk has been updated" in response2.get_data(as_text=True)
+
+    def test_admin_user_name_cannot_be_submitted_when_empty(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.get_user.return_value = self.admin_user_to_edit
+        response = self.client.post(
+            "/admin/admin-users/2345/edit",
+            data={
+                "edit_admin_name": "",
+                "edit_admin_permissions": "admin",
+                "edit_admin_status": "True"
+            }
+        )
+        assert response.status_code == 400
+        assert "You must provide a name." in response.get_data(as_text=True)
+        assert data_api_client.update_user.call_args_list == []


### PR DESCRIPTION
Trello ticket: https://trello.com/c/j1jx6KkX/154-allow-super-admin-edit-admin-roles
Prototype screenshots: https://docs.google.com/document/d/1MjvYx9aQWgcbryiaGrRLOPt_lVm8gIbqOH3vmkKx_fo/edit#heading=h.qdo4oz9trpdq

Screenshots of the real thing:

![screen shot 2017-11-30 at 16 58 01](https://user-images.githubusercontent.com/20957548/33443649-095c3a56-d5f0-11e7-9405-1dac0c1ea061.png)

![screen shot 2017-11-30 at 16 58 32](https://user-images.githubusercontent.com/20957548/33443595-e792f7a2-d5ef-11e7-99f7-df00b84749da.png)

![screen shot 2017-11-30 at 16 58 55](https://user-images.githubusercontent.com/20957548/33443667-0f388826-d5f0-11e7-81c4-294bb0aff651.png)
