### PR TITLE
Revert "Bump digitalmarketplace-utils dependency to 34.1.0"

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.0#egg=digitalmarketplace-utils==34.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.0#egg=digitalmarketplace-utils==34.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.1#egg=digitalmarketplace-apiclient==14.0.1
 
 ## The following requirements were added by pip freeze:
@@ -17,7 +17,7 @@ backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
 certifi==2018.1.18
-cffi==1.11.5
+cffi==1.11.4
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
@@ -45,7 +45,7 @@ python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4
-s3transfer==0.1.13
+s3transfer==0.1.12
 six==1.10.0
 unicodecsv==0.14.1
 urllib3==1.22


### PR DESCRIPTION
This reverts commit 1cd9cd765412ec53fe167ab9ba68e72a5188f7ac.

Because we don't *set* the default for DM_REQUEST_ID_HEADER, apiclient,
which turns out to rely on this value, isn't able to find the correct
header to use when forwarding the request. back this out until we've
updated/fixed either the utils or apiclient

Trello https://trello.com/c/dlbLmRDB/343-make-use-of-zipkin-headers-in-preference-to-request-id-pt-1

I'm going AFK right now so if someone wants to approve **and maybe merge** this that would be cool.