### PR TITLE
Update requirements and remove six

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,16 +1,13 @@
 from collections import OrderedDict
 
-from dmutils.documents import degenerate_document_path_and_return_doc_name
-from flask import render_template, redirect, url_for, abort, request
 from dateutil.parser import parse as parse_date
-from six import next
-
+from dmutils.documents import degenerate_document_path_and_return_doc_name
 from dmutils.formats import datetimeformat
+from flask import render_template, redirect, url_for, abort, request
 
 from .. import main
 from ..auth import role_required
 from ... import data_api_client
-
 
 status_labels = OrderedDict((
     ("signed", "Waiting for countersigning"),

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,6 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.3.0#egg=digitalmarketplace-utils==31.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.3.0#egg=digitalmarketplace-utils==31.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -37,7 +38,6 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
-odfpy==1.3.3
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,12 +12,12 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.23.0
+asn1crypto==0.24.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-certifi==2017.11.5
-cffi==1.11.2
+certifi==2018.1.18
+cffi==1.11.4
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
@@ -49,6 +49,6 @@ s3transfer==0.1.12
 six==1.10.0
 unicodecsv==0.14.1
 urllib3==1.22
-Werkzeug==0.12.2
+Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.1

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -1,10 +1,9 @@
 from itertools import chain
+from urllib.parse import urlparse, parse_qs
 
 import mock
-from lxml import html
-from six import iteritems, iterkeys
-from six.moves.urllib.parse import urlparse, parse_qs
 import pytest
+from lxml import html
 
 from app.main.views.agreements import status_labels
 from ...helpers import LoggedInApplicationTest
@@ -127,7 +126,7 @@ class TestListAgreements(LoggedInApplicationTest):
             for a_element in page.cssselect('.status-filters a')
         ) == tuple(
             ({"status": [status_key]}, status_label)
-            for status_key, status_label in iteritems(status_labels)
+            for status_key, status_label in status_labels.items()
         )
 
         summary_elem = page.xpath("//p[@class='search-summary-border-bottom']")[0]
@@ -141,7 +140,7 @@ class TestListAgreements(LoggedInApplicationTest):
         data_api_client.find_framework_suppliers.return_value = find_framework_suppliers_return_value_g8
 
         # choose the second status (if there is one, otherwise first)
-        chosen_status_key = tuple(iterkeys(status_labels))[:2][-1]
+        chosen_status_key = tuple(status_labels.keys())[:2][-1]
 
         response = self.client.get('/admin/agreements/g-cloud-8?status={}'.format(chosen_status_key))
         page = html.fromstring(response.get_data(as_text=True))
@@ -188,7 +187,7 @@ class TestListAgreements(LoggedInApplicationTest):
             ),
             (
                 ({"status": [status_key]}, status_label)
-                for status_key, status_label in iteritems(status_labels) if status_key != chosen_status_key
+                for status_key, status_label in status_labels.items() if status_key != chosen_status_key
             ),
         ))
 

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -109,13 +109,13 @@ class TestListAgreements(LoggedInApplicationTest):
                 "/admin/suppliers/11112/agreements/g-cloud-8",
                 {},
                 "My other supplier",
-                "Submitted: Friday 30 October 2015 at 1:01am",
+                "Submitted: Friday 30 October 2015 at 1:01am GMT",
             ),
             (
                 "/admin/suppliers/11111/agreements/g-cloud-8",
                 {},
                 "My Supplier",
-                "Submitted: Sunday 1 November 2015 at 1:01am",
+                "Submitted: Sunday 1 November 2015 at 1:01am GMT",
             ),
         )
 
@@ -161,13 +161,13 @@ class TestListAgreements(LoggedInApplicationTest):
                 "/admin/suppliers/11111/agreements/g-cloud-8",
                 {"next_status": [chosen_status_key]},
                 "My Supplier",
-                "Submitted: Sunday 1 November 2015 at 1:01am",
+                "Submitted: Sunday 1 November 2015 at 1:01am GMT",
             ),
             (
                 "/admin/suppliers/11112/agreements/g-cloud-8",
                 {"next_status": [chosen_status_key]},
                 "My other supplier",
-                "Submitted: Friday 30 October 2015 at 1:01am",
+                "Submitted: Friday 30 October 2015 at 1:01am GMT",
             ),
         )
 

--- a/tests/app/main/views/test_application.py
+++ b/tests/app/main/views/test_application.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 
-import pytest
 import mock
+import pytest
+
 from ...helpers import LoggedInApplicationTest
 
 
@@ -16,10 +17,6 @@ class TestApplication(LoggedInApplicationTest):
         with self.app.app_context():
             response = self.client.get('/admin/not-found')
             assert response.status_code == 404
-
-    def test_index_is_404(self):
-        response = self.client.get('/')
-        assert response.status_code == 404
 
     @mock.patch('app.main.views.services.data_api_client')
     def test_headers(self, data_api_client):

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1525,7 +1525,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         # service status:
         "disabled",
         # expected message about the oldest unapproved edit:
-        "Changed on Wednesday 3 February 2010 at 10:11am",
+        "Changed on Wednesday 3 February 2010 at 10:11am GMT",
         # number of audit events per page in API response + expected message about latest edit:
         ((5, expected_message_about_latest_edit_1,),),
     )
@@ -1583,7 +1583,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         # service status:
         "published",
         # expected message about the oldest unapproved edit:
-        "Changed on Tuesday 3 February 2015 at 8:11pm",
+        "Changed on Tuesday 3 February 2015 at 8:11pm GMT",
         # number of audit events per page in API response + expected message about latest edit:
         (
             (5, expected_message_about_latest_edit_2),
@@ -1633,7 +1633,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         # service status:
         "enabled",
         # expected message about the oldest unapproved edit:
-        "Changed on Saturday 30 June 2012 at 9:01pm",
+        "Changed on Saturday 30 June 2012 at 9:01pm BST",
         # number of audit events per page in API response + expected message about latest edit:
         (
             (5, expected_message_about_latest_edit_3),
@@ -1706,7 +1706,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         # service status:
         "enabled",
         # expected message about the oldest unapproved edit:
-        "Changed on Saturday 12 November 2005 at 3:01pm",
+        "Changed on Saturday 12 November 2005 at 3:01pm GMT",
         # number of audit events per page in API response + expected message about latest edit:
         (
             (5, expected_message_about_latest_edit_4),

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1,23 +1,15 @@
 from functools import partial
-
-import pytest
-
-try:
-    from urlparse import urlsplit
-    from StringIO import StringIO
-except ImportError:
-    from urllib.parse import urlsplit
-    from io import BytesIO as StringIO
+from io import BytesIO as StringIO
 from itertools import chain
+from urllib.parse import urlsplit
+
 import mock
-
-from flask import Markup
-from lxml import html
-from six import text_type
-
+import pytest
 from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
 from dmutils import s3
+from flask import Markup
+from lxml import html
 
 from tests.app.main.helpers.flash_tester import assert_flashes
 from ...helpers import LoggedInApplicationTest
@@ -1825,7 +1817,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             assert len(ack_forms) == 1
             assert ack_forms[0].method == "POST"
             assert ack_forms[0].action == "/admin/services/151/updates/{}/approve".format(
-                text_type(find_audit_events_api_response[-1]["id"])
+                str(find_audit_events_api_response[-1]["id"])
             )
             assert sorted(ack_forms[0].form_values()) == [
                 ("csrf_token", mock.ANY),

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1,3 +1,6 @@
+from io import BytesIO
+from urllib.parse import urlparse, parse_qs
+
 import mock
 import pytest
 from dmapiclient import HTTPError, APIError
@@ -6,8 +9,6 @@ from dmutils.email.exceptions import EmailError
 from flask import current_app
 from freezegun import freeze_time
 from lxml import html
-from six import BytesIO
-from six.moves.urllib.parse import urlparse, parse_qs
 
 from ..helpers.flash_tester import assert_flashes
 from ...helpers import LoggedInApplicationTest, Response

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import copy
 from datetime import datetime
 
 import mock
 import pytest
-import six
 from dmapiclient import HTTPError
 from lxml import html
 
@@ -301,7 +298,7 @@ class TestUsersExport(LoggedInApplicationTest):
         ]
         # All users returned from the API should appear in the CSV
         for index, user in enumerate(users):
-            assert sorted([six.text_type(val) for val in user.values()]) == sorted(rows[index + 1])
+            assert sorted([str(val) for val in user.values()]) == sorted(rows[index + 1])
 
     def test_download_csv_for_on_framework_only(self, data_api_client):
         framework = self._valid_framework

--- a/tests/app/test_diff_tool.py
+++ b/tests/app/test_diff_tool.py
@@ -1,13 +1,11 @@
 from collections import OrderedDict
 from itertools import chain
 
-from lxml import html
 import pytest
-from six import string_types
+from lxml import html
 
 from app import content_loader
 from app.main.helpers.diff_tools import html_diff_tables_from_sections_iter
-
 from .helpers import BaseApplicationTest
 
 
@@ -231,7 +229,7 @@ class TestHtmlDiffTablesFromSections(BaseApplicationTest):
             expected_content_a, expected_content_b = (
                 [
                     (line or " ")  # diff outputs an extraneous space in some blank line cases, which is ok by us
-                    for line in (q.splitlines() if isinstance(q, string_types) else q)
+                    for line in (q.splitlines() if isinstance(q, str) else q)
                 ]
                 for q in (r.get(question_id, []) for r in (service_data_a, service_data_b,))
             )


### PR DESCRIPTION
I was a bit worried that the admin app might be affected by the same issue with Werkzeug update as the supplier app (see https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/779).

So I tried updating and everything is fine here - tests pass and I've tried out the file upload pages locally and all seems well.

As there was nothing much to do with that I removed use of `six` from the app and tests, as we're all Python 3 these days.