### PR TITLE
Move 'find supplier and services' fields to their own page

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -4,7 +4,7 @@ from flask_login import current_user, login_required
 
 main = Blueprint('main', __name__)
 
-from .views import agreements, communications, service_updates, services, suppliers, stats, users, buyers, admin_manager
+from .views import agreements, communications, search, service_updates, services, suppliers, stats, users, buyers, admin_manager
 from app.main import errors
 
 

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -4,7 +4,9 @@ from flask_login import current_user, login_required
 
 main = Blueprint('main', __name__)
 
-from .views import agreements, communications, search, service_updates, services, suppliers, stats, users, buyers, admin_manager
+from .views import (
+    agreements, communications, search, service_updates, services, suppliers, stats, users, buyers, admin_manager
+)
 from app.main import errors
 
 

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -1,0 +1,14 @@
+from flask import render_template, request, redirect, url_for, flash
+from flask_login import current_user
+
+from ... import data_api_client
+from .. import main
+
+from dmapiclient import HTTPError
+from ..auth import role_required
+
+
+@main.route('/find-suppliers-and-services', methods=['GET'])
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
+def find_suppliers_and_services():
+    return render_template("find_suppliers_and_services.html")

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -1,10 +1,5 @@
-from flask import render_template, request, redirect, url_for, flash
-from flask_login import current_user
-
-from ... import data_api_client
+from flask import render_template
 from .. import main
-
-from dmapiclient import HTTPError
 from ..auth import role_required
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -31,7 +31,7 @@ def index():
 @role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
 def find():
     if request.args.get("service_id") is None:
-        return render_template("index.html"), 404
+        return render_template("find_suppliers_and_services.html"), 404
     return redirect(
         url_for(".view", service_id=request.args.get("service_id")))
 
@@ -43,11 +43,11 @@ def view(service_id):
         service = data_api_client.get_service(service_id)
         if service is None:
             flash({'no_service': service_id}, 'error')
-            return redirect(url_for('.index'))
+            return redirect(url_for('.find_suppliers_and_services'))
         service_data = service['services']
     except HTTPError:
         flash({'api_error': service_id}, 'error')
-        return redirect(url_for('.index'))
+        return redirect(url_for('.find_suppliers_and_services'))
 
     removed_by = removed_at = None
     if service_data['status'] != 'published':

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -111,7 +111,7 @@ def update_service_status(service_id):
 @main.route('/services/<service_id>/edit/<section_id>', methods=['GET'])
 @main.route('/services/<service_id>/edit/<section_id>/<question_slug>', methods=['GET'])
 @role_required('admin-ccs-category')
-def edit(service_id, section_id, question_slug=None):
+def edit_service(service_id, section_id, question_slug=None):
     service_data = data_api_client.get_service(service_id)['services']
 
     content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -33,12 +33,12 @@ def find_service():
     if request.args.get("service_id") is None:
         return render_template("find_suppliers_and_services.html"), 404
     return redirect(
-        url_for(".view", service_id=request.args.get("service_id")))
+        url_for(".view_service", service_id=request.args.get("service_id")))
 
 
 @main.route('/services/<service_id>', methods=['GET'])
 @role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
-def view(service_id):
+def view_service(service_id):
     try:
         service = data_api_client.get_service(service_id)
         if service is None:
@@ -90,7 +90,7 @@ def update_service_status(service_id):
         backend_status = translate_frontend_to_api[frontend_status]
     else:
         flash({'bad_status': frontend_status}, 'error')
-        return redirect(url_for('.view', service_id=service_id))
+        return redirect(url_for('.view_service', service_id=service_id))
 
     try:
         data_api_client.update_service_status(
@@ -99,13 +99,13 @@ def update_service_status(service_id):
 
     except HTTPError as e:
         flash({'status_error': e.message}, 'error')
-        return redirect(url_for('.view', service_id=service_id))
+        return redirect(url_for('.view_service', service_id=service_id))
 
     message = "admin.status.updated: " \
               "Service ID %s updated to '%s'"
     current_app.logger.info(message, service_id, frontend_status)
     flash({'status_updated': frontend_status})
-    return redirect(url_for('.view', service_id=service_id))
+    return redirect(url_for('.view_service', service_id=service_id))
 
 
 @main.route('/services/<service_id>/edit/<section_id>', methods=['GET'])
@@ -277,4 +277,4 @@ def update(service_id, section_id, question_slug=None):
             errors=errors,
         ), 400
 
-    return redirect(url_for(".view", service_id=service_id))
+    return redirect(url_for(".view_service", service_id=service_id))

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -29,7 +29,7 @@ def index():
 
 @main.route('/services', methods=['GET'])
 @role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
-def find():
+def find_service():
     if request.args.get("service_id") is None:
         return render_template("find_suppliers_and_services.html"), 404
     return redirect(

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -1,7 +1,6 @@
 {% extends "_base_page.html" %}
-{% block page_title %}
-  Add buyer email domains – Digital Marketplace admin
-{% endblock %}
+
+{% block page_title %}Add buyer email domains – Digital Marketplace admin{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -1,6 +1,7 @@
 {% import 'macros/answers.html' as answers %}
 
 {% extends "_base_page.html" %}
+
 {% block page_title %}
   {{ service['serviceName'] }} – Digital Marketplace admin
 {% endblock %}

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -1,5 +1,9 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}
+  Download supplier lists for {{ framework.name }} - Digital Marketplace admin
+{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/download_users.html
+++ b/app/templates/download_users.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Download user lists - Digital Marketplace admin{% endblock %}
+
 {% block breadcrumb %}
   {%
     with items = [

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -2,8 +2,9 @@
 {% from "macros/assurance.html" import assurance_question %}
 
 {% extends "_base_page.html" %}
+
 {% block page_title %}
-  {{ section.name }} – Digital Marketplace admin
+  Edit {{ section.name }} – Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -15,7 +15,7 @@
         "label": "Admin home"
       },
       {
-        "link": url_for(".view", service_id=service_data.id),
+        "link": url_for(".view_service", service_id=service_data.id),
         "label": service_data['serviceName']
       }
     ]
@@ -68,7 +68,7 @@
           {% include "toolkit/button.html" %}
         {% endwith %}
         <p>
-          <a href="{{ url_for('.view', service_id=service_data.id) }}">Return without saving</a>
+          <a href="{{ url_for('.view_service', service_id=service_data.id) }}">Return without saving</a>
         </p>
       </div>
     </div>

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -1,4 +1,5 @@
 {% extends "_base_page.html" %}
+
 {% block page_title %}
   Change name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -2,6 +2,19 @@
 
 {% block page_title %}Access denied - 403 – Digital Marketplace{% endblock %}
 
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('main.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
   {% with heading = "You don’t have permission to perform this action" %}
     {% include 'toolkit/page-heading.html' %}

--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -1,5 +1,20 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Not found - 404 - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('main.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
   {% with heading = "Page could not be found" %}
     {% include 'toolkit/page-heading.html' %}

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -1,5 +1,20 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Internal server error - 500 - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('main.index'),
+              "label": "Admin home"
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
   {% with heading = "Sorry, we’re experiencing technical difficulties" %}
     {% include 'toolkit/page-heading.html' %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -1,8 +1,3 @@
-{% extends "_base_page.html" %}
-{% block page_title %}
-  Digital Marketplace admin
-{% endblock %}
-
 {% if current_user.role == "admin" %}
   {% set page_title = "Edit supplier accounts or view services" %}
 {% elif current_user.role == "admin-ccs-category" %}
@@ -13,12 +8,18 @@
   {% set page_title = "View suppliers and services" %}
 {% endif %}
 
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+  {{ page_title }} - Digital Marketplace admin
+{% endblock %}
+
 {% block breadcrumb %}
   {%
       with items = [
           {
               "link": url_for('.index'),
-              "label": page_title
+              "label": "Admin home"
           },
       ]
   %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -4,6 +4,25 @@
 {% endblock %}
 
 {% block main_content %}
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        {% if message['no_service'] %}
+          {% set displayed_message = "Could not find a service with ID: {}".format(message['no_service']) %}
+        {% elif message['api_error'] %}
+          {% set displayed_message = "Error trying to retrieve service with ID: {}".format(message['api_error']) %}
+        {% endif %}
+        {%
+          with
+          message = displayed_message,
+          type = "destructive" if category == 'error' else "success"
+        %}
+          {% include "toolkit/notification-banner.html" %}
+        {% endwith %}
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
   {%
     with heading = "Admin"
   %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -3,6 +3,19 @@
   Digital Marketplace admin
 {% endblock %}
 
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          },
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
 
   {% with messages = get_flashed_messages(with_categories=true) %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -24,200 +24,69 @@
     {% endif %}
   {% endwith %}
   {%
-    with heading = "Admin"
+    with heading = "Find suppliers and services"
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
-  {% if current_user.has_role('admin-manager') %}
-    {% with items = [
-      {
-        "link": url_for('.manage_admin_users'),
-        "title": "Manage users"
-      },
-    ]
-    %}
-      {% include "toolkit/browse-list.html" %}
-    {% endwith %}
-  {% endif %}
-
-  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager') %}
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
-        <form action="{{ url_for('.find') }}" method="get" class="question">
-          <label class="question-heading" for="service_id">Find a service by service ID</label>
-          <p class='hint'>
-            eg 1234567890123456
-          </p>
-          <input type="text" name="service_id" id="service_id" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
-        {% endif %}
-
-        <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-          <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
-          <p class="hint">
-            eg searching for c would give all suppliers starting with c
-          </p>
-          <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
-
-        <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-          <label class="question-heading" for="supplier_duns_number">Find suppliers by DUNS number</label>
-          <p class="hint">
-            DUNS numbers are usually 9 digits long, eg 234554321
-          </p>
-          <input type="text" name="supplier_duns_number" id="supplier_duns_number" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
-
-        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-
-          {% with
-            smaller = True,
-            heading = "User support"
-          %}
-            {% include "toolkit/page-heading.html" %}
-          {% endwith %}
-
-          {% with items = [
-            {
-              "link": url_for('.find_user_by_email_address'),
-              "title": "Find a user by email"
-            },
-          ]
-          %}
-            {% include "toolkit/browse-list.html" %}
-          {% endwith %}
-
-          {% with items = [
-            {
-              "link": url_for('.find_buyer_by_brief_id'),
-              "title": "Find a buyer by opportunity ID"
-            },
-          ]
-          %}
-            {% include "toolkit/browse-list.html" %}
-          {% endwith %}
-        {% endif %}
-      </div>
-    </div>
-  {% endif %}
-
-<div class="grid-row">
+  <div class="grid-row">
     <div class="column-two-thirds">
 
-  {% if current_user.has_role('admin') %}
-    {% with items = [
-      {
-        "link": url_for('.add_buyer_domains'),
-        "title": "Add a buyer email domain"
-      },
-    ]
-    %}
-      {% include "toolkit/browse-list.html" %}
-    {% endwith %}
-  {% endif %}
+      <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
+        {%
+          with
+          question = "Find a supplier by name",
+          name = "supplier_name_prefix",
+          hint = "You don't have to put in the full name to get a result."
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+        {%
+          with
+          type = "save",
+          label = "Search"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
 
-  {% if current_user.has_any_role('admin-ccs-category') %}
-    {% with
-      smaller = True,
-      heading = "Service edits"
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    {% with items = [
-      {
-        "link": url_for('.service_update_audits'),
-        "title": "Check edits to services"
-      },
-    ]
-    %}
-      {% include "toolkit/browse-list.html" %}
-    {% endwith %}
-  {% endif %}
+      <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
+        {%
+          with
+          question = "Find a supplier by DUNS number",
+          name = "supplier_duns_number",
+          hint = "DUNS numbers are usually 9 digits long, for example, 234554321"
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+        {%
+          with
+          type = "save",
+          label = "Search"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
 
-  {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
-    {% with
-      smaller = True,
-      heading = "Statistics"
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    {% with items = [
-      {
-        "body": "View G-Cloud 9 statistics",
-        "link": "/admin/statistics/g-cloud-9",
-        "title": "G-Cloud 9 statistics"
-      }
-    ]
-    %}
-     {% include "toolkit/browse-list.html" %}
-    {% endwith %}
-  {% endif %}
-
-  {% if current_user.has_any_role('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager') %}
-    {% with
-      smaller = True,
-      heading = "Agreements"
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    {% for framework in frameworks_for_countersigning %}
-      {% with items = [
-        {
-          "body": "Approve " + framework.name + " agreements for countersigning"
-                  if framework['frameworkAgreementVersion'] else
-                  "Download " + framework.name + " agreements",
-          "title": framework.name + " agreements",
-          "link": url_for('.list_agreements', framework_slug=framework['slug'], status='signed')
-        }
-      ]
-      %}
-        {% include "toolkit/browse-list.html" %}
-      {% endwith %}
-    {% endfor %}
-  {% endif %}
-
-  {% if current_user.has_role('admin-framework-manager') %}
-    {% set items = [
-      {
-        "body": "Manage G-Cloud 8 communications",
-        "link": url_for(".manage_communications", framework_slug="g-cloud-8"),
-        "title": "G-Cloud 8 communications"
-      },
-      {
-        "body": "Manage Digital Outcomes and Specialists 2 communications",
-        "link": url_for(".manage_communications", framework_slug="digital-outcomes-and-specialists-2"),
-        "title": "Digital Outcomes and Specialists 2 communications"
-      },
-      {
-        "body": "Manage G-Cloud 9 communications",
-        "link": url_for(".manage_communications", framework_slug="g-cloud-9"),
-        "title": "G-Cloud 9 communications"
-      },
-      {
-        "body": "Download a list of users for frameworks that are open, pending or live",
-        "link": url_for(".list_frameworks_with_users"),
-        "title": "Download user lists"
-      },
-    ]
-    %}
-
-    {% with
-      smaller = True,
-      heading = "Communications"
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-
-    {% with items = items %}
-      {% include "toolkit/browse-list.html" %}
-    {% endwith %}
-  {% endif %}
-
+      {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
+        <form action="{{ url_for('.find') }}" method="get" class="question">
+          {%
+            with
+            question = "Find a service by service ID",
+            name = "service_id",
+            hint = "For example 123456789012345"
+          %}
+            {% include "toolkit/forms/textbox.html" %}
+          {% endwith %}
+          {%
+            with
+            type = "save",
+            label = "Search"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+      </form>
+      {% endif %}
+    </div>
   </div>
-</div>
 {% endblock %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -93,7 +93,7 @@
       </form>
 
       {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
-        <form action="{{ url_for('.find') }}" method="get" class="question">
+        <form action="{{ url_for('.find_service') }}" method="get" class="question">
           {%
             with
             question = "Find a service by service ID",

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -61,7 +61,7 @@
           with
           question = "Find a supplier by name",
           name = "supplier_name_prefix",
-          hint = "You don't have to put in the full name to get a result."
+          hint = "You don’t have to put in the full name to get a result."
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -3,12 +3,22 @@
   Digital Marketplace admin
 {% endblock %}
 
+{% if current_user.role == "admin" %}
+  {% set page_title = "Edit supplier accounts or view services" %}
+{% elif current_user.role == "admin-ccs-category" %}
+  {% set page_title = "Edit suppliers and services" %}
+{% elif current_user.role == "admin-ccs-sourcing" %}
+  {% set page_title = "Edit supplier declarations" %}
+{% elif current_user.role == "admin-framework-manager" %}
+  {% set page_title = "View suppliers and services" %}
+{% endif %}
+
 {% block breadcrumb %}
   {%
       with items = [
           {
               "link": url_for('.index'),
-              "label": "Admin home"
+              "label": page_title
           },
       ]
   %}
@@ -37,7 +47,7 @@
     {% endif %}
   {% endwith %}
   {%
-    with heading = "Find suppliers and services"
+    with heading = page_title
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -68,6 +68,7 @@
         {%
           with
           type = "save",
+          name = "find_supplier_by_name_search",
           label = "Search"
         %}
           {% include "toolkit/button.html" %}
@@ -86,6 +87,7 @@
         {%
           with
           type = "save",
+          name = "find_supplier_by_duns_number_search",
           label = "Search"
         %}
           {% include "toolkit/button.html" %}
@@ -105,6 +107,7 @@
           {%
             with
             type = "save",
+            name = "find_service_by_id_search",
             label = "Search"
           %}
             {% include "toolkit/button.html" %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,6 @@
 {% extends "_base_page.html" %}
-{% block page_title %}
-  Digital Marketplace admin
-{% endblock %}
+
+{% block page_title %}Digital Marketplace admin{% endblock %}
 
 {% block main_content %}
 <div class="grid-row">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,6 +4,8 @@
 {% endblock %}
 
 {% block main_content %}
+<div class="grid-row">
+  <div class="column-two-thirds">
   {%
     with heading = "Admin"
   %}
@@ -22,38 +24,59 @@
     {% endwith %}
   {% endif %}
 
-        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+  {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
-          {% with
-            smaller = True,
-            heading = "User support"
-          %}
-            {% include "toolkit/page-heading.html" %}
-          {% endwith %}
+    {% with
+      smaller = True,
+      heading = "User support"
+    %}
+      {% include "toolkit/page-heading.html" %}
+    {% endwith %}
 
-          {% with items = [
-            {
-              "link": url_for('.find_user_by_email_address'),
-              "title": "Find a user by email"
-            },
-          ]
-          %}
-            {% include "toolkit/browse-list.html" %}
-          {% endwith %}
+    {% with items = [
+      {
+        "link": url_for('.find_user_by_email_address'),
+        "title": "Find a user by email"
+      },
+    ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+  {% endif %}
 
-          {% with items = [
-            {
-              "link": url_for('.find_buyer_by_brief_id'),
-              "title": "Find a buyer by opportunity ID"
-            },
-          ]
-          %}
-            {% include "toolkit/browse-list.html" %}
-          {% endwith %}
-        {% endif %}
+  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager') %}
 
-<div class="grid-row">
-    <div class="column-two-thirds">
+    {% set link_texts = {
+        'admin': 'Edit supplier accounts or view services',
+        'admin-ccs-category': 'Edit suppliers and services',
+        'admin-ccs-sourcing': 'Edit supplier declarations',
+        'admin-framework-manager': 'View suppliers and services',
+        }
+    %}
+    {% with items = [
+      {
+        "link": url_for('.find_suppliers_and_services'),
+        "title": link_texts[current_user.role]
+      },
+    ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+
+  {% endif %}
+
+  {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+
+    {% with items = [
+      {
+        "link": url_for('.find_buyer_by_brief_id'),
+        "title": "Find a buyer by opportunity ID"
+      },
+    ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+  {% endif %}
 
   {% if current_user.has_role('admin') %}
     {% with items = [

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,38 +22,6 @@
     {% endwith %}
   {% endif %}
 
-  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager') %}
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
-        <form action="{{ url_for('.find') }}" method="get" class="question">
-          <label class="question-heading" for="service_id">Find a service by service ID</label>
-          <p class='hint'>
-            eg 1234567890123456
-          </p>
-          <input type="text" name="service_id" id="service_id" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
-        {% endif %}
-
-        <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-          <label class="question-heading" for="supplier_name_prefix">Find suppliers by name prefix</label>
-          <p class="hint">
-            eg searching for c would give all suppliers starting with c
-          </p>
-          <input type="text" name="supplier_name_prefix" id="supplier_name_prefix" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
-
-        <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-          <label class="question-heading" for="supplier_duns_number">Find suppliers by DUNS number</label>
-          <p class="hint">
-            DUNS numbers are usually 9 digits long, eg 234554321
-          </p>
-          <input type="text" name="supplier_duns_number" id="supplier_duns_number" class="text-box">
-          <input type="submit" value="Search" class="button-save">
-        </form>
-
         {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
 
           {% with
@@ -83,9 +51,6 @@
             {% include "toolkit/browse-list.html" %}
           {% endwith %}
         {% endif %}
-      </div>
-    </div>
-  {% endif %}
 
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -2,6 +2,10 @@
 
 {% extends "_base_page.html" %}
 
+{% block page_title %}
+  Upload {{ framework.name }} communications - Digital Marketplace admin
+{% endblock %}
+
 {% block breadcrumb %}
   {%
       with items = [

--- a/app/templates/service_status_update_audits.html
+++ b/app/templates/service_status_update_audits.html
@@ -1,9 +1,8 @@
 {% import "toolkit/summary-table.html" as summary %}
 
 {% extends "_base_page.html" %}
-{% block page_title %}
-  Digital Marketplace admin
-{% endblock %}
+
+{% block page_title %}Service status changes - Digital Marketplace admin{% endblock %}
 
 {% set csrf = csrf_token() %}
 

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -1,8 +1,9 @@
 {% import "toolkit/summary-table.html" as summary %}
 
 {% extends "_base_page.html" %}
+
 {% block page_title %}
-  Digital Marketplace admin
+  Check edits to services - Digital Marketplace admin
 {% endblock %}
 
 {% set csrf = csrf_token() %}

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -3,7 +3,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-  Change {{ framework.name }} declaration
+  Change {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -4,7 +4,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-  Upload {{ framework.name }} countersigned agreement
+  Upload {{ framework.name }} countersigned agreement - Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -3,7 +3,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-  Change {{ framework.name }} declaration
+  View {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -3,7 +3,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }}
+  Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }} – Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -2,6 +2,8 @@
 
 {% extends "_base_page.html" %}
 
+{% block page_title %}Manage admin users - Digital Marketplace admin{% endblock %}
+
 {% block breadcrumb %}
   {%
       with items = [

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -2,6 +2,10 @@
 
 {% extends "_base_page.html" %}
 
+{% block page_title %}
+  Uploaded {{ framework.name }} framework agreements – Digital Marketplace admin
+{% endblock %}
+
 {% block breadcrumb %}
   {%
       with items = [

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -2,6 +2,10 @@
 
 {% extends "_base_page.html" %}
 
+{% block page_title %}
+  {{ framework.name }} framework agreements - Digital Marketplace admin
+{% endblock %}
+
 {% block breadcrumb %}
   {%
       with items = [

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -2,9 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
-    Buyers – Digital Marketplace admin
-{% endblock %}
+{% block page_title %}Buyers - Digital Marketplace admin{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -90,7 +90,7 @@
         type = "temporary-message",
         heading = "Removed by {} on ".format(removed_by) + "{}.".format(removed_at|dateformat)|nbsp,
         message = (
-          ("<a href='{}'>Publish service</a>"|safe).format(url_for('.view', service_id=service_id, publish=True))
+          ("<a href='{}'>Publish service</a>"|safe).format(url_for('.view_service', service_id=service_id, publish=True))
           if current_user.has_role('admin-ccs-category') else ""
         )
       %}
@@ -118,7 +118,7 @@
         <li><a href="{{ "/{}/services/{}".format(service_data['frameworkFramework'], service_id) }}">View service</a></li>
       {% endif %}
       {% if current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
-        <li><a href="{{ url_for('.view', service_id=service_id, remove=True) }}">Remove service</a></li>
+        <li><a href="{{ url_for('.view_service', service_id=service_id, remove=True) }}">Remove service</a></li>
       {% endif %}
     </ul>
     {# endlinks #}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -126,7 +126,7 @@
     {% for section in sections %}
       {{ summary.heading(section.name) }}
       {% if section.editable and current_user.has_role('admin-ccs-category') %}
-        {{ summary.top_link("Edit", url_for('.edit', service_id=service_id, section_id=section.id)) }}
+        {{ summary.top_link("Edit", url_for('.edit_service', service_id=service_id, section_id=section.id)) }}
       {% endif %}
       {% call(question) summary.list_table(
         section.questions,
@@ -142,7 +142,7 @@
           {{ summary.field_name(question.label) }}
           {{ summary[question.type](question.value, question.assurance) }}
           {% if section.edit_questions and current_user.has_role('admin-ccs-category') %}
-            {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for('.edit', service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+            {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for('.edit_service', service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
           {% endif %}
 
         {% endcall %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -2,6 +2,7 @@
 {% import 'macros/answers.html' as answers %}
 
 {% extends "_base_page.html" %}
+
 {% block page_title %}
   {{ service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] }} – Digital Marketplace admin
 {% endblock %}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -1,6 +1,7 @@
 {% import "toolkit/summary-table.html" as summary %}
 
 {% extends "_base_page.html" %}
+
 {% block page_title %}
   {{ framework.name }} Statistics – Digital Marketplace admin
 {% endblock %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -2,8 +2,9 @@
 {% import 'macros/answers.html' as answers %}
 
 {% extends "_base_page.html" %}
+
 {% block page_title %}
-  {{ supplier.name }} – Digital Marketplace admin
+  {{ supplier.name }} - Services – Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -104,7 +104,7 @@
             {% endcall %}
             {{ summary.edit_link(
                  'Edit' if current_user.has_role('admin-ccs-category') else 'View',
-                 url_for('.view', service_id=item.id)
+                 url_for('.view_service', service_id=item.id)
                )
             }}
           {% endcall %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -3,7 +3,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-  {{ supplier.name }} – Digital Marketplace admin
+  {{ supplier.name }} users – Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -2,6 +2,8 @@
 
 {% extends "_base_page.html" %}
 
+{% block page_title %}Suppliers - Digital Marketplace admin{% endblock %}
+
 {% block breadcrumb %}
   {%
       with items = [

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -3,7 +3,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-    Users – Digital Marketplace admin
+    Find a user – Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -202,3 +202,25 @@ class TestIndex(LoggedInApplicationTest):
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
         )
+
+    @pytest.mark.parametrize("role, link_should_be_visible, expected_link_text", [
+        ("admin", True, "Edit supplier accounts or view services"),
+        ("admin-ccs-category", True, "Edit suppliers and services"),
+        ("admin-ccs-sourcing", True, "Edit supplier declarations"),
+        ("admin-framework-manager", True, "View suppliers and services"),
+        ("admin-manager", False, None),
+    ])
+    def test_link_to_find_suppliers_and_services_page_is_shown_with_role_dependent_text(
+            self, role, link_should_be_visible, expected_link_text
+    ):
+        self.user_role = role
+        response = self.client.get('/admin')
+        document = html.fromstring(response.get_data(as_text=True))
+        link_is_visible = bool(document.xpath('.//a[@href="/admin/find-suppliers-and-services"]'))
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+        if link_should_be_visible:
+            link_text = document.xpath('.//a[@href="/admin/find-suppliers-and-services"]//text()')[0]
+            assert link_text == expected_link_text

--- a/tests/app/main/views/test_search.py
+++ b/tests/app/main/views/test_search.py
@@ -1,0 +1,35 @@
+import mock
+import pytest
+from dmapiclient import HTTPError
+from lxml import html
+
+from tests.app.main.helpers.flash_tester import assert_flashes
+from ...helpers import LoggedInApplicationTest, Response
+
+
+@mock.patch('app.main.views.buyers.data_api_client')
+class TestSearchView(LoggedInApplicationTest):
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 200),
+        ("admin-ccs-category", 200),
+        ("admin-ccs-sourcing", 200),
+        ("admin-manager", 403),
+        ("admin-framework-manager", 200),
+    ])
+    def test_find_suppliers_and_services_page_is_only_accessible_to_specific_user_roles(
+        self, data_api_client, role, expected_code
+    ):
+        self.user_role = role
+        response = self.client.get('/admin/find-suppliers-and-services')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
+    def test_should_show_find_suppliers_and_services_page(self, data_api_client):
+        response = self.client.get('/admin/find-suppliers-and-services')
+        page_html = response.get_data(as_text=True)
+        document = html.fromstring(page_html)
+        heading = document.xpath(
+            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+
+        assert response.status_code == 200
+        assert heading == "Find suppliers and services"

--- a/tests/app/main/views/test_search.py
+++ b/tests/app/main/views/test_search.py
@@ -20,15 +20,22 @@ class TestSearchView(LoggedInApplicationTest):
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_should_show_find_suppliers_and_services_page(self):
+    @pytest.mark.parametrize("role, expected_header", [
+        ("admin", "Edit supplier accounts or view services"),
+        ("admin-ccs-category", "Edit suppliers and services"),
+        ("admin-ccs-sourcing", "Edit supplier declarations"),
+        ("admin-framework-manager", "View suppliers and services"),
+    ])
+    def test_should_show_find_suppliers_and_services_page_with_role_appropriate_header(self, role, expected_header):
+        self.user_role = role
         response = self.client.get('/admin/find-suppliers-and-services')
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
-        heading = document.xpath(
+        header = document.xpath(
             '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
 
         assert response.status_code == 200
-        assert heading == "Find suppliers and services"
+        assert header == expected_header
 
     @pytest.mark.parametrize("role,form_1_exists,form_2_exists,form_3_exists", [
         ("admin", True, True, True),

--- a/tests/app/main/views/test_search.py
+++ b/tests/app/main/views/test_search.py
@@ -1,13 +1,9 @@
-import mock
 import pytest
-from dmapiclient import HTTPError
 from lxml import html
 
-from tests.app.main.helpers.flash_tester import assert_flashes
-from ...helpers import LoggedInApplicationTest, Response
+from ...helpers import LoggedInApplicationTest
 
 
-@mock.patch('app.main.views.buyers.data_api_client')
 class TestSearchView(LoggedInApplicationTest):
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 200),
@@ -17,14 +13,14 @@ class TestSearchView(LoggedInApplicationTest):
         ("admin-framework-manager", 200),
     ])
     def test_find_suppliers_and_services_page_is_only_accessible_to_specific_user_roles(
-        self, data_api_client, role, expected_code
+        self, role, expected_code
     ):
         self.user_role = role
         response = self.client.get('/admin/find-suppliers-and-services')
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_should_show_find_suppliers_and_services_page(self, data_api_client):
+    def test_should_show_find_suppliers_and_services_page(self):
         response = self.client.get('/admin/find-suppliers-and-services')
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
@@ -33,3 +29,32 @@ class TestSearchView(LoggedInApplicationTest):
 
         assert response.status_code == 200
         assert heading == "Find suppliers and services"
+
+    @pytest.mark.parametrize("role,form_1_exists,form_2_exists,form_3_exists", [
+        ("admin", True, True, True),
+        ("admin-ccs-category", True, True, True),
+        ("admin-ccs-sourcing", True, True, False),
+        ("admin-framework-manager", True, True, True),
+    ])
+    def test_forms_visible_for_relevant_roles(self, role, form_1_exists, form_2_exists, form_3_exists):
+        self.user_role = role
+        response = self.client.get('/admin/find-suppliers-and-services')
+        document = html.fromstring(response.get_data(as_text=True))
+        title_1_exists = bool(
+            document.xpath('//span[@class="question-heading"][contains(text(),"Find a supplier by name")]')
+        )
+        title_2_exists = bool(
+            document.xpath('//span[@class="question-heading"][contains(text(),"Find a supplier by DUNS number")]')
+        )
+        title_3_exists = bool(
+            document.xpath('//span[@class="question-heading"][contains(text(),"Find a service by service ID")]')
+        )
+        assert title_1_exists == form_1_exists, (
+            "Role {} {} see the Find a supplier by name form".format(role, "can not" if form_1_exists else "can")
+        )
+        assert title_2_exists == form_2_exists, (
+            "Role {} {} see the Find a supplier by DUNS number form".format(role, "can not" if form_2_exists else "can")
+        )
+        assert title_3_exists == form_3_exists, (
+            "Role {} {} see the Find a service by service ID form".format(role, "can not" if form_3_exists else "can")
+        )

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -359,7 +359,7 @@ class TestServiceView(LoggedInApplicationTest):
 
         response1 = self.client.get('/admin/services/1')
         assert response1.status_code == 302
-        assert response1.location == 'http://localhost/admin'
+        assert response1.location == 'http://localhost/admin/find-suppliers-and-services'
         response2 = self.client.get(response1.location)
         assert b'Error trying to retrieve service with ID: 1' in response2.data
 


### PR DESCRIPTION
Trello ticket: https://trello.com/c/E7fLF72t/167-move-find-supplier-and-services-fields-to-their-own-page

Associated smoketest changes in a PR here **MERGE THESE AT THE SAME TIME AS THIS ONE**:
 - [ ] https://github.com/alphagov/digitalmarketplace-functional-tests/pull/436

### Admin homepage with a link instead of the forms:
<img width="658" alt="screen shot 2017-12-07 at 16 18 38" src="https://user-images.githubusercontent.com/20957548/33725606-8b3f6fc8-db6a-11e7-88d6-69d79cab7d5e.png">

---

### New 'Find suppliers and services' page:
<img width="542" alt="screen shot 2017-12-07 at 16 19 34" src="https://user-images.githubusercontent.com/20957548/33725642-b33054b6-db6a-11e7-92a8-07ce5de0025f.png">

