### PR TITLE
config: add user.marketplace.team to DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS

### DIFF
--- a/config.py
+++ b/config.py
@@ -101,6 +101,7 @@ class Live(Config):
     DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS = {
         "example.com": "success@simulator.amazonses.com",
         "example.gov.uk": "success@simulator.amazonses.com",
+        "user.marketplace.team": "success@simulator.amazonses.com",
     }
 
     NOTIFY_TEMPLATES = {


### PR DESCRIPTION
This means our functional tests which use sanitized db dump accounts could
send emails and they also then have an email domain available to them that
is admin-qualified.

What do people think?

Should I _also_ add a `admin.example.gov.uk` explicitly for this purpose?