### PR TITLE
Use shim link button behaviour from FE toolkit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,12 +14,12 @@
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 
 ; // JavaScript in the govuk_frontend_toolkit doesn't have trailing semicolons
 
 //= include _scroll-through-statistics.js
 //= include _selection-buttons.js
-//= include _shim-links-with-button-role.js
 //= include _tables-to-charts.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/module-loader.js

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v26.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v26.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v9.3.0",
     "hogan": "3.0.2",


### PR DESCRIPTION
This functionality has been moved into the DM frontend toolkit
and so can be pulled in as a dependancy instead. Note, this app
was missing the original shim links file but we will pull in
the dependancy anyway so we can be accessible by default.

Related PR - alphagov/digitalmarketplace-frontend-toolkit#394