### PR TITLE
digitalmarketplace-frontend-toolkit dependency: bump to v27.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-uglify": "1.5.1",
     "colors": "1.1.2",
     "jquery": "1.12.0",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.3.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v9.3.0",
     "hogan.js": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,9 +529,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#53d93084e1361b553bf8623b48cd43d069008231"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.0.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.3.1":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#bec67d8d44fa0f279be32786e7fb75a6e1981629"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#695eacbe2e835b5e51d2649a87b7ad766997910c"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello https://trello.com/c/sFnBpHvr/120-there-is-a-table-heading-alignment-issue-on-ie11-or-below-browsers

This should pull in the IE table style fixes.