### PR TITLE
Change from flake8-putty to flake8-per-file-ignores.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,13 +3,13 @@
 # D203: 1 blank line required before class docstring
 # F401: 'identifier' imported but unused
 # E402: module level import not at top of file
-# C901: too complex
 # W503: line break before binary operator
 exclude = venv,venv3,__pycache__,node_modules,bower_components,app/content
 ignore = D203,W503
 max-complexity = 24
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +E402
-    app/main/views/*.py : +C901
+per-file-ignores =
+    **/__init__.py : F401
+    app/__init__.py : E402
+    app/main/__init__.py : E402
+    app/status/__init__.py : E402

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@
 coverage==3.7.1
 cssselect==0.9.1
 freezegun==0.3.7
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 mock==2.0.0
 pytest==3.2.3
 pytest-cov==2.5.1


### PR DESCRIPTION
This allows us to support newer Python 3 syntax including f-strings and
type annotations.

Report after changing extensions:
```
samuelwilliams:~/git/digitalmarketplace-admin-frontend [master]$ make test-flake8
[ -z $VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
/Users/samuelwilliams/git/digitalmarketplace-admin-frontend/venv/bin/flake8 .
./app/main/views/__init__.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/admin_manager.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/agreements.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/buyers.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/buyers.py:19:5: E722 do not use bare except'
./app/main/views/communications.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/service_updates.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/services.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/stats.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/suppliers.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/users.py:0:1: X100 Superfluous per-file-ignores for C901
make: *** [test-flake8] Error 1```