### PR TITLE
Hide suppliers from agreement countersigning list if not on framework

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -18,12 +18,14 @@ status_labels = OrderedDict((
 
 
 def _get_supplier_frameworks(framework_slug, status=None):
-    return data_api_client.find_framework_suppliers(
-        framework_slug,
-        agreement_returned=True,
-        with_declarations=False,
-        **({"statuses": status} if status else {})
-    )['supplierFrameworks']
+    return [
+        supplier_framework for supplier_framework in data_api_client.find_framework_suppliers(
+            framework_slug, agreement_returned=True,
+            with_declarations=False,
+            **({"statuses": status} if status else {})
+        )['supplierFrameworks']
+        if supplier_framework['onFramework']
+    ]
 
 
 @main.route('/agreements/<framework_slug>', methods=['GET'])

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -25,6 +25,7 @@ class TestListAgreements(LoggedInApplicationTest):
                     'agreementReturnedAt': '2015-10-30T01:01:01.000000Z',
                     'agreementPath': 'path/11112-agreement.pdf',
                     'frameworkSlug': 'g-cloud-8',
+                    'onFramework': True
                 },
                 {
                     'supplierName': 'My Supplier',
@@ -33,6 +34,15 @@ class TestListAgreements(LoggedInApplicationTest):
                     'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
                     'agreementPath': 'path/11111-agreement.pdf',
                     'frameworkSlug': 'g-cloud-8',
+                    'onFramework': True
+                },
+                {
+                    'supplierName': 'My Supplier no longer on framework',
+                    'supplierId': 11111,
+                    'agreementReturned': True,
+                    'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
+                    'agreementPath': 'path/11111-agreement.pdf',
+                    'onFramework': False
                 },
             ],
         }
@@ -55,6 +65,7 @@ class TestListAgreements(LoggedInApplicationTest):
                     'agreementReturned': True,
                     'agreementReturnedAt': '2015-10-30T01:01:01.000000Z',
                     'agreementPath': 'path/11112-agreement.pdf',
+                    'onFramework': True
                 },
                 {
                     'supplierName': 'My Supplier',
@@ -62,6 +73,7 @@ class TestListAgreements(LoggedInApplicationTest):
                     'agreementReturned': True,
                     'agreementReturnedAt': '2015-11-01T01:01:01.000000Z',
                     'agreementPath': 'path/11111-agreement.pdf',
+                    'onFramework': True
                 },
             ]
         }
@@ -104,6 +116,7 @@ class TestListAgreements(LoggedInApplicationTest):
             ("with_declarations", False),
         ))
 
+        # only suppliers who are on the framework are shown in the results list
         assert tuple(self._unpack_search_result(result) for result in page.cssselect('.search-result')) == (
             (
                 "/admin/suppliers/11112/agreements/g-cloud-8",
@@ -229,36 +242,43 @@ class TestNextAgreementRedirect(LoggedInApplicationTest):
                     "supplierId": 4321,
                     "frameworkSlug": "g-cloud-8",
                     "agreementStatus": "signed",
+                    'onFramework': True
                 },
                 {
                     "supplierId": 1234,
                     "frameworkSlug": "g-cloud-8",
                     "agreementStatus": "on-hold",
+                    'onFramework': True
                 },
                 {
                     "supplierId": 31415,
                     "frameworkSlug": "g-cloud-8",
                     "agreementStatus": "signed",
+                    'onFramework': True
                 },
                 {
                     "supplierId": 27,
                     "frameworkSlug": "g-cloud-8",
                     "agreementStatus": "signed",
+                    'onFramework': True
                 },
                 {
                     "supplierId": 141,
                     "frameworkSlug": "g-cloud-8",
                     "agreementStatus": "countersigned",
+                    'onFramework': True
                 },
                 {
                     "supplierId": 151,
                     "frameworkSlug": "g-cloud-8",
                     "agreementStatus": "on-hold",
+                    'onFramework': True
                 },
                 {
                     "supplierId": 99,
                     "frameworkSlug": "g-cloud-8",
                     "agreementStatus": "approved",
+                    'onFramework': True
                 },
             ],
         }


### PR DESCRIPTION
Trello: https://trello.com/c/QiXbQBqz/84-remove-uploaded-fa-for-ciobureau-llp

Context: the supplier uploaded an invalid agreement, and subsequently removed themselves from the framework (disabled their services). However they are still showing as 'on hold' in the Admin countersigning list.

Filtering out suppliers with `onFramework: false` means that we can then do a simple API request to remove the supplier from the framework, rather than having to go into the production DB and delete the record.