### PR TITLE
Use centralised status method

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,33 +1,12 @@
-from flask import jsonify, current_app, request
+from flask import request
 
-from .. import data_api_client
 from . import status
-from dmutils.status import get_flags
+from .. import data_api_client
+from dmutils.status import get_app_status
 
 
 @status.route('/_status')
 def status():
-
-    if 'ignore-dependencies' in request.args:
-        return jsonify(
-            status="ok",
-        ), 200
-
-    version = current_app.config['VERSION']
-    status = data_api_client.get_status()
-
-    if status['status'] == "ok":
-        return jsonify(
-            status="ok",
-            version=version,
-            api_status=status,
-            flags=get_flags(current_app)
-        )
-
-    return jsonify(
-        status="error",
-        version=version,
-        api_status=status,
-        message="Error connecting to the (Data) API.",
-        flags=get_flags(current_app)
-    ), 500
+    return get_app_status(data_api_client=data_api_client,
+                          search_api_client=None,
+                          ignore_dependencies='ignore-dependencies' in request.args)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 ## The following requirements were added by pip freeze:

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -132,7 +132,16 @@ class LoggedInApplicationTest(BaseApplicationTest):
     def user_loader(self, user_id):
         if user_id:
             return User(
-                user_id, 'test@example.com', None, None, False, True, 'tester', self.user_role
+                user_id=user_id,
+                email_address='test@example.com',
+                supplier_id=None,
+                supplier_name=None,
+                supplier_organisation_size='micro',
+                locked=False,
+                active=True,
+                name='tester',
+                role=self.user_role,
+                user_research_opted_in=True,
             )
 
     def teardown_method(self, method):

--- a/tests/app/status/test_views.py
+++ b/tests/app/status/test_views.py
@@ -27,11 +27,10 @@ class TestStatus(BaseApplicationTest):
 
     @mock.patch('app.status.views.data_api_client')
     def test_status_error(self, data_api_client):
-
         data_api_client.get_status.return_value = {
             'status': 'error',
             'app_version': None,
-            'message': 'Cannot connect to (Data) API'
+            'message': 'Cannot connect to Data API'
         }
 
         response = self.client.get('/admin/_status')


### PR DESCRIPTION
 ## Summary
The status endpoint for all of the apps is highly redundant across
repositories so I've moved it to dm-utils. We now only need to call this
method from the view stub in each app and pass in a couple of resources
(mainly the current_app and any api clients) to get a consistent status
JSON blob back.

 ## Ticket
https://trello.com/c/BBvu6eUk/383-ensure-healthcheck-endpoint-fails-if-low-disk-space