### PR TITLE
Use 'bucket-owner-full-control' instead of 'private' ACL

### DIFF
--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -44,7 +44,9 @@ def upload_communication(framework_slug):
 
         if 'communication' not in errors.keys():
             path = "{}/communications/updates/communications/{}".format(framework_slug, the_file.filename)
-            communications_bucket.save(path, the_file, acl='private', download_filename=the_file.filename)
+            communications_bucket.save(
+                path, the_file, acl='bucket-owner-full-control', download_filename=the_file.filename
+            )
             flash('communication', 'upload_communication')
 
     if request.files.get('clarification'):
@@ -54,7 +56,9 @@ def upload_communication(framework_slug):
 
         if 'clarification' not in errors.keys():
             path = "{}/communications/updates/clarifications/{}".format(framework_slug, the_file.filename)
-            communications_bucket.save(path, the_file, acl='private', download_filename=the_file.filename)
+            communications_bucket.save(
+                path, the_file, acl='bucket-owner-full-control', download_filename=the_file.filename
+            )
             flash('clarification', 'upload_communication')
 
     if len(errors) > 0:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -276,7 +276,9 @@ def upload_countersigned_agreement_file(supplier_id, framework_slug):
                 framework_slug, supplier_id, 'agreements', COUNTERPART_FILENAME
             )
             download_filename = generate_download_filename(supplier_id, COUNTERPART_FILENAME, supplier_name)
-            agreements_bucket.save(path, the_file, acl='private', move_prefix=None, download_filename=download_filename)
+            agreements_bucket.save(
+                path, the_file, acl='bucket-owner-full-control', move_prefix=None, download_filename=download_filename
+            )
 
             data_api_client.update_framework_agreement(
                 agreement_id,

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -138,7 +138,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         self.s3.return_value.save.assert_called_once_with(
             '{}/communications/updates/communications/test-comm.pdf'.format(self.framework_slug),
             mock.ANY,  # werkzeug.datastructures.FileStorage object we are saving to s3
-            acl='private',
+            acl='bucket-owner-full-control',
             download_filename='test-comm.pdf'
         )
 
@@ -155,6 +155,6 @@ class TestCommunicationsView(LoggedInApplicationTest):
         self.s3.return_value.save.assert_called_once_with(
             '{}/communications/updates/clarifications/test-comm.pdf'.format(self.framework_slug),
             mock.ANY,  # werkzeug.datastructures.FileStorage object we are saving to s3
-            acl='private',
+            acl='bucket-owner-full-control',
             download_filename='test-comm.pdf'
         )

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1209,7 +1209,7 @@ class TestUploadCountersignedAgreementFile(LoggedInApplicationTest):
         s3.S3.return_value.save.assert_called_once_with(
             expected_countersign_path,
             mock.ANY,
-            acl='private',
+            acl='bucket-owner-full-control',
             move_prefix=None,
             download_filename='Supplier_Mc_Supply_Face-1234-agreement-countersignature.pdf'
         )
@@ -1258,7 +1258,7 @@ class TestUploadCountersignedAgreementFile(LoggedInApplicationTest):
         s3.S3.return_value.save.assert_called_once_with(
             "g-cloud-7/agreements/1234/1234-agreement-countersignature-2016-12-25-063001.pdf",
             mock.ANY,
-            acl='private',
+            acl='bucket-owner-full-control',
             move_prefix=None,
             download_filename='Supplier_Mc_Supply_Face-1234-agreement-countersignature.pdf'
         )
@@ -1316,7 +1316,7 @@ class TestUploadCountersignedAgreementFile(LoggedInApplicationTest):
         s3.S3.return_value.save.assert_called_once_with(
             "g-cloud-7/agreements/1234/1234-agreement-countersignature-2016-12-25-063001.pdf",
             mock.ANY,
-            acl='private',
+            acl='bucket-owner-full-control',
             move_prefix=None,
             download_filename='DM_Supplier_Name-1234-agreement-countersignature.pdf'
         )


### PR DESCRIPTION
Because we now log in to S3 using IAM roles inherited from other accounts, files uploaded as 'private' can not be viewed by developers logged in to the console.

Using 'bucket-owner-full-control' rather than 'private' means that devs will be able to view and modify documents in the S3 console.