### PR TITLE
147-admin-fe-download-user-research-participants

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from dmutils import csv_generator
 from dmutils.config import convert_to_boolean
-from flask import abort, render_template, request, Response
+from flask import abort, render_template, request, Response, url_for
 from flask_login import flash, current_user
 
 from .. import main
@@ -45,6 +45,26 @@ def user_list_page_for_framework(framework_slug):
     return render_template(
         "download_framework_users.html",
         framework=framework,
+    ), 200
+
+
+@main.route('/users/download/suppliers', methods=['GET'])
+@role_required('admin')
+def supplier_user_research_participants_by_framework():
+    bad_statuses = ['coming', 'expired']
+    frameworks = data_api_client.find_frameworks().get("frameworks")
+    frameworks = sorted(filter(lambda i: i['status'] not in bad_statuses, frameworks), key=lambda i: i['name'])
+    items = [
+        {
+            "title": "User research participants on {}".format(framework['name']),
+            "link": url_for('.download_users', framework_slug=framework['slug'], user_research_opted_in=True),
+            "file_type": "CSV"
+        }
+        for framework in frameworks
+    ]
+    return render_template(
+        "user_research_participants.html",
+        items=items
     ), 200
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -39,6 +39,11 @@
         <a href="{{ url_for('.find_suppliers_and_services') }}">{{ find_supplier_and_services_link_text[current_user.role] }}</a>
       </p>
 
+    {% if current_user.has_any_role('admin') %}
+      <p>
+        <a href="{{ url_for('.supplier_user_research_participants_by_framework') }}">Download lists of potential user research participants</a>
+      </p>
+    {% endif %}
   {% endif %}
   {% if current_user.has_any_role('admin-ccs-category') %}
       <p>
@@ -63,6 +68,9 @@
   {% if current_user.has_role('admin') %}
       <p>
         <a href="{{ url_for('.add_buyer_domains') }}">Add a buyer email domain</a>
+      </p>
+      <p>
+        <a href="{{ url_for('.download_buyers') }}">Download list of potential user research participants</a>
       </p>
   {% endif %}
 

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -1,0 +1,36 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+  Download lists of potential user research participants - Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": url_for('.index'),
+        "label": "Admin home"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  {%
+    with heading = "Download lists of potential user research participants"
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+    <p class="lede">
+    Check you've got the most recent version of the list before you contact users.
+</p><br>
+
+  {%
+    with
+    items = items
+  %}
+    {% include "toolkit/documents.html" %}
+  {% endwith %}
+{% endblock %}

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -149,7 +149,7 @@ class TestIndex(LoggedInApplicationTest):
             assert link_text == expected_link_text
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
-        ("admin", False),
+        ("admin", True),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", True),


### PR DESCRIPTION
https://trello.com/c/vFOX8hcq/147-admin-fe-download-user-research-participants
https://github.com/alphagov/digitalmarketplace-functional-tests/pull/489

Add the links/ new page for the user research participants csvs. Links should only show for 'admin' role.

![screen shot 2018-03-20 at 14 46 53](https://user-images.githubusercontent.com/3469840/37662269-a0305548-2c4e-11e8-9b48-831fb26d5758.png)
![screen shot 2018-03-20 at 14 47 03](https://user-images.githubusercontent.com/3469840/37662268-a01241fc-2c4e-11e8-8a11-9dc9187d12f4.png)

