### PR TITLE
BUGFIX: show most recent upload date on framework files

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -1,6 +1,7 @@
-from flask import render_template
-from app.main import main
 from dmapiclient import APIError
+from flask import render_template
+
+from app.main import main
 
 
 @main.app_errorhandler(APIError)

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,10 +1,9 @@
-from wtforms import RadioField, validators
-from flask.ext.wtf import Form
-from wtforms.validators import DataRequired
 from dmutils.forms import StripWhitespaceStringField
+from flask_wtf import Form
+from wtforms import RadioField, validators
+from wtforms.validators import DataRequired
 
 from .. import data_api_client
-
 
 ADMIN_ROLES = [
     (

--- a/app/main/helpers/diff_tools.py
+++ b/app/main/helpers/diff_tools.py
@@ -1,12 +1,10 @@
 import difflib
 from itertools import chain
 
+from dmcontent.questions import Multiquestion
 from flask import Markup, render_template
 from flask._compat import string_types
-
 from lxml import html
-
-from dmcontent.questions import Multiquestion
 
 
 def _unpack_question(question):

--- a/app/main/helpers/service.py
+++ b/app/main/helpers/service.py
@@ -1,5 +1,5 @@
-import re
 import datetime
+import re
 
 
 def parse_document_upload_time(data):

--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -1,15 +1,14 @@
+from distutils.util import strtobool
+
+from dmapiclient import HTTPError
+from dmutils.email.user_account_email import send_user_account_email
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import current_user
 
-from dmutils.email.user_account_email import send_user_account_email
-
-from ... import data_api_client
 from .. import main
-
-from ..forms import InviteAdminForm, EditAdminUserForm
-from dmapiclient import HTTPError
 from ..auth import role_required
-from distutils.util import strtobool
+from ..forms import InviteAdminForm, EditAdminUserForm
+from ... import data_api_client
 
 
 @main.route('/admin-users', methods=['GET'])

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -1,7 +1,6 @@
 from dmutils import s3  # this style of import so we only have to mock once
 from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
-from flask import render_template, redirect, url_for, current_app, \
-    request, flash
+from flask import render_template, redirect, url_for, current_app, request, flash
 
 from .. import main
 from ..auth import role_required

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -14,20 +14,19 @@ def manage_communications(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
     # Get the last items from the timestamp-ordered buckets, in order to show the most recently updated timestamps
-    # The "or [None]" is to ensure we dereference from a list with at least one item when no files exist in the bucket
+    # The "or [None]" ensures we have a list with at least one item (None) when no files exist in the bucket
     communications = communications_bucket.list(
         '{}/communications/updates/communications'.format(framework_slug), load_timestamps=True
     ) or [None]
     clarifications = communications_bucket.list(
         '{}/communications/updates/clarifications'.format(framework_slug), load_timestamps=True
     ) or [None]
-    *_, last_clarification = clarifications
-    *_, last_communication = communications
 
     return render_template(
         'manage_communications.html',
-        clarification=last_clarification,
-        communication=last_communication,
+        # Pass in the last (most recent) clarification and communication from the lists; used to show "last modified"
+        clarification=clarifications[-1],
+        communication=communications[-1],
         framework=framework
     )
 

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -1,4 +1,5 @@
 from flask import render_template
+
 from .. import main
 from ..auth import role_required
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from datetime import datetime
 from itertools import chain
 

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -56,7 +56,7 @@
        question="Communication",
        hint="This must be an open document format (pdf, pda, odt, ods, odp) or CSV",
        name="communication",
-       value="Last modified {}".format(communication.last_modified),
+       value="Last modified {}".format(communication.last_modified|datetimeformat) if communication else "No communications have been uploaded yet",
        error=communication_error
     %}
       {% include "toolkit/forms/upload.html" %}
@@ -67,7 +67,7 @@
        question="Clarification answers",
        hint="This must be PDF",
        name="clarification",
-       value="Last modified {}".format(clarification.last_modified),
+       value="Last modified {}".format(clarification.last_modified|datetimeformat) if clarification else "No clarification answers have been uploaded yet",
        error=clarification_error
     %}
       {% include "toolkit/forms/upload.html" %}

--- a/tests/app/main/test_form_validators.py
+++ b/tests/app/main/test_form_validators.py
@@ -1,7 +1,6 @@
 import mock
 import pytest
-
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms.fields.core import Field
 from wtforms.validators import StopValidation
 

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -1,10 +1,9 @@
 # coding=utf-8
-from __future__ import unicode_literals
-
 from io import BytesIO
 
 import mock
 import pytest
+from lxml import html
 
 from ...helpers import LoggedInApplicationTest
 
@@ -25,13 +24,61 @@ class TestCommunicationsView(LoggedInApplicationTest):
         ("admin-framework-manager", 200),
         ("admin-manager", 403),
     ])
-    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, get_framework_mock, role, expected_code):
         self.user_role = role
         response = self.client.get("/admin/communications/{}".format(self.framework_slug))
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_post_documents_for_framework(self, data_api_client):
+    def test_page_shows_empty_messages_if_no_files_uploaded(self, get_framework_mock):
+        self.s3.return_value.list.side_effect = ([], [])  # Empty lists for both communication and clarification files
+        get_framework_mock.return_value = {"frameworks": {"status": "open"}}
+        response = self.client.get("/admin/communications/{}".format(self.framework_slug))
+        document = html.fromstring(response.get_data(as_text=True))
+        file_upload_messages = document.xpath('//p[@class="file-upload-existing-value"]')
+
+        assert len(file_upload_messages) == 2
+        assert file_upload_messages[0].text_content().strip() == "No communications have been uploaded yet"
+        assert file_upload_messages[1].text_content().strip() == "No clarification answers have been uploaded yet"
+
+    def test_page_shows_timestamp_from_last_file_in_list_if_some_files_already_uploaded(self, get_framework_mock):
+        # The first list is for communication files, the second for clarifications
+        self.s3.return_value.list.side_effect = (
+            [
+                {
+                    "path": "g-things-23/communications/updates/communications/communication-1.pdf",
+                    "last_modified": "2018-01-01T01:01:01.000001Z"
+                },
+                {
+                    "path": "g-things-23/communications/updates/communications/communication-2.pdf",
+                    "last_modified": "2018-02-02T02:02:02.000002Z"
+                },
+                {
+                    "path": "g-things-23/communications/updates/communications/communication-3.pdf",
+                    "last_modified": "2018-03-03T03:03:03.000003Z"
+                },
+            ],
+            [
+                {
+                    "path": "g-things-23/communications/updates/clarifiactions/clarification-1.pdf",
+                    "last_modified": "2018-04-04T01:01:01.000001Z"
+                },
+                {
+                    "path": "g-things-23/communications/updates/clarifiactions/clarification-2.pdf",
+                    "last_modified": "2018-07-25T02:02:02.000002Z"  # Test GMT/BST pretty formatting while we're here
+                },
+            ],
+        )
+        get_framework_mock.return_value = {"frameworks": {"status": "open"}}
+        response = self.client.get("/admin/communications/{}".format(self.framework_slug))
+        document = html.fromstring(response.get_data(as_text=True))
+        file_upload_messages = document.xpath('//p[@class="file-upload-existing-value"]')
+
+        assert len(file_upload_messages) == 2
+        assert file_upload_messages[0].text_content().strip() == "Last modified Saturday 3 March 2018 at 3:03am GMT"
+        assert file_upload_messages[1].text_content().strip() == "Last modified Wednesday 25 July 2018 at 3:02am BST"
+
+    def test_post_documents_for_framework(self, get_framework_mock):
 
         response = self.client.post(
             "/admin/communications/{}".format(self.framework_slug),
@@ -50,7 +97,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         assert response.status_code == 302
 
     @pytest.mark.parametrize("disallowed_role", ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-manager"])
-    def test_disallowed_roles_can_not_post_documents_for_framework(self, data_api_client, disallowed_role):
+    def test_disallowed_roles_can_not_post_documents_for_framework(self, get_framework_mock, disallowed_role):
 
         self.user_role = disallowed_role
 
@@ -63,7 +110,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         )
         assert response.status_code == 403
 
-    def test_post_bad_documents_for_framework(self, data_api_client):
+    def test_post_bad_documents_for_framework(self, get_framework_mock):
 
         self.client.post(
             "/admin/communications/{}".format(self.framework_slug),
@@ -78,7 +125,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         assert flash_messages.get('not_open_document_format_or_csv') == 'communication'
         assert flash_messages.get('not_pdf') == 'clarification'
 
-    def test_communications_file_saves_with_correct_path(self, data_api_client):
+    def test_communications_file_saves_with_correct_path(self, get_framework_mock):
 
         response = self.client.post(
             "/admin/communications/{}".format(self.framework_slug),
@@ -95,7 +142,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
             download_filename='test-comm.pdf'
         )
 
-    def test_clarification_file_saves_with_correct_path(self, data_api_client):
+    def test_clarification_file_saves_with_correct_path(self, get_framework_mock):
 
         response = self.client.post(
             "/admin/communications/{}".format(self.framework_slug),


### PR DESCRIPTION
While updating the admin requirements in #352 I noticed this bug and thought it best to fix it while I was there...

The "Last modified" date shown to admin users on the "upload communications and clarifications" page should be the latest date a file was uploaded, but was actually displaying the date of the first upload to the relevant bucket.

I suspect that maybe our S3 list() used to return things in reverse date order and got swapped to increasing date order at some point.  But who knows, maybe this never worked...

I've also added nicer "empty" messages for when no files are uploaded yet - it used to just say "Last modified None".