### PR TITLE
Make buyer download filename nicer

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -137,7 +137,7 @@ def download_buyers():
         csv_generator.iter_csv(rows_iter),
         mimetype='text/csv',
         headers={
-            "Content-Disposition": "attachment;filename=all-digital-marketplace-buyers-on-{}.csv".format(
+            "Content-Disposition": "attachment;filename=all-buyers-on-{}.csv".format(
                 datetime.utcnow().strftime('%Y-%m-%d_at_%H-%M-%S')
             ),
             "Content-Type": "text/csv; header=present"

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -137,8 +137,8 @@ def download_buyers():
         csv_generator.iter_csv(rows_iter),
         mimetype='text/csv',
         headers={
-            "Content-Disposition": "attachment;filename=buyers_{}.csv".format(
-                datetime.utcnow().strftime('%Y%m%dT%H%M%S')
+            "Content-Disposition": "attachment;filename=all-digital-marketplace-buyers-on-{}.csv".format(
+                datetime.utcnow().strftime('%Y-%m-%d_at_%H-%M-%S')
             ),
             "Content-Type": "text/csv; header=present"
         }

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -138,7 +138,7 @@ def download_buyers():
         mimetype='text/csv',
         headers={
             "Content-Disposition": "attachment;filename=all-buyers-on-{}.csv".format(
-                datetime.utcnow().strftime('%Y-%m-%d_at_%H-%M-%S')
+                datetime.utcnow().strftime('%Y-%m-%d-at-%H-%M-%S')
             ),
             "Content-Type": "text/csv; header=present"
         }

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -487,7 +487,10 @@ class TestBuyersExport(LoggedInApplicationTest):
 
             response = self.client.get('/admin/users/download/buyers')
 
-            assert response.headers['Content-Disposition'] == 'attachment;filename=buyers_20160805T160000.csv'
+            assert (
+                response.headers['Content-Disposition'] ==
+                'attachment;filename=all-digital-marketplace-buyers-on-2016-08-05_at_16-00-00.csv'
+            )
 
     @pytest.mark.parametrize("role, expected_code", [
         ("admin", 403),

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -489,7 +489,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
             assert (
                 response.headers['Content-Disposition'] ==
-                'attachment;filename=all-buyers-on-2016-08-05_at_16-00-00.csv'
+                'attachment;filename=all-buyers-on-2016-08-05-at-16-00-00.csv'
             )
 
     @pytest.mark.parametrize("role, expected_code", [

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -489,7 +489,7 @@ class TestBuyersExport(LoggedInApplicationTest):
 
             assert (
                 response.headers['Content-Disposition'] ==
-                'attachment;filename=all-digital-marketplace-buyers-on-2016-08-05_at_16-00-00.csv'
+                'attachment;filename=all-buyers-on-2016-08-05_at_16-00-00.csv'
             )
 
     @pytest.mark.parametrize("role, expected_code", [


### PR DESCRIPTION
I've kept the timestamp as that seems important information, but I think the filename is a bit more human-friendly this way.

Old filename example:
`buyers_20160805T160000.csv`
New filename example:
`all-digital-marketplace-buyers-on-2016-08-05_at_16-00-00.csv`
