### PR TITLE
176 Split the supplier csv into 2 (Active and All interested)

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -26,6 +26,7 @@ $path: "/admin/static/images/";
 @import "toolkit/secondary-action-link";
 
 // Digital Marketplace front end toolkit components
+@import "toolkit/_document.scss";
 @import "forms/_option-select.scss";
 @import "forms/_keyword-search.scss";
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -113,7 +113,7 @@ def download_users(framework_slug):
 
 
 @main.route('/users/download/buyers', methods=['GET'])
-@role_required('admin-framework-manager', 'admin')  # TODO: REMOVE ADMIN
+@role_required('admin-framework-manager')
 def download_buyers_and_briefs():
     users = {user["id"]: dict(user, briefs=[]) for user in data_api_client.find_users_iter(role="buyer")}
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -95,8 +95,10 @@ def download_users(framework_slug):
     if on_framework_only:
         supplier_headers = on_framework_only_headers
         supplier_rows = [row for row in supplier_rows if row['application_result'] == 'pass']
+        download_filename = "suppliers-on-{}.csv".format(framework_slug)
     else:
         supplier_headers = on_framework_only_headers + additional_full_headers
+        download_filename = "{}-suppliers-who-applied-or-started-application.csv".format(framework_slug)
     formatted_rows = []
     for row in supplier_rows:
         formatted_rows.append([row[heading] for heading in supplier_headers])
@@ -106,7 +108,7 @@ def download_users(framework_slug):
         csv_generator.iter_csv(formatted_rows),
         mimetype='text/csv',
         headers={
-            "Content-Disposition": "attachment;filename=users-{}.csv".format(framework_slug),
+            "Content-Disposition": "attachment;filename={}".format(download_filename),
             "Content-Type": "text/csv; header=present"
         }
     )

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -61,7 +61,7 @@ def list_frameworks_with_users(errors=None):
 
 
 @main.route('/frameworks/<framework_slug>/users', methods=['GET'])
-@role_required('admin-framework-manager', 'admin')  # TODO: REMOVE ADMIN
+@role_required('admin-framework-manager')
 def user_list_page_for_framework(framework_slug):
     bad_statuses = ['coming', 'expired']
     framework = data_api_client.get_framework(framework_slug).get("frameworks")
@@ -75,13 +75,16 @@ def user_list_page_for_framework(framework_slug):
 
 
 @main.route('/frameworks/<framework_slug>/users/download', methods=['GET'])
-@role_required('admin-framework-manager', 'admin')  # TODO: REMOVE ADMIN
-def download_users(framework_slug, on_framework_only=False):
+@role_required('admin-framework-manager')
+def download_users(framework_slug):
+    on_framework_only = request.args.get('on_framework_only')
     supplier_rows = data_api_client.export_users(framework_slug).get('users', [])
-    supplier_headers = [
+    on_framework_only_headers = [
         "email address",
         "user_name",
         "supplier_id",
+    ]
+    additional_full_headers = [
         "declaration_status",
         "application_status",
         "application_result",
@@ -89,6 +92,11 @@ def download_users(framework_slug, on_framework_only=False):
         "variations_agreed"
     ]
 
+    if on_framework_only:
+        supplier_headers = on_framework_only_headers
+        supplier_rows = [row for row in supplier_rows if row['application_result'] == 'pass']
+    else:
+        supplier_headers = on_framework_only_headers + additional_full_headers
     formatted_rows = []
     for row in supplier_rows:
         formatted_rows.append([row[heading] for heading in supplier_headers])

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -1,0 +1,41 @@
+{% extends "_base_page.html" %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  {%
+    with heading = "Download supplier lists for {}".format(framework['name'])
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  {%
+    with
+    items = [
+      {
+          "title": "Suppliers who’ve applied or started an application",
+          "link": url_for('.download_users', framework_slug=framework['slug']),
+          "file_type": "CSV"
+      },
+      {
+          "title": "Suppliers on the framework",
+          "link": url_for('.download_users', framework_slug=framework['slug'], on_framework_only=True),
+          "file_type": "CSV"
+      },
+    ]
+  %}
+    {% include "toolkit/documents.html" %}
+  {% endwith %}
+
+{% endblock %}

--- a/app/templates/download_users.html
+++ b/app/templates/download_users.html
@@ -50,7 +50,7 @@
         items = [
           {
               "title": framework.label,
-              "link": url_for('.download_users', framework_slug=framework.value)
+              "link": url_for('.user_list_page_for_framework', framework_slug=framework.value)
           }
         ]
       %}

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -399,6 +399,7 @@ class TestUsersExport(LoggedInApplicationTest):
 
 @mock.patch('app.main.views.users.data_api_client')
 class TestBuyersExport(LoggedInApplicationTest):
+    user_role = "admin-framework-manager"
 
     def test_response_data_has_buyer_info(self, data_api_client):
         data_api_client.find_users_iter.return_value = [


### PR DESCRIPTION
For this ticket: https://trello.com/c/ci1yeRFZ/176-split-the-supplier-csv-into-2-active-and-all-interested

**NOTE** I've left the breadcrumb as one step away from the admin homepage, as that's where it will be after the home page reorg ticket (the intermediate page at `/admin/users/download` is going to go away altogether).

## New page ##

![screen shot 2017-12-05 at 15 23 07](https://user-images.githubusercontent.com/6525554/33614824-4cd41c34-d9d0-11e7-930a-3c5f164b245f.png)
