### PR TITLE
Public stats page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -59,11 +59,13 @@ def create_app(config_name):
 
     application.permanent_session_lifetime = timedelta(hours=1)
     from .main import main as main_blueprint
+    from .main import public as public_blueprint
     from .status import status as status_blueprint
     from dmutils.external import external as external_blueprint
 
     application.register_blueprint(status_blueprint, url_prefix='/admin')
     application.register_blueprint(main_blueprint, url_prefix='/admin')
+    application.register_blueprint(public_blueprint, url_prefix='/admin')
 
     # Must be registered last so that any routes declared in the app are registered first (i.e. take precedence over
     # the external NotImplemented routes in the dm-utils external blueprint).

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,6 +3,7 @@ from flask_login import current_user, login_required
 
 
 main = Blueprint('main', __name__)
+public = Blueprint('public', __name__)  # Admin login not required
 
 from .views import (
     agreements, communications, search, service_updates, services, suppliers, stats, users, buyers, admin_manager

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -4,15 +4,17 @@ from dmapiclient.audit import AuditTypes
 from dmutils.formats import DATETIME_FORMAT
 from flask import render_template, request
 
-from .. import main
-from ..auth import role_required
+from .. import public
 from ..helpers.sum_counts import format_snapshots
 from ... import data_api_client
 
 
-@main.route('/statistics/<string:framework_slug>', methods=['GET'])
-@role_required('admin-ccs-sourcing', 'admin-framework-manager')
+@public.route('/statistics/<string:framework_slug>', methods=['GET'])
 def view_statistics(framework_slug):
+    """This view is not protected by a role_required check as of 10/05/2018 and a decision that the protection offered
+    by the admin-frontend's IP restriction is sufficient. The data displayed here is not particularly sensitive and
+    this allows us to easily display it on screens e.g. in the office, without having to leave a privileged user logged
+    into the admin site (which would be Bad)."""
 
     snapshots = data_api_client.find_audit_events(
         audit_type=AuditTypes.snapshot_framework_stats,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -99,7 +99,7 @@
 
         {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
         <p>
-          <a href="{{ url_for('.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
+          <a href="{{ url_for('public.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
         </p>
         {% endif %}
         {% if current_user.has_any_role('admin-framework-manager') %}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -10,7 +10,7 @@
   {%
     with items = [
       {
-        "link": url_for('.index'),
+        "link": url_for('main.index'),
         "label": "Admin home"
       }
     ]

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -1,29 +1,15 @@
 import mock
-import pytest
 from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
 
-from ...helpers import LoggedInApplicationTest
+from ...helpers import BaseApplicationTest
 
 
 @mock.patch('app.main.views.stats.data_api_client')
-class TestStats(LoggedInApplicationTest):
-    def setup_method(self, method, *args, **kwargs):
-        super(TestStats, self).setup_method(method, *args, **kwargs)
-        self.user_role = 'admin-ccs-sourcing'
-
-    @pytest.mark.parametrize("role,expected_code", [
-        ("admin", 403),
-        ("admin-ccs-category", 403),
-        ("admin-ccs-sourcing", 200),
-        ("admin-framework-manager", 200),
-        ("admin-manager", 403),
-    ])
-    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
-        self.user_role = role
+class TestStats(BaseApplicationTest):
+    def test_get_page_should_be_publically_accessible(self, data_api_client):
         response = self.client.get('/admin/statistics/g-cloud-7')
-        actual_code = response.status_code
-        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+        assert response.status_code == 200, "Expected 200 OK without logged-in user"
 
     def test_get_stats_page(self, data_api_client):
         data_api_client.find_audit_events.return_value = {


### PR DESCRIPTION
 ## Summary
Remove the role check on the framework application stats page. This will
allow us to display these stats e.g. in the office without having to
leave a privileged admin user logged into the marketplace. The admin
site is protected by an IP whitelist by the digitalmarketplace-router,
which should provide sufficient protection - added to the fact that the
data we show here should not be particularly sensitive and much of it is
available on the performance platform already.

 ## Ticket
https://trello.com/c/zTkPCGSY/289-please-create-an-admin-account-which-can-access-framework-application-stats-so-we-can-look-at-them-on-the-big-tv