### PR TITLE
Fix user permissions to avoid showing empty framework headers

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -70,32 +70,34 @@
       <h2 class="heading-large">Manage applications</h2>
 
     {% for framework in frameworks %}
-      <h3 class="heading-xmedium">{{framework.name}}</h3>
+      {% if framework.status in ["standstill", "live"] or current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
+        <h3 class="heading-xmedium">{{framework.name}}</h3>
 
-      {% if framework.status in ["live", "standstill"] %}
-        {% set agreement_link_text = {
-            'admin-ccs-category': 'View agreements',
-            'admin-ccs-sourcing': 'Countersign agreements',
-            'admin-framework-manager': 'View agreements',
-            }
-        %}
-      <p>
-        <a href="{{ url_for('.list_agreements', framework_slug=framework['slug'], status='signed') }}">{{ agreement_link_text[current_user.role] }}</a>
-      </p>
-      {% endif %}
+        {% if framework.status in ["live", "standstill"] %}
+          {% set agreement_link_text = {
+              'admin-ccs-category': 'View agreements',
+              'admin-ccs-sourcing': 'Countersign agreements',
+              'admin-framework-manager': 'View agreements',
+              }
+          %}
+        <p>
+          <a href="{{ url_for('.list_agreements', framework_slug=framework['slug'], status='signed') }}">{{ agreement_link_text[current_user.role] }}</a>
+        </p>
+        {% endif %}
 
-      {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
-      <p>
-        <a href="{{ url_for('.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
-      </p>
-      {% endif %}
-      {% if current_user.has_any_role('admin-framework-manager') %}
-      <p>
-        <a href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Upload communications</a>
-      </p>
-      <p>
-        <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">Contact suppliers</a>
-      </p>
+        {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
+        <p>
+          <a href="{{ url_for('.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
+        </p>
+        {% endif %}
+        {% if current_user.has_any_role('admin-framework-manager') %}
+        <p>
+          <a href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Upload communications</a>
+        </p>
+        <p>
+          <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">Contact suppliers</a>
+        </p>
+        {% endif %}
       {% endif %}
     {% endfor %}
   {% endif %}

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -200,6 +200,26 @@ class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):
 
         assert bool(document.xpath('.//h3[contains(text(),"Amazing Digital Framework")]')) == header_shown
 
+    @pytest.mark.parametrize('framework_status, header_shown', [
+        ('coming', False),
+        ('open', False),
+        ('pending', False),
+        ('standstill', True),
+        ('live', True),
+        ('expired', False),
+    ])
+    def test_framework_action_lists_only_shown_when_framework_standstill_or_live_for_category_users(
+        self, framework_status, header_shown
+    ):
+        data_api_client.find_frameworks = mock.Mock()
+        data_api_client.find_frameworks.return_value = self._get_mock_framework_response(framework_status)
+
+        self.user_role = "admin-ccs-category"
+        response = self.client.get('/admin')
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert bool(document.xpath('.//h3[contains(text(),"Amazing Digital Framework")]')) == header_shown
+
     @pytest.mark.parametrize('framework_status, agreements_shown, stats_shown, comms_shown, contact_shown', [
         ('coming', False, False, False, False),
         ('open', False, True, True, True),


### PR DESCRIPTION
Trello ticket: https://trello.com/c/eiXTF1OD/1-bug-framework-headings-show-up-on-admin-homepage-when-there-are-no-action-links-below-them