### PR TITLE
Services can only be edited while framework is live

### DIFF
--- a/app/main/helpers/frameworks.py
+++ b/app/main/helpers/frameworks.py
@@ -1,0 +1,13 @@
+from flask import abort
+
+
+def get_framework_or_404(client, framework_slug, allowed_statuses=None):
+    if allowed_statuses is None:
+        allowed_statuses = ['open', 'pending', 'standstill', 'live']
+
+    framework = client.get_framework(framework_slug)['frameworks']
+
+    if allowed_statuses and framework['status'] not in allowed_statuses:
+        abort(404)
+
+    return framework

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -134,14 +134,14 @@ class TestServiceView(LoggedInApplicationTest):
 
     def test_service_view_status_enabled(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
-            'frameworkSlug': 'g-cloud-7',
+            'frameworkSlug': 'g-cloud-8',
             'serviceName': 'test',
             'supplierId': 1000,
             'lot': 'iaas',
             'id': "1412",
             "status": "enabled",
         }}
-        data_api_client.get_framework.return_value = {'frameworks': {'slug': 'g-cloud-7', 'status': 'live'}}
+        data_api_client.get_framework.return_value = self.get_framework_api_response
         data_api_client.find_audit_events.return_value = self.find_audit_events_api_response
         response = self.client.get('/admin/services/1412')
 

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -416,54 +416,6 @@ class TestServiceView(LoggedInApplicationTest):
         assert "1<img src=a onerror=alert(1)>" not in html_response
         assert "1&lt;img src=a onerror=alert(1)&gt;" in html_response
 
-    def test_independence_of_viewing_services(self, data_api_client):
-        data_api_client.find_audit_events.return_value = self.find_audit_events_api_response
-        data_api_client.get_framework.return_value = self.get_framework_api_response
-        data_api_client.get_service.return_value = {'services': {
-            'lot': 'SCS',
-            'frameworkSlug': 'g-cloud-8',
-            'serviceName': 'test',
-            'supplierId': 1000,
-            'id': "1",
-            'status': 'published'
-        }}
-        response = self.client.get('/admin/services/1')
-        assert b'Termination cost' in response.data
-
-        data_api_client.get_service.return_value = {'services': {
-            'lot': 'SaaS',
-            'frameworkSlug': 'g-cloud-8',
-            'serviceName': 'test',
-            'supplierId': 1000,
-            'id': "1",
-            'status': 'published'
-        }}
-        response = self.client.get('/admin/services/1')
-        assert b'Termination cost' not in response.data
-
-        data_api_client.get_service.return_value = {'services': {
-            'lot': 'SCS',
-            'frameworkSlug': 'g-cloud-8',
-            'serviceName': 'test',
-            'supplierId': 1000,
-            'id': "1",
-            'status': 'published'
-        }}
-        response = self.client.get('/admin/services/1')
-        assert b'Termination cost' in response.data
-
-        data_api_client.get_service.return_value = {'services': {
-            'lot': 'paas',
-            'serviceName': 'test',
-            'supplierId': 1000,
-            'frameworkSlug': 'g-cloud-8',
-            'id': "1",
-            'status': 'published'
-        }}
-        data_api_client.find_audit_events.return_value = self.find_audit_events_api_response
-        response = self.client.get('/admin/services/1')
-        assert b'Termination cost' in response.data
-
     def test_view_service_link_appears_for_gcloud_framework(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'lot': 'paas',


### PR DESCRIPTION
Part 2 for this ticket: https://trello.com/c/6mO70EhR/186-editing-of-services-from-expired-frameworks

We currently show a list of services on live frameworks to admin users, but if the URL is manipulated to have the ID of a service on an expired framework it could still be edited or have its status changed.

This changes things to prevent that from happening.

There's a thing here where I've copied `get_framework_or_404()` from the supplier frontend.  I thought about putting it somewhere to share between apps, but wasn't sure where the right place would be... utils doesn't generally have API helpers like this, but it could do.  But perhaps the API client would be a better home for these things?  And then I thought that it might be weird to have library functions that abort your whole request, and maybe its nicer for the apps themselves to decide whether to abort, in which case copying it as I've done here is the right thing.

Open to suggestions on this.  Though I'm not promising to fix it for this PR, as it feels more like a piece of work in itself if we're going to extract these kind of helpers to a single place.