### PR TITLE
 Revert back to eea/odfpy

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@
 # F401: 'identifier' imported but unused
 # E402: module level import not at top of file
 # W503: line break before binary operator
-exclude = venv,venv3,__pycache__,node_modules,app/content
+exclude = venv*,__pycache__,node_modules,app/content
 ignore = D203,W503
 max-complexity = 24
 max-line-length = 120

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -64,7 +64,11 @@ def create_app(config_name):
 
     application.register_blueprint(status_blueprint, url_prefix='/admin')
     application.register_blueprint(main_blueprint, url_prefix='/admin')
+
+    # Must be registered last so that any routes declared in the app are registered first (i.e. take precedence over
+    # the external NotImplemented routes in the dm-utils external blueprint).
     application.register_blueprint(external_blueprint)
+
     login_manager.login_view = '/user/login'
     main_blueprint.config = application.config.copy()
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,6 +7,5 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.3.0#egg=digitalmarketplace-utils==31.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,8 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.3.0#egg=digitalmarketplace-utils==31.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -38,6 +37,7 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -31,9 +31,9 @@ class TestServiceUpdates(LoggedInApplicationTest):
                 ('2017-04-25T14:43:46.061077Z', '597637931594387', u'Making £ Inc', '240701', '240684'),
             ),
             (
-                ('Company name', '1123456789012351', '15 July at 19:03:43', '/admin/services/1123456789012351/updates'),
+                ('Company name', '1123456789012351', '15 July at 18:03:43', '/admin/services/1123456789012351/updates'),
                 (u'Testing Ltd', '1123456789012348', '5 March at 10:42:16', '/admin/services/1123456789012348/updates'),
-                (u'Making £ Inc', '597637931594387', '25 April at 15:43:46', '/admin/services/597637931594387/updates'),
+                (u'Making £ Inc', '597637931594387', '25 April at 14:43:46', '/admin/services/597637931594387/updates'),
             ),
             '3 edited services',
         ),
@@ -43,7 +43,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
                 ('2016-03-05T10:42:16.061077Z', '597637931590001', 'Ideal Health', '240699', '240682'),
             ),
             (
-                ('Company name', '597637931590002', '15 July at 19:03:43', '/admin/services/597637931590002/updates'),
+                ('Company name', '597637931590002', '15 July at 18:03:43', '/admin/services/597637931590002/updates'),
                 ('Ideal Health', '597637931590001', '5 March at 10:42:16', '/admin/services/597637931590001/updates'),
             ),
             '2 edited services',
@@ -58,7 +58,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
                 ('2012-07-15T18:03:43.061077Z', '597637931590002', 'Company name', '240697', '240680'),
             ),
             (
-                ('Company name', '597637931590002', '15 July at 19:03:43', '/admin/services/597637931590002/updates'),
+                ('Company name', '597637931590002', '15 July at 18:03:43', '/admin/services/597637931590002/updates'),
             ),
             '1 edited service',
         ),

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -191,9 +191,9 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 200
         assert "Test User" in response.get_data(as_text=True)
         assert "test.user@sme.com" in response.get_data(as_text=True)
-        assert "10:33:53" in response.get_data(as_text=True)
+        assert "09:33:53" in response.get_data(as_text=True)
         assert "23 July" in response.get_data(as_text=True)
-        assert "13:46:01" in response.get_data(as_text=True)
+        assert "12:46:01" in response.get_data(as_text=True)
         assert "29 June" in response.get_data(as_text=True)
         assert "No" in response.get_data(as_text=True)
 

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -92,7 +92,7 @@ class TestUsersView(LoggedInApplicationTest):
 
         last_login = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[3].strip()
-        assert last_login == '10:33:53'
+        assert last_login == '09:33:53'
 
         last_login_day = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[4].strip()
@@ -100,7 +100,7 @@ class TestUsersView(LoggedInApplicationTest):
 
         last_password_changed = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[5].strip()
-        assert last_password_changed == '13:46:01'
+        assert last_password_changed == '12:46:01'
 
         last_password_changed_day = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[6].strip()


### PR DESCRIPTION
Update utils to use eea/odfpy rather than our interim alphagov/odfpy
fork, which we created to allow us to patch a bug. Now that the bug has
been accepted into the main library as of release 1.3.6
(eea/odfpy#72) we no longer need to support own
our fork.

Also adds a comment when registering the external blueprint from 
dm-utils to ensure it is registered last.