### PR TITLE
digitalmarketplace-utils dependency: bump to 36.2.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.1#egg=digitalmarketplace-utils==36.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,15 +8,15 @@ Flask-WTF==0.11
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.0.0#egg=digitalmarketplace-utils==36.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.1#egg=digitalmarketplace-utils==36.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 backoff==1.0.7
-boto3==1.4.4
-botocore==1.5.95
-certifi==2018.1.18
+boto3==1.4.8
+botocore==1.8.50
+certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0


### PR DESCRIPTION
This includes fixes for security issues https://snyk.io/vuln/SNYK-PYTHON-BOTO3-40617 and https://snyk.io/vuln/SNYK-PYTHON-WTFORMS-40581, the fix for the latter requiring a synchronized rollout across all frontends