### PR TITLE
Accessible text for Edit links

### DIFF
--- a/app/templates/_view_suppliers_agreements.html
+++ b/app/templates/_view_suppliers_agreements.html
@@ -23,55 +23,55 @@
 
     {% call summary.row() %}
       {% call summary.field() %}
-       <a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-7") }}">Edit declaration</a>
+       <a href="{{ url_for('.view_supplier_declaration', supplier_id=item.id, framework_slug='g-cloud-7') }}">Edit <span class="visually-hidden">G-Cloud 7 </span>declaration</a>
       {% endcall %}
       {% call summary.field() %}
-        <a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Edit declaration</a>
+        <a href="{{ url_for('.view_supplier_declaration', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists') }}">Edit <span class="visually-hidden">Digital Outcomes and Specialists </span>declaration</a>
       {% endcall %}
       {% call summary.field() %}
-        <a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-8") }}">Edit declaration</a>
+        <a href="{{ url_for('.view_supplier_declaration', supplier_id=item.id, framework_slug='g-cloud-8') }}">Edit <span class="visually-hidden">G-Cloud 8 </span>declaration</a>
       {% endcall %}
       {% call summary.field() %}
-        <a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists-2") }}">Edit declaration</a>
+        <a href="{{ url_for('.view_supplier_declaration', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists-2') }}">Edit <span class="visually-hidden">Digital Outcomes and Specialists 2 </span>declaration</a>
       {% endcall %}
       {% call summary.field() %}
-        <a href="{{ url_for(".view_supplier_declaration", supplier_id=item.id, framework_slug="g-cloud-9") }}">Edit declaration</a>
+        <a href="{{ url_for('.view_supplier_declaration', supplier_id=item.id, framework_slug='g-cloud-9') }}">Edit <span class="visually-hidden">G-Cloud 9 </span>declaration</a>
       {% endcall %}
     {% endcall %}
 
     {% call summary.row(no_border=True) %}
       {% call summary.field() %}
-        ⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7", document_name=agreement_filename) }}" >Agreement</a>
+        ⬇ <a href="{{ url_for('.download_agreement_file', supplier_id=item.id, framework_slug='g-cloud-7', document_name=agreement_filename) }}" ><span class="visually-hidden">Download G-Cloud 7 </span>Agreement</a>
       {% endcall %}
       {% call summary.field() %}
-        ⬇ <a href="{{ url_for(".download_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists", document_name=agreement_filename) }}" >Agreement</a>
+        ⬇ <a href="{{ url_for('.download_agreement_file', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists', document_name=agreement_filename) }}" ><span class="visually-hidden">Download Digital Outcomes and Specialists </span>Agreement</a>
       {% endcall %}
       {% call summary.field(rowspan=3) %}
-        <a href="{{ url_for(".view_signed_agreement", supplier_id=item.id, framework_slug="g-cloud-8") }}">View agreement</a>
+        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='g-cloud-8') }}">View agreement<span class="visually-hidden"> for G-Cloud 8</span></a>
       {% endcall %}
       {% call summary.field(rowspan=3) %}
-        <a href="{{ url_for(".view_signed_agreement", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists-2") }}">View agreement</a>
+        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists-2') }}">View agreement<span class="visually-hidden"> for Digital Outcomes and Specialists 2</span></a>
       {% endcall %}
       {% call summary.field(rowspan=3) %}
-        <a href="{{ url_for(".view_signed_agreement", supplier_id=item.id, framework_slug="g-cloud-9") }}">View agreement</a>
+        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='g-cloud-9') }}">View agreement<span class="visually-hidden">for G-Cloud 9</span></a>
       {% endcall %}
     {% endcall %}
 
     {% call summary.row(no_border=True) %}
       {% call summary.field() %}
-        ⬇ <a href="{{ url_for(".download_signed_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Signed agreement</a>
+        ⬇ <a href="{{ url_for('.download_signed_agreement_file', supplier_id=item.id, framework_slug='g-cloud-7') }}"><span class="visually-hidden">Download G-Cloud 7 </span>Signed agreement</a>
       {% endcall %}
       {% call summary.field() %}
-        ⬇ <a href="{{ url_for(".download_signed_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Signed agreement</a>
+        ⬇ <a href="{{ url_for('.download_signed_agreement_file', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists') }}"><span class="visually-hidden">Download Digital Outcomes and Specialists </span>Signed agreement</a>
       {% endcall %}
     {% endcall %}
 
     {% call summary.row(no_border=True) %}
       {% call summary.field() %}
-        ⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="g-cloud-7") }}">Countersigned agreement</a>
+        ⬆ <a href="{{ url_for('.list_countersigned_agreement_file', supplier_id=item.id, framework_slug='g-cloud-7') }}"><span class="visually-hidden">Upload G-Cloud 7 </span>Countersigned agreement</a>
       {% endcall %}
       {% call summary.field() %}
-        ⬆ <a href="{{ url_for(".list_countersigned_agreement_file", supplier_id=item.id, framework_slug="digital-outcomes-and-specialists") }}">Countersigned agreement</a>
+        ⬆ <a href="{{ url_for('.list_countersigned_agreement_file', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists') }}"><span class="visually-hidden">Upload Digital Outcomes and Specialists </span>Countersigned agreement</a>
       {% endcall %}
     {% endcall %}
   {% endcall %}

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -71,10 +71,8 @@
                 {% endcall %}
                 {{ summary.edit_link(
                   "View changes",
-                  url_for(
-                    '.service_updates',
-                    service_id=item.data.serviceId,
-                  )
+                  url_for('.service_updates', service_id=item.data.serviceId),
+                  hidden_text="for " + item.data.supplierName
                 ) }}
               {% endcall %}
             {% endcall %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -35,7 +35,7 @@
 
   {% for section in content.summary(declaration) %}
     {{ summary.heading(section.name) }}
-    {{ summary.top_link("Edit", url_for('.edit_supplier_declaration_section', supplier_id=supplier.id, framework_slug=framework.slug, section_id=section.id)) }}
+    {{ summary.top_link("Edit", url_for('.edit_supplier_declaration_section', supplier_id=supplier.id, framework_slug=framework.slug, section_id=section.id), hidden_text=section.name) }}
     {% call(item) summary.list_table(
       section.questions,
       caption="Declaration",

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -59,7 +59,7 @@
       {{ summary.text(item.emailAddress) }}
       {{ summary.text(role_descriptors[item.role]) }}
       {{ summary.text("Active" if item.active else "Suspended") }}
-      {{ summary.edit_link("Edit", url_for(".edit_admin_user", admin_user_id=item.id)) }}
+      {{ summary.edit_link("Edit", url_for(".edit_admin_user", admin_user_id=item.id), hidden_text=item.name) }}
     {% endcall %}
   {% endcall %}
 </div>

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -114,7 +114,7 @@
     {# links #}
     <ul class="list-no-bullet">
       {% if service_data['frameworkFramework'] == 'g-cloud' %}
-        <li><a href="{{ "/{}/services/{}".format(service_data['frameworkFramework'], service_id) }}">View service</a></li>
+        <li><a href="{{ '/{}/services/{}'.format(service_data['frameworkFramework'], service_id) }}">View service</a></li>
       {% endif %}
       {% if current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
         <li><a href="{{ url_for('.view_service', service_id=service_id, remove=True) }}">Remove service</a></li>
@@ -125,7 +125,7 @@
     {% for section in sections %}
       {{ summary.heading(section.name) }}
       {% if section.editable and current_user.has_role('admin-ccs-category') %}
-        {{ summary.top_link("Edit", url_for('.edit_service', service_id=service_id, section_id=section.id)) }}
+        {{ summary.top_link("Edit", url_for('.edit_service', service_id=service_id, section_id=section.id), hidden_text=section.name) }}
       {% endif %}
       {% call(question) summary.list_table(
         section.questions,
@@ -141,7 +141,7 @@
           {{ summary.field_name(question.label) }}
           {{ summary[question.type](question.value, question.assurance) }}
           {% if section.edit_questions and current_user.has_role('admin-ccs-category') %}
-            {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for('.edit_service', service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+            {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for('.edit_service', service_id=service_id, section_id=section.id, question_slug=question.slug), hidden_text=question.label) }}
           {% endif %}
 
         {% endcall %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -103,7 +103,8 @@
             {% endcall %}
             {{ summary.edit_link(
                  'Edit' if current_user.has_role('admin-ccs-category') else 'View',
-                 url_for('.view_service', service_id=item.id)
+                 url_for('.view_service', service_id=item.id),
+                 hidden_text=item.serviceName
                )
             }}
           {% endcall %}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-uglify": "1.5.1",
     "colors": "1.1.2",
     "jquery": "1.12.0",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v9.3.0",
     "hogan.js": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,9 +529,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#53d93084e1361b553bf8623b48cd43d069008231"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.0.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.1.0":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#62e640ed4ee5d793fd18b9b642fce0d965cf59ba"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#ef2ba1182aaf8756c1748aa10ef68c6abb5a6ca3"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello: https://trello.com/c/sYJYKnK9/58-how-summary-tables-handle-their-links-means-pages-can-contain-multiple-links-with-duplicate-text

If there are multiple links on a page with the same text, it can be confusing for screen reader users. This PR adds context in hidden text spans for the following links:
- Editing an admin user (`admin-manager` role)
- Uploading/downloading a supplier agreement file (`admin-ccs-sourcing` role)
- Editing a supplier declaration (`admin-ccs-sourcing` role)
- Editing a supplier service (`admin-ccs-category` role)
- Viewing unapproved supplier service edits (`admin-ccs-category` role)

This should be reviewed by a content designer (just in case) as well as a dev.

Also fixes some single/double apostrophe clashes.

See previous PRs for Brief Responses and Supplier FEs: 
https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/32
https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/804