### PR TITLE
Move find a user by email field to its own page

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -24,19 +24,19 @@ def find_user_by_email_address():
     if email_address:
         users = data_api_client.get_user(email_address=request.args.get("email_address"))
 
-    if users:
-        return render_template(
-            template,
-            users=[users['users']],
-            email_address=request.args.get("email_address")
-        )
-    else:
+    if not users and 'email_address' in request.args:
         flash('no_users', 'error')
         return render_template(
             template,
             users=list(),
             email_address=None
         ), 404
+    else:
+        return render_template(
+            template,
+            users=[users['users']] if users else list(),
+            email_address=request.args.get("email_address")
+        )
 
 
 # TODO: This page to die once links to framework-specific lists is on index page

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -75,14 +75,15 @@
 
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
-        <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-          <label class="question-heading" for="email_address">Find users by email address</label>
-          <p class='hint'>
-            eg john@smokeyjoes.com
-          </p>
-          <input type="text" name="email_address" id="email_address" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
+          {% with items = [
+            {
+              "link": url_for('.find_user_by_email_address'),
+              "title": "Find a user by email"
+            },
+          ]
+          %}
+            {% include "toolkit/browse-list.html" %}
+          {% endwith %}
 
         <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
           <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -75,6 +75,22 @@
 
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
+        <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+          <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
+          <p class='hint'>
+            You can find this number at the end of the opportunities’ URL.
+          </p>
+          <input type="text" name="brief_id" id="brief_id" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+        </form>
+
+          {% with
+            smaller = True,
+            heading = "User support"
+          %}
+            {% include "toolkit/page-heading.html" %}
+          {% endwith %}
+
           {% with items = [
             {
               "link": url_for('.find_user_by_email_address'),
@@ -84,15 +100,6 @@
           %}
             {% include "toolkit/browse-list.html" %}
           {% endwith %}
-
-        <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-          <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
-          <p class='hint'>
-            You can find this number at the end of the opportunities’ URL.
-          </p>
-          <input type="text" name="brief_id" id="brief_id" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
 
         {% endif %}
       </div>

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -37,9 +37,26 @@
   {% endif %}
   {% endwith %}
 
-  {% with heading = email_address if email_address %}
+  {% with heading = "Find a user" %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}
+
+  <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
+  {%
+    with
+    question = "Find a user by email",
+    name = "email_address"
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+  {%
+    with
+    type = "save",
+    label = "Search"
+  %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
+  </form>
 
   {% call(item) summary.list_table(
           users,
@@ -144,14 +161,6 @@
 
       {% endcall %}
       {% endcall %}
-  <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-    <label class="question-heading" for="email_address">Find users by email address</label>
-    <p class='hint'>
-      eg name@example.com
-    </p>
-    <input type="text" name="email_address" id="email_address" class="text-box" maxlength="200">
-    <input type="submit" value="Search" class="button-save">
-  </form>
   </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -50,6 +50,40 @@ class TestIndex(LoggedInApplicationTest):
         )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", True),
+        ("admin-ccs-category", True),
+        ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
+        ("admin-manager", False),
+    ])
+    def test_user_support_header_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        header_is_visible = "User support" in data
+
+        assert header_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", True),
+        ("admin-ccs-category", True),
+        ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
+        ("admin-manager", False),
+    ])
+    def test_find_a_user_by_email_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Find a user by email" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from lxml import html
 
 from ...helpers import LoggedInApplicationTest
 
@@ -42,28 +43,28 @@ class TestIndex(LoggedInApplicationTest):
     def test_add_buyer_email_domain_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Add a buyer email domain" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/buyers/add-buyer-domains"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", True),
         ("admin-ccs-category", True),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", False),
         ("admin-manager", False),
     ])
-    def test_user_support_header_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+    def test_user_support_header_is_shown_to_users_with_right_roles(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        header_is_visible = "User support" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"User support")]'))
 
-        assert header_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
@@ -76,8 +77,8 @@ class TestIndex(LoggedInApplicationTest):
     def test_find_a_user_by_email_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Find a user by email" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/users"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
@@ -93,8 +94,8 @@ class TestIndex(LoggedInApplicationTest):
     def test_manage_admin_users_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Manage users" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/admin-users"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
@@ -110,62 +111,62 @@ class TestIndex(LoggedInApplicationTest):
     def test_check_service_edits_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Check edits to services" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/services/updates/unapproved"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", True),
         ("admin-framework-manager", True),
         ("admin-manager", False),
     ])
-    def test_statistics_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+    def test_statistics_header_is_shown_to_users_with_the_right_role(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Statistics" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"Statistics")]'))
 
-        assert link_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", True),
         ("admin-ccs-sourcing", True),
         ("admin-framework-manager", True),
         ("admin-manager", False),
     ])
-    def test_view_agreements_links_are_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+    def test_view_agreements_links_are_shown_to_users_with_the_right_role(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Agreements" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"Agreements")]'))
 
-        assert link_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", True),
         ("admin-manager", False),
     ])
-    def test_view_communications_links_are_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+    def test_view_communications_links_are_shown_to_users_with_the_right_role(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Communications" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"Communications")]'))
 
-        assert link_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
@@ -178,8 +179,8 @@ class TestIndex(LoggedInApplicationTest):
     def test_download_user_lists_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Download user lists" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/users/download"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -28,6 +28,18 @@ class TestUsersView(LoggedInApplicationTest):
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
+    def test_should_show_find_users_page(self, data_api_client):
+        data_api_client.get_user.return_value = None
+        response = self.client.get('/admin/users')
+        page_html = response.get_data(as_text=True)
+        document = html.fromstring(page_html)
+        heading = document.xpath(
+            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+
+        assert response.status_code == 200
+        assert "Sorry, we couldn't find an account with that email address" not in page_html
+        assert heading == "Find a user"
+
     def test_should_be_a_404_if_user_not_found(self, data_api_client):
         data_api_client.get_user.return_value = None
         response = self.client.get('/admin/users?email_address=some@email.com')
@@ -58,21 +70,6 @@ class TestUsersView(LoggedInApplicationTest):
             '//p[@class="summary-item-no-content"]//text()')[0].strip()
         assert page_title == "No users to show"
 
-    def test_should_be_a_404_if_no_email_param_provided(self, data_api_client):
-        data_api_client.get_user.return_value = None
-        response = self.client.get('/admin/users')
-        assert response.status_code == 404
-
-        document = html.fromstring(response.get_data(as_text=True))
-
-        page_title = document.xpath(
-            '//p[@class="banner-message"]//text()')[0].strip()
-        assert page_title == "Sorry, we couldn't find an account with that email address"
-
-        page_title = document.xpath(
-            '//p[@class="summary-item-no-content"]//text()')[0].strip()
-        assert page_title == "No users to show"
-
     def test_should_show_buyer_user(self, data_api_client):
         buyer = self.load_example_listing("user_response")
         buyer.pop('supplier', None)
@@ -82,10 +79,6 @@ class TestUsersView(LoggedInApplicationTest):
         assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
-
-        email_address = document.xpath(
-            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
-        assert email_address == "test.user@sme.com"
 
         name = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[0].strip()
@@ -130,10 +123,6 @@ class TestUsersView(LoggedInApplicationTest):
         assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
-
-        email_address = document.xpath(
-            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
-        assert email_address == "test.user@sme.com"
 
         role = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()


### PR DESCRIPTION
**All changes here are included in: https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/331 - so if you feel like a bigger review then head straight over there!**

Trello ticket: https://trello.com/c/GfqT3M7t/166-move-find-a-user-by-email-field-to-its-own-page

 - Also refactor some tests

### Find a user page:
<img width="1102" alt="screen shot 2017-12-06 at 12 22 37" src="https://user-images.githubusercontent.com/20957548/33661533-431d3bb6-da80-11e7-80e6-91a55079b12f.png">

---
### Relevant section on the homepage:
<img width="718" alt="screen shot 2017-12-06 at 12 22 52" src="https://user-images.githubusercontent.com/20957548/33661534-4330cce4-da80-11e7-9dc1-d104a9b830ef.png">