### PR TITLE
Move find buyer by opportunity field to its own page

### DIFF
--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -12,26 +12,21 @@ from ... import data_api_client
 @role_required('admin', 'admin-ccs-category')
 def find_buyer_by_brief_id():
     brief_id = request.args.get('brief_id')
+    brief = None
+    status_code = 200
 
     try:
-        brief = data_api_client.get_brief(brief_id).get('briefs')
-
+        brief = data_api_client.get_brief(brief_id)
     except:
-        flash('no_brief', 'error')
-        return render_template(
-            "view_buyers.html",
-            users=list(),
-            brief_id=brief_id
-        ), 404
+        if not brief and 'brief_id' in request.args:
+            flash('no_brief', 'error')
+            status_code = 404
 
-    users = brief.get('users')
-    title = brief.get('title')
     return render_template(
         "view_buyers.html",
-        users=users,
-        title=title,
+        brief=brief.get('briefs') if brief else None,
         brief_id=brief_id
-    )
+    ), status_code
 
 
 @main.route('/buyers/add-buyer-domains', methods=['GET', 'POST'])

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -17,8 +17,8 @@ def find_buyer_by_brief_id():
 
     try:
         brief = data_api_client.get_brief(brief_id)
-    except:
-        if not brief and 'brief_id' in request.args:
+    except HTTPError:
+        if 'brief_id' in request.args:
             flash('no_brief', 'error')
             status_code = 404
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -19,10 +19,9 @@ CLOSED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 def find_user_by_email_address():
     template = "view_users.html"
     users = None
-
     email_address = request.args.get("email_address", None)
     if email_address:
-        users = data_api_client.get_user(email_address=request.args.get("email_address"))
+        users = data_api_client.get_user(email_address=email_address)
 
     if not users and 'email_address' in request.args:
         flash('no_users', 'error')
@@ -35,7 +34,7 @@ def find_user_by_email_address():
         return render_template(
             template,
             users=[users['users']] if users else list(),
-            email_address=request.args.get("email_address")
+            email_address=email_address
         )
 
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -17,25 +17,23 @@ CLOSED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 @main.route('/users', methods=['GET'])
 @role_required('admin', 'admin-ccs-category')
 def find_user_by_email_address():
-    template = "view_users.html"
     users = None
-    email_address = request.args.get("email_address", None)
-    if email_address:
-        users = data_api_client.get_user(email_address=email_address)
+    email_address = None
+    response_code = 200
 
-    if not users and 'email_address' in request.args:
-        flash('no_users', 'error')
-        return render_template(
-            template,
-            users=list(),
-            email_address=None
-        ), 404
-    else:
-        return render_template(
-            template,
-            users=[users['users']] if users else list(),
-            email_address=email_address
-        )
+    if "email_address" in request.args:
+        email_address = request.args.get("email_address")
+        if email_address:
+            users = data_api_client.get_user(email_address=email_address)
+        if not users:
+            flash('no_users', 'error')
+            response_code = 404
+
+    return render_template(
+        "view_users.html",
+        users=[users['users']] if users else list(),
+        email_address=email_address
+    ), response_code
 
 
 # TODO: This page to die once links to framework-specific lists is on index page

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -24,19 +24,19 @@ def find_user_by_email_address():
     if email_address:
         users = data_api_client.get_user(email_address=request.args.get("email_address"))
 
-    if users:
-        return render_template(
-            template,
-            users=[users['users']],
-            email_address=request.args.get("email_address")
-        )
-    else:
+    if not users and 'email_address' in request.args:
         flash('no_users', 'error')
         return render_template(
             template,
             users=list(),
             email_address=None
         ), 404
+    else:
+        return render_template(
+            template,
+            users=[users['users']] if users else list(),
+            email_address=request.args.get("email_address")
+        )
 
 
 # TODO: This page to die once links to framework-specific lists is on index page

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -75,15 +75,6 @@
 
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
-        <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-          <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
-          <p class='hint'>
-            You can find this number at the end of the opportunities’ URL.
-          </p>
-          <input type="text" name="brief_id" id="brief_id" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
-
           {% with
             smaller = True,
             heading = "User support"
@@ -101,6 +92,15 @@
             {% include "toolkit/browse-list.html" %}
           {% endwith %}
 
+          {% with items = [
+            {
+              "link": url_for('.find_buyer_by_brief_id'),
+              "title": "Find a buyer by opportunity ID"
+            },
+          ]
+          %}
+            {% include "toolkit/browse-list.html" %}
+          {% endwith %}
         {% endif %}
       </div>
     </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -75,14 +75,15 @@
 
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
-        <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-          <label class="question-heading" for="email_address">Find users by email address</label>
-          <p class='hint'>
-            eg john@smokeyjoes.com
-          </p>
-          <input type="text" name="email_address" id="email_address" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
+          {% with items = [
+            {
+              "link": url_for('.find_user_by_email_address'),
+              "title": "Find a user by email"
+            },
+          ]
+          %}
+            {% include "toolkit/browse-list.html" %}
+          {% endwith %}
 
         <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
           <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -75,6 +75,22 @@
 
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
+        <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+          <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
+          <p class='hint'>
+            You can find this number at the end of the opportunities’ URL.
+          </p>
+          <input type="text" name="brief_id" id="brief_id" class="text-box">
+          <input type="submit" value="Search" class="button-save">
+        </form>
+
+          {% with
+            smaller = True,
+            heading = "User support"
+          %}
+            {% include "toolkit/page-heading.html" %}
+          {% endwith %}
+
           {% with items = [
             {
               "link": url_for('.find_user_by_email_address'),
@@ -84,15 +100,6 @@
           %}
             {% include "toolkit/browse-list.html" %}
           {% endwith %}
-
-        <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-          <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
-          <p class='hint'>
-            You can find this number at the end of the opportunities’ URL.
-          </p>
-          <input type="text" name="brief_id" id="brief_id" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
 
         {% endif %}
       </div>

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -37,12 +37,32 @@
   {% endif %}
   {% endwith %}
 
-  {% with heading = brief_id + ' - ' + title if title %}
+  {% with heading = "Find a buyer" %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
+
+  <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
+    {%
+      with
+      question = "Find a buyer by opportunity ID",
+      name = "brief_id",
+      hint = "You can find this number at the end of the opportunities’ URL."
+    %}
+      {% include "toolkit/forms/textbox.html" %}
+    {% endwith %}
+    {%
+      with
+      type = "save",
+      label = "Search"
+    %}
+      {% include "toolkit/button.html" %}
+    {% endwith %}
+  </form>
+
+  {{ summary.heading(brief.title) }}
   {% call(item) summary.list_table(
-          users,
+          brief.users,
           caption="Buyers",
           empty_message="No buyers to show",
           field_headings=[
@@ -69,17 +89,6 @@
       {% endcall %}
 
   {% endcall %}
-
-  <br>
-
-  <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
-      <label class="question-heading" for="brief_id">Find buyer by opportunity ID</label>
-      <p class='hint'>
-        You can find this number at the end of the opportunities’ URL.
-      </p>
-      <input type="text" name="brief_id" id="brief_id" class="text-box">
-      <input type="submit" value="Search" class="button-save">
-  </form>
   </div>
 
 {% endblock %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -37,9 +37,26 @@
   {% endif %}
   {% endwith %}
 
-  {% with heading = email_address if email_address %}
+  {% with heading = "Find a user" %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}
+
+  <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
+  {%
+    with
+    question = "Find a user by email",
+    name = "email_address"
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+  {%
+    with
+    type = "save",
+    label = "Search"
+  %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
+  </form>
 
   {% call(item) summary.list_table(
           users,
@@ -144,14 +161,6 @@
 
       {% endcall %}
       {% endcall %}
-  <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-    <label class="question-heading" for="email_address">Find users by email address</label>
-    <p class='hint'>
-      eg name@example.com
-    </p>
-    <input type="text" name="email_address" id="email_address" class="text-box" maxlength="200">
-    <input type="submit" value="Search" class="button-save">
-  </form>
   </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -35,13 +35,13 @@ class TestBuyersView(LoggedInApplicationTest):
         assert heading == "Find a buyer"
 
     def test_should_be_a_404_if_no_brief_found(self, data_api_client):
-        data_api_client.get_brief.side_effect = Response(status_code=404)
+        data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
         response = self.client.get('admin/buyers?brief_id=1')
 
         assert response.status_code == 404
 
     def test_should_display_a_useful_message_if_no_brief_found(self, data_api_client):
-        data_api_client.get_brief.side_effect = Response(status_code=404)
+        data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
         response = self.client.get('admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
@@ -54,7 +54,7 @@ class TestBuyersView(LoggedInApplicationTest):
         Asserts that raw HTML in a bad brief ID cannot be injected into a flash message.
         """
         # impl copied from test_should_display_a_useful_message_if_no_brief_found
-        data_api_client.get_brief.side_effect = Response(status_code=404)
+        data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
         response = self.client.get('admin/buyers?brief_id=1%3Cimg%20src%3Da%20onerror%3Dalert%281%29%3E')
         assert response.status_code == 404
 

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -4,7 +4,7 @@ from dmapiclient import HTTPError
 from lxml import html
 
 from tests.app.main.helpers.flash_tester import assert_flashes
-from ...helpers import LoggedInApplicationTest
+from ...helpers import LoggedInApplicationTest, Response
 
 
 @mock.patch('app.main.views.buyers.data_api_client')
@@ -14,6 +14,7 @@ class TestBuyersView(LoggedInApplicationTest):
         ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 403),
         ("admin-manager", 403),
+        ("admin-framework-manager", 403),
     ])
     def test_find_buyers_page_is_only_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
         self.user_role = role
@@ -21,14 +22,26 @@ class TestBuyersView(LoggedInApplicationTest):
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_should_be_a_404_if_no_brief_found(self, data_api_client):
+    def test_should_show_find_buyers_page(self, data_api_client):
         data_api_client.get_brief.return_value = None
+        response = self.client.get('admin/buyers')
+        page_html = response.get_data(as_text=True)
+        document = html.fromstring(page_html)
+        heading = document.xpath(
+            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+
+        assert response.status_code == 200
+        assert "There are no opportunities with ID" not in page_html
+        assert heading == "Find a buyer"
+
+    def test_should_be_a_404_if_no_brief_found(self, data_api_client):
+        data_api_client.get_brief.side_effect = Response(status_code=404)
         response = self.client.get('admin/buyers?brief_id=1')
 
         assert response.status_code == 404
 
     def test_should_display_a_useful_message_if_no_brief_found(self, data_api_client):
-        data_api_client.get_brief.return_value = None
+        data_api_client.get_brief.side_effect = Response(status_code=404)
         response = self.client.get('admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
@@ -41,7 +54,7 @@ class TestBuyersView(LoggedInApplicationTest):
         Asserts that raw HTML in a bad brief ID cannot be injected into a flash message.
         """
         # impl copied from test_should_display_a_useful_message_if_no_brief_found
-        data_api_client.get_brief.return_value = None
+        data_api_client.get_brief.side_effect = Response(status_code=404)
         response = self.client.get('admin/buyers?brief_id=1%3Cimg%20src%3Da%20onerror%3Dalert%281%29%3E')
         assert response.status_code == 404
 
@@ -62,6 +75,16 @@ class TestBuyersView(LoggedInApplicationTest):
         table_content = document.xpath('//p[@class="summary-item-no-content"]//text()')[0].strip()
 
         assert table_content == "No buyers to show"
+
+    def test_should_show_brief_title(self, data_api_client):
+        brief = self.load_example_listing("brief_response")
+        data_api_client.get_brief.return_value = brief
+        response = self.client.get('/admin/buyers?brief_id=1')
+
+        document = html.fromstring(response.get_data(as_text=True))
+        title = document.xpath('//h2[@class="summary-item-heading"]//text()')[0].strip()
+
+        assert title == "Individual Specialist-Buyer Requirements"
 
     def test_should_show_buyers_contact_details(self, data_api_client):
         brief = self.load_example_listing("brief_response")

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -50,6 +50,40 @@ class TestIndex(LoggedInApplicationTest):
         )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", True),
+        ("admin-ccs-category", True),
+        ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
+        ("admin-manager", False),
+    ])
+    def test_user_support_header_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        header_is_visible = "User support" in data
+
+        assert header_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", True),
+        ("admin-ccs-category", True),
+        ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
+        ("admin-manager", False),
+    ])
+    def test_find_a_user_by_email_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        data = response.get_data(as_text=True)
+        link_is_visible = "Find a user by email" in data
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -185,3 +185,20 @@ class TestIndex(LoggedInApplicationTest):
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
         )
+
+    @pytest.mark.parametrize("role, link_should_be_visible", [
+        ("admin", True),
+        ("admin-ccs-category", True),
+        ("admin-ccs-sourcing", False),
+        ("admin-framework-manager", False),
+        ("admin-manager", False),
+    ])
+    def test_find_buyer_by_opportunity_id_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+        self.user_role = role
+        response = self.client.get('/admin')
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/buyers"]'))
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from lxml import html
 
 from ...helpers import LoggedInApplicationTest
 
@@ -42,28 +43,28 @@ class TestIndex(LoggedInApplicationTest):
     def test_add_buyer_email_domain_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Add a buyer email domain" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/buyers/add-buyer-domains"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", True),
         ("admin-ccs-category", True),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", False),
         ("admin-manager", False),
     ])
-    def test_user_support_header_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+    def test_user_support_header_is_shown_to_users_with_right_roles(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        header_is_visible = "User support" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"User support")]'))
 
-        assert header_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
@@ -76,8 +77,8 @@ class TestIndex(LoggedInApplicationTest):
     def test_find_a_user_by_email_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Find a user by email" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/users"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
@@ -93,8 +94,8 @@ class TestIndex(LoggedInApplicationTest):
     def test_manage_admin_users_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Manage users" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/admin-users"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
@@ -110,62 +111,62 @@ class TestIndex(LoggedInApplicationTest):
     def test_check_service_edits_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Check edits to services" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/services/updates/unapproved"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", True),
         ("admin-framework-manager", True),
         ("admin-manager", False),
     ])
-    def test_statistics_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+    def test_statistics_header_is_shown_to_users_with_the_right_role(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Statistics" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"Statistics")]'))
 
-        assert link_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", True),
         ("admin-ccs-sourcing", True),
         ("admin-framework-manager", True),
         ("admin-manager", False),
     ])
-    def test_view_agreements_links_are_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+    def test_view_agreements_links_are_shown_to_users_with_the_right_role(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Agreements" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"Agreements")]'))
 
-        assert link_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
-    @pytest.mark.parametrize("role, link_should_be_visible", [
+    @pytest.mark.parametrize("role, header_should_be_visible", [
         ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", True),
         ("admin-manager", False),
     ])
-    def test_view_communications_links_are_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
+    def test_view_communications_links_are_shown_to_users_with_the_right_role(self, role, header_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Communications" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        header_is_visible = bool(document.xpath('.//h1[contains(text(),"Communications")]'))
 
-        assert link_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        assert header_is_visible is header_should_be_visible, (
+            "Role {} {} see the header".format(role, "can not" if header_should_be_visible else "can")
         )
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
@@ -178,8 +179,8 @@ class TestIndex(LoggedInApplicationTest):
     def test_download_user_lists_link_is_shown_to_users_with_the_right_role(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Download user lists" in data
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/users/download"]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -28,6 +28,18 @@ class TestUsersView(LoggedInApplicationTest):
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
+    def test_should_show_find_users_page(self, data_api_client):
+        data_api_client.get_user.return_value = None
+        response = self.client.get('/admin/users')
+        page_html = response.get_data(as_text=True)
+        document = html.fromstring(page_html)
+        heading = document.xpath(
+            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+
+        assert response.status_code == 200
+        assert "Sorry, we couldn't find an account with that email address" not in page_html
+        assert heading == "Find a user"
+
     def test_should_be_a_404_if_user_not_found(self, data_api_client):
         data_api_client.get_user.return_value = None
         response = self.client.get('/admin/users?email_address=some@email.com')
@@ -58,21 +70,6 @@ class TestUsersView(LoggedInApplicationTest):
             '//p[@class="summary-item-no-content"]//text()')[0].strip()
         assert page_title == "No users to show"
 
-    def test_should_be_a_404_if_no_email_param_provided(self, data_api_client):
-        data_api_client.get_user.return_value = None
-        response = self.client.get('/admin/users')
-        assert response.status_code == 404
-
-        document = html.fromstring(response.get_data(as_text=True))
-
-        page_title = document.xpath(
-            '//p[@class="banner-message"]//text()')[0].strip()
-        assert page_title == "Sorry, we couldn't find an account with that email address"
-
-        page_title = document.xpath(
-            '//p[@class="summary-item-no-content"]//text()')[0].strip()
-        assert page_title == "No users to show"
-
     def test_should_show_buyer_user(self, data_api_client):
         buyer = self.load_example_listing("user_response")
         buyer.pop('supplier', None)
@@ -82,10 +79,6 @@ class TestUsersView(LoggedInApplicationTest):
         assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
-
-        email_address = document.xpath(
-            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
-        assert email_address == "test.user@sme.com"
 
         name = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[0].strip()
@@ -130,10 +123,6 @@ class TestUsersView(LoggedInApplicationTest):
         assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
-
-        email_address = document.xpath(
-            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
-        assert email_address == "test.user@sme.com"
 
         role = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -20,6 +20,7 @@ class TestUsersView(LoggedInApplicationTest):
         ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 403),
         ("admin-manager", 403),
+        ("admin-framework-manager", 403),
     ])
     def test_find_users_page_is_only_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
         self.user_role = role


### PR DESCRIPTION
**This follows the commits here: https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/329**
**Only the final two commits here are new since then**

For this ticket: https://trello.com/c/tuG2TN4H/165-move-find-buyer-by-opportunity-field-to-its-own-page

### New link on home page:
![screen shot 2017-12-06 at 16 07 04](https://user-images.githubusercontent.com/6525554/33671495-adf9fa22-da9f-11e7-8dfc-ef153e6c1c0e.png)


### Updated "find a buyer" page:
![screen shot 2017-12-06 at 16 07 29](https://user-images.githubusercontent.com/6525554/33671498-b164e8a2-da9f-11e7-99cf-189986a087fa.png)

