### PR TITLE
Simplify buyer list download to not include briefs

### DIFF
--- a/app/templates/download_users.html
+++ b/app/templates/download_users.html
@@ -69,7 +69,7 @@
       items = [
         {
             "title": 'All frameworks',
-            "link": url_for('.download_buyers_and_briefs')
+            "link": url_for('.download_buyers')
         }
       ]
     %}

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -10,7 +10,6 @@ import six
 from dmapiclient import HTTPError
 from lxml import html
 
-from app.main.views.users import CLOSED_BRIEF_STATUSES
 from ...helpers import LoggedInApplicationTest
 
 
@@ -406,134 +405,6 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "emailAddress": "chris@gov.uk",
                 "phoneNumber": "01234567891",
                 "createdAt": "2016-08-04T12:00:00.000000Z",
-            }
-        ]
-
-        data_api_client.find_briefs_iter.return_value = [
-            {
-                'id': 321,
-                'title': 'This is a brief',
-                'status': 'draft',
-                'users': [{
-                    'id': 1
-                }],
-                "location": "Wales",
-                "lotSlug": "magic-roundabout",
-            }
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-        assert len(rows) == 2
-
-        header = rows[0]
-        buyer = rows[1]
-
-        assert header == [
-            u'user.name',
-            u'user.emailAddress',
-            u'user.phoneNumber',
-            u'user.createdAtDate',
-
-            u'brief.id',
-            u'brief.title',
-            u'brief.location',
-            u'brief.lotSlug',
-            u'brief.status',
-            u'brief.applicationsClosedAtDateIfClosed',
-        ]
-        assert buyer == [
-            u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-            u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
-        ]
-
-    def test_response_has_two_lines_for_buyer_if_multiple_briefs(self, data_api_client):
-        data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-            },
-        ]
-
-        data_api_client.find_briefs_iter.return_value = [
-            {
-                'id': 321,
-                'title': 'This is a brief',
-                'status': 'draft',
-                'location': 'Wales',
-                'users': [{
-                    'id': 1
-                }],
-                'lotSlug': 'magic-roundabout',
-            },
-            {
-                'id': 432,
-                'title': 'This is a second brief',
-                'status': 'draft',
-                'users': [{
-                    'id': 1
-                }],
-                'lotSlug': 'manege-enchante',
-            },
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-        buyer_briefs = rows[1:]
-
-        assert buyer_briefs == [
-            [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
-            ],
-            [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'432', u'This is a second brief', u'', u'manege-enchante', u'draft', u'',
-            ],
-        ]
-
-    def test_buyer_is_listed_if_they_have_no_briefs(self, data_api_client):
-        data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-            }
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-        buyer_briefs = rows[1:]
-
-        assert buyer_briefs == [
-            [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'', u'', u'', u'', u'', u'',
-            ],
-        ]
-
-    def test_multiple_buyers_are_assigned_correct_briefs(self, data_api_client):
-        data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
             },
             {
                 'id': 2,
@@ -544,168 +415,17 @@ class TestBuyersExport(LoggedInApplicationTest):
             },
         ]
 
-        data_api_client.find_briefs_iter.return_value = [
-            {
-                'id': 321,
-                'title': 'This is a brief',
-                'location': 'London',
-                'status': 'draft',
-                'users': [{
-                    'id': 1
-                }],
-                'lotSlug': 'magic-roundabout',
-            },
-            {
-                'id': 432,
-                'title': 'This is a second brief',
-                'location': 'Wales',
-                'status': 'draft',
-                'users': [{
-                    'id': 2
-                }],
-                'lotSlug': 'manege-enchante',
-            }
-        ]
-
         response = self.client.get('/admin/users/download/buyers')
         assert response.status_code == 200
 
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-        buyer_briefs = rows[1:]
 
-        assert buyer_briefs == [
-            [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'321', u'This is a brief', u'London', u'magic-roundabout', u'draft', u'',
-            ],
-            [
-                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
-                u'432', u'This is a second brief', u'Wales', u'manege-enchante', u'draft', u'',
-            ],
+        assert len(rows) == 3
+        assert rows == [
+            ['email address', 'name'],
+            ['chris@gov.uk', 'Chris'],
+            ['topher@gov.uk', 'Topher'],
         ]
-
-    def test_mutiple_buyers_are_assigned_same_brief_if_they_are_users(self, data_api_client):
-        data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-            },
-            {
-                'id': 2,
-                "name": "Topher",
-                "emailAddress": "topher@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-05T12:00:00.000000Z",
-            },
-        ]
-
-        data_api_client.find_briefs_iter.return_value = [
-            {
-                'id': 321,
-                'title': 'This is a brief',
-                'status': 'draft',
-                'location': 'Wales',
-                'users': [
-                    {
-                        'id': 1
-                    },
-                    {
-                        'id': 2
-                    }
-                ],
-                'lotSlug': 'magic-roundabout',
-            }
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-        buyer_briefs = rows[1:]
-
-        assert buyer_briefs == [
-            [
-                u'Chris', u'chris@gov.uk', u'01234567891', u'2016-08-04',
-                u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
-            ],
-            [
-                u'Topher', u'topher@gov.uk', u'01234567891', u'2016-08-05',
-                u'321', u'This is a brief', u'Wales', u'magic-roundabout', u'draft', u'',
-            ],
-        ]
-
-    def test_brief_status_is_output_as_open_instead_of_live(self, data_api_client):
-        data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-            }
-        ]
-
-        data_api_client.find_briefs_iter.return_value = [
-            {
-                'id': 321,
-                'title': 'This is a brief',
-                'location': 'London',
-                'status': 'live',
-                'users': [{
-                    'id': 1
-                }],
-                "applicationsClosedAt": "2016-09-05T12:00:00.000000Z",
-                'lotSlug': 'magic-roundabout',
-            }
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-        buyer = rows[1]
-
-        assert buyer[4:] == [u"321", u"This is a brief", u"London", u'magic-roundabout', u"open", u"", ]
-
-    @pytest.mark.parametrize("status", CLOSED_BRIEF_STATUSES)
-    def test_brief_applications_closed_at_is_output_if_brief_status_is_closed_or_awarded(self, data_api_client, status):
-        data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-            }
-        ]
-
-        data_api_client.find_briefs_iter.return_value = [
-            {
-                'id': 321,
-                'title': 'This is a brief',
-                'location': 'London',
-                'status': status,
-                'users': [{
-                    'id': 1
-                }],
-                "applicationsClosedAt": "2016-09-05T12:00:00.000000Z",
-                'lotSlug': 'magic-roundabout',
-            }
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-        buyer = rows[1]
-
-        assert buyer[4:] == [u"321", u"This is a brief", u"London", u'magic-roundabout', status, u"2016-09-05", ]
 
     def test_csv_is_sorted_by_name(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -745,7 +465,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
 
-        assert [row[0] for row in rows[1:5]] == ['Brian', 'Dougal', 'Florence', 'Zebedee']
+        assert [row[1] for row in rows[1:5]] == ['Brian', 'Dougal', 'Florence', 'Zebedee']
 
     def test_response_is_a_csv(self, data_api_client):
         data_api_client.find_users_iter.return_value = [
@@ -756,18 +476,6 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "phoneNumber": "01234567891",
                 "createdAt": "2016-08-04T12:00:00.000000Z",
             },
-        ]
-
-        data_api_client.find_briefs_iter.return_value = [
-            {
-                'id': 321,
-                'title': 'This is a brief',
-                'status': 'draft',
-                'users': [{
-                    'id': 1
-                }],
-                'lotSlug': 'magic-roundabout',
-            }
         ]
 
         response = self.client.get('/admin/users/download/buyers')
@@ -785,18 +493,6 @@ class TestBuyersExport(LoggedInApplicationTest):
                     "phoneNumber": "01234567891",
                     "createdAt": "2016-08-04T12:00:00.000000Z",
                 },
-            ]
-
-            data_api_client.find_briefs_iter.return_value = [
-                {
-                    'id': 321,
-                    'title': 'This is a brief',
-                    'status': 'draft',
-                    'users': [{
-                        'id': 1
-                    }],
-                    'lotSlug': 'magic-roundabout',
-                }
             ]
 
             response = self.client.get('/admin/users/download/buyers')


### PR DESCRIPTION
For this ticket: https://trello.com/c/wDt7oO83/175-update-the-buyer-csv

Including briefs is causing this list to time out in production, and it turns out that no-one actually needs this info these days anyway.

So this greatly simplifies the buyer user list download to only include email address and name.

Sample output file from my local machine:
```
email address,name
localtest@gov.uk,DM Functional Test Buyer User 1
921c7860ab5c62e01c542fd895a22672@example.gov.uk,Hugs and Cuddles Ministry
af790a39a1aa6a3770019340c81434d3@example.gov.uk,Hugs and Cuddles Ministry
kevin.keenoy+buyer2@digital.cabinet-office.gov.uk,Kev
kevin.keenoy+buyer@digital.cabinet-office.gov.uk,Kev Keenoy
kev@gov.uk,Kev.UK
```