### PR TITLE
 Add link to 'change password' to admin dashboard

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -22,6 +22,7 @@
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
       {% block main_content %}{% endblock %}
     </main>
   </div>

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -19,8 +19,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% include "toolkit/flash_messages.html" %}
-
   {% for error in email_domain_form.new_buyer_domain.errors %}
     {%
       with

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -22,8 +22,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% include "toolkit/flash_messages.html" %}
-
   {%
     with
     smaller = true,

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -20,8 +20,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% include "toolkit/flash_messages.html" %}
-
   {% for error in edit_admin_user_form.edit_admin_name.errors %}
     {%
       with

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -28,9 +28,6 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% include "toolkit/flash_messages.html" %}
-
   {%
     with heading = page_title
   %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,6 +10,10 @@
   %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
+  </div>
+</div>
+<div class="grid-row">
+  <div class="column-two-thirds">
     <div class="dmspeak">
   {% if current_user.has_role('admin-manager') %}
       <p>
@@ -110,6 +114,13 @@
     {% endfor %}
   {% endif %}
     </div>
+  </div>
+  <div class="column-one-third dmspeak">
+    <h2 class="heading-xmedium">Account settings</h2>
+
+    <p>
+      <a href="{{ url_for('external.change_password') }}">Change your password</a>
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -18,8 +18,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% include "toolkit/flash_messages.html" %}
-
   {% with heading = "Upload {} communications".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -21,9 +21,6 @@
   {% endwith %}
 {% endblock %}
 {% block main_content %}
-
-  {% include "toolkit/flash_messages.html" %}
-
     {%
       with
       heading = "Check edits to services"

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -20,8 +20,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% include "toolkit/flash_messages.html" %}
-
   {% if remove_countersigned_agreement_confirm %}
       <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug) }}'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -22,10 +22,6 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% include "toolkit/flash_messages.html" %}
-
-
 <div class='grid-row'>
   <div class="column-one-whole">
     {%

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -18,9 +18,6 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% include "toolkit/flash_messages.html" %}
-
   {% with heading = "Manage users" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -18,8 +18,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% include "toolkit/flash_messages.html" %}
-
   {% with heading = "Find a buyer" %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -62,8 +62,6 @@
       </form>
     {% endif %}
 
-    {% include "toolkit/flash_messages.html" %}
-
     {% if service_data['status'] != 'published' and removed_by %}
       {%
         with

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -39,8 +39,6 @@
         </form>
       </div>
     {% endif %}
-
-    {% include "toolkit/flash_messages.html" %}
   {% endblock %}
 
   <div class="grid-row">

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -23,9 +23,6 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% include "toolkit/flash_messages.html" %}
-
   {% with heading = supplier.name %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -20,8 +20,6 @@
 {% endblock %}
 
 {% block main_content %}
-  {% include "toolkit/flash_messages.html" %}
-
   {% with heading = "Find a user" %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.5.0#egg=digitalmarketplace-utils==36.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.5.0#egg=digitalmarketplace-utils==36.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 ## The following requirements were added by pip freeze:

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -7,6 +7,20 @@ from ...helpers import LoggedInApplicationTest
 
 
 class TestIndex(LoggedInApplicationTest):
+
+    @pytest.mark.parametrize("role", [
+        "admin",
+        "admin-ccs-category",
+        "admin-ccs-sourcing",
+        "admin-framework-manager",
+        "admin-manager"
+    ])
+    def test_change_password_link_is_shown_to_all_admin_users(self, role):
+        self.user_role = role
+        response = self.client.get('/admin')
+        document = html.fromstring(response.get_data(as_text=True))
+        assert bool(document.xpath('.//a[@href="/user/change-password"]')), "Role {} cannot see the link".format(role)
+
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", True),
         ("admin-ccs-category", False),


### PR DESCRIPTION
The link has been placed in a new section, 'Account settings', to make it consistent with other apps

This work follows our security report recommendation (see ticket for link to report)
The Trello ticket: https://trello.com/c/TieWrBG5/44-password-reset-link-from-logged-in-session

![screen shot 2018-04-27 at 12 12 24](https://user-images.githubusercontent.com/20957548/39364633-82251944-4a26-11e8-84cf-d58a54b89560.png)

