### PR TITLE
Add published service count to export_users_for_framework csv

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -63,7 +63,8 @@ def download_users(framework_slug):
         "application_status",
         "application_result",
         "framework_agreement",
-        "variations_agreed"
+        "variations_agreed",
+        "published_service_count"
     ]
 
     if on_framework_only:

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -232,7 +232,8 @@ class TestUsersExport(LoggedInApplicationTest):
         "supplier_id": 1,
         "email address": "test.user@sme.com",
         "user_name": "Test User",
-        "variations_agreed": "var1"
+        "variations_agreed": "var1",
+        "published_service_count": "0"
     }
 
     def _return_user_export_response(self, data_api_client, framework, users, framework_slug=None, only_on_fwk=False):
@@ -294,7 +295,8 @@ class TestUsersExport(LoggedInApplicationTest):
             'application_status',
             'application_result',
             'framework_agreement',
-            'variations_agreed'
+            'variations_agreed',
+            'published_service_count'
         ]
         # All users returned from the API should appear in the CSV
         for index, user in enumerate(users):


### PR DESCRIPTION
As part of the work for the contract variations.
CCS only want to email suppliers with an active account and who have not been removed from the framework.

This can be determined as any supplier on framework with a service that is published.

Adding the published service count allows them to determine which suppliers are active on the framework.