### PR TITLE
Flash messages in the Admin FE

### DIFF
--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -11,6 +11,10 @@ from ..forms import InviteAdminForm, EditAdminUserForm
 from ... import data_api_client
 
 
+INVITATION_SENT_MESSAGE = "An invitation has been sent to {email_address}."
+EMAIL_ADDRESS_UPDATED_MESSAGE = "{email_address} has been updated."
+
+
 @main.route('/admin-users', methods=['GET'])
 @role_required('admin-manager')
 def manage_admin_users():
@@ -53,7 +57,7 @@ def invite_admin_user():
             notify_template_id,
             personalisation={'name': current_user.name}
         )
-        flash('An invitation has been sent to {}.'.format(email_address), category='success')
+        flash(INVITATION_SENT_MESSAGE.format(email_address=email_address))
         return redirect(url_for('main.manage_admin_users'))
 
     errors = {
@@ -90,7 +94,7 @@ def edit_admin_user(admin_user_id):
                 role=edited_admin_permissions,
                 active=edited_admin_status
             )
-            flash("{} has been updated.".format(admin_user["emailAddress"]), "message")
+            flash(EMAIL_ADDRESS_UPDATED_MESSAGE.format(email_address=admin_user["emailAddress"]))
             return redirect(url_for('.manage_admin_users'))
         except HTTPError as e:
             status_code = 400

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -8,6 +8,10 @@ from ..forms import EmailDomainForm
 from ... import data_api_client
 
 
+ADDED_BUYER_DOMAIN_MESSAGE = 'You’ve added {buyer_domain}.'
+NO_BRIEFS_ERROR_MESSAGE = "There are no opportunities with ID {brief_id}"
+
+
 @main.route('/buyers', methods=['GET'])
 @role_required('admin', 'admin-ccs-category')
 def find_buyer_by_brief_id():
@@ -19,7 +23,7 @@ def find_buyer_by_brief_id():
         brief = data_api_client.get_brief(brief_id)
     except HTTPError:
         if 'brief_id' in request.args:
-            flash('no_brief', 'error')
+            flash(NO_BRIEFS_ERROR_MESSAGE.format(brief_id=brief_id), 'error')
             status_code = 404
 
     return render_template(
@@ -38,7 +42,7 @@ def add_buyer_domains():
         try:
             new_domain = request.form.get('new_buyer_domain')
             data_api_client.create_buyer_email_domain(new_domain, current_user.email_address)
-            flash('You’ve added {}.'.format(new_domain), 'message')
+            flash(ADDED_BUYER_DOMAIN_MESSAGE.format(buyer_domain=new_domain))
             return redirect(url_for('.add_buyer_domains'))
         except HTTPError as e:
             status_code = 400

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -41,27 +41,26 @@ def upload_communication(framework_slug):
         the_file = request.files['communication']
         if not (file_is_open_document_format(the_file) or file_is_csv(the_file)):
             errors['communication'] = 'not_open_document_format_or_csv'
+            flash('Communication file is not an open document format or a CSV.', 'error')
 
         if 'communication' not in errors.keys():
             path = "{}/communications/updates/communications/{}".format(framework_slug, the_file.filename)
             communications_bucket.save(
                 path, the_file, acl='bucket-owner-full-control', download_filename=the_file.filename
             )
-            flash('communication', 'upload_communication')
+            flash('New communication was uploaded.')
 
     if request.files.get('clarification'):
         the_file = request.files['clarification']
         if not file_is_pdf(the_file):
             errors['clarification'] = 'not_pdf'
+            flash('Clarification file is not a PDF.', 'error')
 
         if 'clarification' not in errors.keys():
             path = "{}/communications/updates/clarifications/{}".format(framework_slug, the_file.filename)
             communications_bucket.save(
                 path, the_file, acl='bucket-owner-full-control', download_filename=the_file.filename
             )
-            flash('clarification', 'upload_communication')
+            flash('New clarification was uploaded.')
 
-    if len(errors) > 0:
-        for category, message in errors.items():
-            flash(category, message)
     return redirect(url_for('.manage_communications', framework_slug=framework_slug))

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -7,6 +7,9 @@ from ..auth import role_required
 from ... import data_api_client
 
 
+APPROVED_SERVICE_EDITS_MESSAGE = "The changes to service {service_id} were approved."
+
+
 @main.route('/services/updates/unapproved', methods=['GET'])
 @role_required('admin-ccs-category')
 def service_update_audits():
@@ -40,5 +43,5 @@ def submit_service_update_approval(service_id, audit_id):
         audit_event["id"],
         current_user.email_address
     )
-    flash("The changes to service {} were approved.".format(service_id), 'message')
+    flash(APPROVED_SERVICE_EDITS_MESSAGE.format(service_id=service_id))
     return redirect(url_for('.service_update_audits'))

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -24,7 +24,7 @@ def find_user_by_email_address():
         if email_address:
             users = data_api_client.get_user(email_address=email_address)
         if not users:
-            flash('no_users', 'error')
+            flash("Sorry, we couldn't find an account with that email address", 'error')
             response_code = 404
 
     return render_template(

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -19,19 +19,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-      {% for category, message in messages %}
-          {%
-          with
-            message = message,
-            type = "destructive" if category == 'error' else 'success'
-          %}
-          {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-      {% endfor %}
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {% for error in email_domain_form.new_buyer_domain.errors %}
     {%

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -22,27 +22,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-  {% for category, message in messages %}
-    {% if category == 'error' %}
-        <div class="banner-destructive-without-action">
-    {% else %}
-        <div class="banner-success-without-action">
-    {% endif %}
-      <p class="banner-message">
-          {% if message['bad_status'] %}
-          Not a valid status: '{{ message['bad_status'] }}'
-          {% elif message['status_error'] %}
-          Error trying to update status of service: {{ message['status_error'] }}
-          {% elif message['status_updated'] %}
-          Service status has been updated to: {{ message['status_updated']|title }}
-          {% endif %}
-      </p>
-      {% endfor %}
-  </div>
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {%
     with

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -20,19 +20,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-      {% for category, message in messages %}
-          {%
-          with
-            message = message,
-            type = "destructive" if category == 'error' else 'success'
-          %}
-          {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-      {% endfor %}
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {% for error in edit_admin_user_form.edit_admin_name.errors %}
     {%

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -29,24 +29,8 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        {% if message['no_service'] %}
-          {% set displayed_message = "Could not find a service with ID: {}".format(message['no_service']) %}
-        {% elif message['api_error'] %}
-          {% set displayed_message = "Error trying to retrieve service with ID: {}".format(message['api_error']) %}
-        {% endif %}
-        {%
-          with
-          message = displayed_message,
-          type = "destructive" if category == 'error' else "success"
-        %}
-          {% include "toolkit/notification-banner.html" %}
-        {% endwith %}
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
+
   {%
     with heading = page_title
   %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -18,33 +18,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-          {% for category, message in messages %}
-              {% if category == 'upload_communication' %}
-                <div class="banner-success-without-action">
-                  <p class="banner-message">
-                  {% if message == 'clarification' %}
-                    New clarification was uploaded.
-                  {% elif message == 'communication' %}
-                    New communication was uploaded.
-                  {% endif %}
-                  </p>
-                </div>
-              {% else %}
-                <div class="banner-destructive-without-action">
-                    <p class="banner-message">
-                    {% if category == 'not_open_document_format_or_csv' and message == 'communication' %}
-                        Communication file is not an open document format or a CSV.
-                    {% elif category == 'not_pdf' and message == 'clarification' %}
-                        Clarification file is not a PDF.
-                    {% endif %}
-                  </p>
-                </div>
-              {% endif %}
-          {% endfor %}
-      {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {% with heading = "Upload {} communications".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -22,19 +22,7 @@
 {% endblock %}
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-      {% for category, message in messages %}
-          {%
-          with
-              message = message,
-              type = "destructive" if category == 'error' else 'success'
-          %}
-          {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-      {% endfor %}
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
     {%
       with

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -20,39 +20,18 @@
 {% endblock %}
 
 {% block main_content %}
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-  {% for category, message in messages %}
-  {% if category == 'upload_countersigned_agreement' %}
-    {%
-      with
-      message = "Countersigned agreement file was uploaded",
-      type = "success"
-    %}
-      {% include "toolkit/notification-banner.html" %}
-    {% endwith %}
-  {% elif category == 'not_pdf' %}
-    {%
-      with
-      message = "Countersigned agreement file is not a PDF",
-      type = "destructive"
-    %}
-      {% include "toolkit/notification-banner.html" %}
-    {% endwith %}
-    {% elif category == 'remove_countersigned_agreement' %}
-    <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug) }}'>
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    <div class="banner-destructive-with-action">
-      <p class="banner-message">
-        Do you want to remove the countersigned agreement?
-      </p>
-      <button class="button-destructive banner-action" type="submit">Yes</button>
-    </div>
-  {% endif %}
+  {% include "toolkit/flash_messages.html" %}
 
-  {% endfor %}
+  {% if remove_countersigned_agreement_confirm %}
+      <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug) }}'>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <div class="banner-destructive-with-action">
+        <p class="banner-message">
+          Do you want to remove the countersigned agreement?
+        </p>
+        <button class="button-destructive banner-action" type="submit">Yes</button>
+      </div>
   {% endif %}
-  {% endwith %}
 
   <div class="grid-row">
     <div class="service-title">

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -23,19 +23,7 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-        {%
-          with
-          message = message,
-          type = "success"
-        %}
-          {% include "toolkit/notification-banner.html" %}
-        {% endwith %}
-      {% endfor %}
-    {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
 
 <div class='grid-row'>

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -19,19 +19,7 @@
 
 {% block main_content %}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-      {% for category, message in messages %}
-          {%
-          with
-              message = message,
-              type = "destructive" if category == 'error' else 'success'
-          %}
-          {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-      {% endfor %}
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {% with heading = "Manage users" %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -18,22 +18,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-      {% for category, message in messages %}
-          {% if message == 'no_brief' %}
-              {% set displayed_message = "There are no opportunities with ID {}".format(brief_id) %}
-          {% endif %}
-          {%
-          with
-              message = displayed_message,
-              type = "destructive" if category == 'error' else "success"
-          %}
-          {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-      {% endfor %}
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {% with heading = "Find a buyer" %}
   {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -62,26 +62,7 @@
       </form>
     {% endif %}
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% for category, message in messages %}
-        {% with message = message, type = "destructive" if category == 'error' else 'success' %}
-          {% if message['status_updated'] %}
-            {% if message['status_updated'] == 'public' %}
-              {% set message = "You published ‘{}’.".format(service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName']) %}
-              {% include "toolkit/notification-banner.html" %}
-            {% endif %}
-          {% elif message['bad_status'] %}
-            {% set message = "Not a valid status: {}".format(message['bad_status']) %}
-            {% include "toolkit/notification-banner.html" %}
-          {% elif message['status_error'] %}
-            {% set message = "Error trying to update status of service: ".format(message['status_error']) %}
-            {% include "toolkit/notification-banner.html" %}
-          {% else %}
-            {% include "toolkit/notification-banner.html" %}
-          {% endif %}
-        {% endwith %}
-      {% endfor %}
-    {% endwith %}
+    {% include "toolkit/flash_messages.html" %}
 
     {% if service_data['status'] != 'published' and removed_by %}
       {%

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -40,13 +40,7 @@
       </div>
     {% endif %}
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% for category, message in messages %}
-        {% with message = message, type = "destructive" if category == 'error' else 'success' %}
-          {% include "toolkit/notification-banner.html" %}
-        {% endwith %}
-      {% endfor %}
-    {% endwith %}
+    {% include "toolkit/flash_messages.html" %}
   {% endblock %}
 
   <div class="grid-row">

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -23,27 +23,8 @@
 {% endblock %}
 
 {% block main_content %}
-{% set flash_messages_content = {
-        'user_invited': 'User invited',
-        'user_not_invited': 'Not invited',
-        'user_moved': 'User moved to this supplier',
-        'user_not_moved': 'User not moved to this supplier - please check you entered the address of an existing supplier user'
-    }
-%}
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-      {% for category, message in messages %}
-          {%
-          with
-              message = flash_messages_content[message],
-              type = "destructive" if category == 'error' else 'success'
-          %}
-          {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-      {% endfor %}
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {% with heading = supplier.name %}
   {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -20,22 +20,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-      {% for category, message in messages %}
-          {% if message == 'no_users' %}
-              {% set displayed_message = "Sorry, we couldn't find an account with that email address" %}
-          {% endif %}
-          {%
-          with
-              message = displayed_message,
-              type = "destructive" if category == 'error' else "success"
-          %}
-          {% include "toolkit/notification-banner.html" %}
-          {% endwith %}
-      {% endfor %}
-  {% endif %}
-  {% endwith %}
+  {% include "toolkit/flash_messages.html" %}
 
   {% with heading = "Find a user" %}
   {% include "toolkit/page-heading.html" %}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -68,9 +68,13 @@ class BaseApplicationTest(object):
         pattern = re.compile(r'\s+')
         return re.sub(pattern, '', content)
 
-    def _get_flash_messages(self):
+    def assert_flashes(self, expected_message, expected_category='message'):
         with self.client.session_transaction() as session:
-            return MultiDict(session['_flashes'])
+            if '_flashes' not in session:
+                raise AssertionError('nothing flashed')
+            messages = MultiDict(session['_flashes'])
+            assert expected_message in messages.getlist(expected_category), \
+                "Didn't find '{}' in '{}'".format(expected_message, messages.getlist(expected_category))
 
     @staticmethod
     def _get_fixture_data(fixture_filename):

--- a/tests/app/main/helpers/flash_tester.py
+++ b/tests/app/main/helpers/flash_tester.py
@@ -1,8 +1,0 @@
-def assert_flashes(self, expected_message, expected_category='message'):
-    with self.client.session_transaction() as session:
-        try:
-            category, message = session['_flashes'][0]
-        except KeyError:
-            raise AssertionError('nothing flashed')
-        assert expected_message in message
-        assert expected_category in category

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -5,7 +5,6 @@ import pytest
 from dmapiclient import HTTPError
 
 from ...helpers import LoggedInApplicationTest, Response
-from ..helpers.flash_tester import assert_flashes
 
 
 @mock.patch("app.main.views.admin_manager.data_api_client")
@@ -267,7 +266,7 @@ class TestInviteAdminUserView(LoggedInApplicationTest):
         data_api_client.email_is_valid_for_admin_user.return_value = True
         res = self.client.post('/admin/admin-users/invite', data={'role': 'admin', 'email_address': 'test@test.com'})
         assert res.status_code == 302
-        assert_flashes(self, 'An invitation has been sent to test@test.com.', 'success')
+        self.assert_flashes('An invitation has been sent to test@test.com.')
 
 
 @mock.patch("app.main.views.admin_manager.data_api_client")
@@ -407,14 +406,14 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
             }
         )
         assert response1.status_code == 302
-        assert_flashes(self, "reality.auditor@digital.cabinet-office.gov.uk has been updated", "message")
+        self.assert_flashes("reality.auditor@digital.cabinet-office.gov.uk has been updated.", "message")
         assert data_api_client.update_user.call_args_list == [mock.call(
             "2345", name="Lady Myria Lejean", role=role, active=False
         )]
 
         assert response1.location == "http://localhost/admin/admin-users"
         response2 = self.client.get(response1.location)
-        assert "reality.auditor@digital.cabinet-office.gov.uk has been updated" in response2.get_data(as_text=True)
+        assert "reality.auditor@digital.cabinet-office.gov.uk has been updated." in response2.get_data(as_text=True)
 
     def test_admin_user_name_cannot_be_submitted_when_empty(self, data_api_client):
         self.user_role = "admin-manager"

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -3,7 +3,6 @@ import pytest
 from dmapiclient import HTTPError
 from lxml import html
 
-from tests.app.main.helpers.flash_tester import assert_flashes
 from ...helpers import LoggedInApplicationTest, Response
 
 
@@ -134,7 +133,7 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
                                      data={'new_buyer_domain': 'kev.uk'}
                                      )
         assert response1.status_code == 302
-        assert_flashes(self, "You’ve added kev.uk", "message")
+        self.assert_flashes("You’ve added kev.uk.")
         assert data_api_client.create_buyer_email_domain.call_args_list == [mock.call("kev.uk", "test@example.com")]
 
         response2 = self.client.get(response1.location)

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -89,10 +89,9 @@ class TestCommunicationsView(LoggedInApplicationTest):
         )
 
         # check that we did actually mock-send two files
-        self.s3.return_value.save.call_count == 2
-        flash_messages = self._get_flash_messages()
-        # arguably a misunderstanding here about what an appropriate 'message category' looks like
-        assert set(flash_messages.getlist('upload_communication')) == set(('clarification', 'communication',))
+        assert self.s3.return_value.save.call_count == 2
+        self.assert_flashes('New communication was uploaded.')
+        self.assert_flashes('New clarification was uploaded.')
 
         assert response.status_code == 302
 
@@ -120,10 +119,8 @@ class TestCommunicationsView(LoggedInApplicationTest):
             }
         )
 
-        flash_messages = self._get_flash_messages()
-        # definitely a misunderstanding here about what an appropriate 'message category' looks like
-        assert flash_messages.get('not_open_document_format_or_csv') == 'communication'
-        assert flash_messages.get('not_pdf') == 'clarification'
+        self.assert_flashes('Communication file is not an open document format or a CSV.', expected_category='error')
+        self.assert_flashes('Clarification file is not a PDF.', expected_category='error')
 
     def test_communications_file_saves_with_correct_path(self, get_framework_mock):
 

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -3,7 +3,6 @@ import mock
 import pytest
 from lxml import html
 
-from tests.app.main.helpers.flash_tester import assert_flashes
 from ...helpers import LoggedInApplicationTest
 
 
@@ -126,7 +125,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         data_api_client.get_audit_event.side_effect = lambda audit_event_id: {123: audit_event}[audit_event_id]
         response = self.client.post('/admin/services/321/updates/123/approve')
         assert response.status_code == 302
-        assert_flashes(self, "The changes to service 321 were approved.")
+        self.assert_flashes("The changes to service 321 were approved.")
         assert response.location == 'http://localhost/admin/services/updates/unapproved'
 
         data_api_client.acknowledge_service_update_including_previous.assert_called_with(


### PR DESCRIPTION
Trello: https://trello.com/c/arqFIzNG/301-flash-messages-admin-app

- Moves flash message content out of templates and into Python code
- Replaces `notification-banner.html` toolkit template with `flash_messages.html`
- Replaces a destructive action (for removing countersigned agreements) flash message with a conditional query param flag, following the pattern for removing supplier services from a framework
- Refactors `assert_flashes` helper function to be a method on the `BaseApplicationTest` class, as per other apps. The method can now assert multiple flash messages on the same page (eg uploaded communications/clarifications).

I've split out the different features into their own commits for ease of review - I can squash later.