### PR TITLE
164 Change name label and description for roles in the admin manager view

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -6,6 +6,14 @@ from dmutils.forms import StripWhitespaceStringField
 from .. import data_api_client
 
 
+ADMIN_ROLES = [
+    ('admin-framework-manager', 'Manage framework applications'),
+    ('admin-ccs-sourcing', 'Audit framework applications (CCS Sourcing)'),
+    ('admin-ccs-category', 'Manage services (CCS Category)',),
+    ('admin', 'Support user accounts'),
+]
+
+
 class AdminEmailAddressValidator(object):
 
     def __init__(self, message=None):
@@ -37,12 +45,6 @@ class EmailDomainForm(Form):
 
 
 class InviteAdminForm(Form):
-    role_choices = [
-        ('admin-ccs-category', 'Category'),
-        ('admin-framework-manager', 'Framework Manager'),
-        ('admin-ccs-sourcing', 'Sourcing'),
-        ('admin', 'Support'),
-    ]
 
     email_address = StripWhitespaceStringField(
         'Email address',
@@ -55,12 +57,12 @@ class InviteAdminForm(Form):
     role = RadioField(
         'Permissions',
         validators=[validators.InputRequired(message='You must choose a permission')],
-        choices=role_choices
+        choices=ADMIN_ROLES
     )
 
     def __init__(self, *args, **kwargs):
         super(InviteAdminForm, self).__init__(*args, **kwargs)
-        self.role.toolkit_macro_options = [{'value': i[0], 'label': i[1]} for i in self.role_choices]
+        self.role.toolkit_macro_options = [{'value': i[0], 'label': i[1]} for i in ADMIN_ROLES]
 
 
 class EditAdminUserForm(Form):
@@ -68,14 +70,7 @@ class EditAdminUserForm(Form):
         DataRequired(message="You must provide a name.")
     ])
 
-    permissions_choices = [
-        ("admin-ccs-category", "Category"),
-        ('admin-framework-manager', 'Framework Manager'),
-        ("admin-ccs-sourcing", "Sourcing"),
-        ("admin", "Support"),
-    ]
-
-    edit_admin_permissions = RadioField('Permissions', choices=permissions_choices)
+    edit_admin_permissions = RadioField('Permissions', choices=ADMIN_ROLES)
 
     status_choices = [
         ("True", "Active"),
@@ -87,7 +82,7 @@ class EditAdminUserForm(Form):
     def __init__(self, *args, **kwargs):
         super(EditAdminUserForm, self).__init__(*args, **kwargs)
         self.edit_admin_permissions.toolkit_macro_options = [
-            {'value': choice[0], 'label': choice[1]} for choice in self.permissions_choices
+            {'value': choice[0], 'label': choice[1]} for choice in ADMIN_ROLES
         ]
         self.edit_admin_status.toolkit_macro_options = [
             {'value': choice[0], 'label': choice[1]} for choice in self.status_choices

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -7,10 +7,26 @@ from .. import data_api_client
 
 
 ADMIN_ROLES = [
-    ('admin-framework-manager', 'Manage framework applications'),
-    ('admin-ccs-sourcing', 'Audit framework applications (CCS Sourcing)'),
-    ('admin-ccs-category', 'Manage services (CCS Category)',),
-    ('admin', 'Support user accounts'),
+    (
+        'admin-framework-manager',
+        'Manage framework applications',
+        'Manages communications about the framework and publishes supplier clarification questions.',
+    ),
+    (
+        'admin-ccs-sourcing',
+        'Audit framework applications (CCS Sourcing)',
+        'Checks declarations and agreements.',
+    ),
+    (
+        'admin-ccs-category',
+        'Manage services (CCS Category)',
+        'Helps with service problems and makes sure services are in scope.',
+    ),
+    (
+        'admin',
+        'Support user accounts',
+        'Helps buyers and suppliers solve problems with their accounts.'
+    ),
 ]
 
 
@@ -57,12 +73,18 @@ class InviteAdminForm(Form):
     role = RadioField(
         'Permissions',
         validators=[validators.InputRequired(message='You must choose a permission')],
-        choices=ADMIN_ROLES
+        choices=[(code, name) for code, name, description in ADMIN_ROLES]
     )
 
     def __init__(self, *args, **kwargs):
         super(InviteAdminForm, self).__init__(*args, **kwargs)
-        self.role.toolkit_macro_options = [{'value': i[0], 'label': i[1]} for i in ADMIN_ROLES]
+        self.role.toolkit_macro_options = [
+            {
+                'value': choice[0],
+                'label': choice[1],
+                'description': choice[2]
+            } for choice in ADMIN_ROLES
+        ]
 
 
 class EditAdminUserForm(Form):
@@ -70,7 +92,10 @@ class EditAdminUserForm(Form):
         DataRequired(message="You must provide a name.")
     ])
 
-    edit_admin_permissions = RadioField('Permissions', choices=ADMIN_ROLES)
+    edit_admin_permissions = RadioField(
+        'Permissions',
+        choices=[(code, name) for code, name, description in ADMIN_ROLES]
+    )
 
     status_choices = [
         ("True", "Active"),
@@ -82,7 +107,11 @@ class EditAdminUserForm(Form):
     def __init__(self, *args, **kwargs):
         super(EditAdminUserForm, self).__init__(*args, **kwargs)
         self.edit_admin_permissions.toolkit_macro_options = [
-            {'value': choice[0], 'label': choice[1]} for choice in ADMIN_ROLES
+            {
+                'value': choice[0],
+                'label': choice[1],
+                'description': choice[2]
+            } for choice in ADMIN_ROLES
         ]
         self.edit_admin_status.toolkit_macro_options = [
             {'value': choice[0], 'label': choice[1]} for choice in self.status_choices

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -37,10 +37,10 @@
 
 <div class="page-section">
   {% set role_descriptors = {
-      "admin": "Support",
-      "admin-ccs-category": "Category",
-      "admin-ccs-sourcing": "Sourcing",
-      "admin-framework-manager": "Framework Manager",
+      "admin": "Support accounts",
+      "admin-ccs-category": "Manage services",
+      "admin-ccs-sourcing": "Audit framework",
+      "admin-framework-manager": "Manage framework",
     }
   %}
 

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -330,6 +330,15 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
             ("Manage services (CCS Category)", True),
             ("Support user accounts", False)
         ]
+        permission_descriptions = [
+            descr.strip() for descr in document.xpath("//p[@class='question-description']/text()")
+        ]
+        assert permission_descriptions == [
+            'Manages communications about the framework and publishes supplier clarification questions.',
+            'Checks declarations and agreements.',
+            'Helps with service problems and makes sure services are in scope.',
+            'Helps buyers and suppliers solve problems with their accounts.'
+        ]
 
     def test_edit_admin_user_form_prefills_status_with_active(self, data_api_client):
         self.user_role = "admin-manager"

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -320,17 +320,16 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
 
         assert document.xpath('//span[@class="question-heading"]')[1].text.strip() == "Permissions"
 
-        assert document.cssselect('#input-edit_admin_permissions-1')[0].label.text.strip() == "Category"
-        assert document.cssselect('#input-edit_admin_permissions-1')[0].checked
-
-        assert document.cssselect('#input-edit_admin_permissions-2')[0].label.text.strip() == "Framework Manager"
-        assert not document.cssselect('#input-edit_admin_permissions-2')[0].checked
-
-        assert document.cssselect('#input-edit_admin_permissions-3')[0].label.text.strip() == "Sourcing"
-        assert not document.cssselect('#input-edit_admin_permissions-3')[0].checked
-
-        assert document.cssselect('#input-edit_admin_permissions-4')[0].label.text.strip() == "Support"
-        assert not document.cssselect('#input-edit_admin_permissions-4')[0].checked
+        permission_options_checked = [
+            (input.label.text.strip(), input.checked)
+            for input in document.xpath("//div[@id='edit_admin_permissions']//input")
+        ]
+        assert permission_options_checked == [
+            ("Manage framework applications", False),
+            ("Audit framework applications (CCS Sourcing)", False),
+            ("Manage services (CCS Category)", True),
+            ("Support user accounts", False)
+        ]
 
     def test_edit_admin_user_form_prefills_status_with_active(self, data_api_client):
         self.user_role = "admin-manager"

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -108,39 +108,47 @@ class TestAdminManagerListView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         rows = document.cssselect(".summary-item-row")
-        # Active users in alphabetical order
+        # Active users in alphabetical order (status, name, role)
         assert "Active" in rows[0].text_content()
         assert "Suspended" not in rows[0].text_content()
         assert "CCS Category Support" in rows[0].text_content()
+        assert "Manage services" in rows[0].text_content()
 
         assert "Active" in rows[1].text_content()
         assert "Suspended" not in rows[1].text_content()
         assert "Extra Support" in rows[1].text_content()
+        assert "Support accounts" in rows[1].text_content()
 
         assert "Active" in rows[2].text_content()
         assert "Suspended" not in rows[2].text_content()
         assert "Rashguy Support" in rows[2].text_content()
+        assert "Support accounts" in rows[2].text_content()
 
         assert "Active" in rows[3].text_content()
         assert "Suspended" not in rows[3].text_content()
         assert "Sourcing Support" in rows[3].text_content()
+        assert "Audit framework" in rows[3].text_content()
 
         assert "Active" in rows[4].text_content()
         assert "Suspended" not in rows[4].text_content()
         assert "Wonderful Framework Manager" in rows[4].text_content()
+        assert "Manage framework" in rows[4].text_content()
 
-        # Deactivated users in alphabetical order
+        # Deactivated users in alphabetical order (status, name, role)
         assert "Active" not in rows[5].text_content()
         assert "Suspended" in rows[5].text_content()
         assert "CCS Category Support - Retired" in rows[5].text_content()
+        assert "Manage services" in rows[5].text_content()
 
         assert "Active" not in rows[6].text_content()
         assert "Suspended" in rows[6].text_content()
         assert "Has-been Framework Manager" in rows[6].text_content()
+        assert "Manage framework" in rows[6].text_content()
 
         assert "Active" not in rows[7].text_content()
         assert "Suspended" in rows[7].text_content()
         assert "Has-been Sourcing Support" in rows[7].text_content()
+        assert "Audit framework" in rows[7].text_content()
 
     def test_should_link_to_edit_admin_user_page(self, data_api_client):
         self.user_role = "admin-manager"


### PR DESCRIPTION
Trello: https://trello.com/c/lrwGdJHl/164-change-name-label-and-description-for-roles-in-the-admin-manager-view

- Show new labels and descriptions on admin user invite form:
![invite-user-labels](https://user-images.githubusercontent.com/3492540/33725460-1bbaba36-db6a-11e7-9617-4fbcc6467ec9.png)
- Show new labels and descriptions on admin user edit form:
![edit-admin-user-labels](https://user-images.githubusercontent.com/3492540/33725562-6af43834-db6a-11e7-917e-0848a14b4dea.png)
- Show short labels in the admin user list:
![admin-user-list](https://user-images.githubusercontent.com/3492540/33725537-533d18d2-db6a-11e7-943c-0405c0a62e34.png)
