### PR TITLE
Fix parts of admin app that use wtforms for validation but then pull the final values from the raw form

### DIFF
--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -84,9 +84,9 @@ def edit_admin_user(admin_user_id):
 
     if edit_admin_user_form.validate_on_submit():
         try:
-            edited_admin_name = request.form.get("edit_admin_name")
-            edited_admin_permissions = request.form.get("edit_admin_permissions")
-            edited_admin_status = bool(strtobool(request.form.get("edit_admin_status")))
+            edited_admin_name = edit_admin_user_form.edit_admin_name.data
+            edited_admin_permissions = edit_admin_user_form.edit_admin_permissions.data
+            edited_admin_status = strtobool(edit_admin_user_form.edit_admin_status.data)
 
             data_api_client.update_user(
                 admin_user_id,

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -429,3 +429,17 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
         assert response.status_code == 400
         assert "You must provide a name." in response.get_data(as_text=True)
         assert data_api_client.update_user.call_args_list == []
+
+    def test_strip_whitespace_from_admin_user_name(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.get_user.return_value = self.admin_user_to_edit
+        self.client.post(
+            "/admin/admin-users/2345/edit",
+            data={
+                "edit_admin_name": "Lady Myria Lejean    ",
+                "edit_admin_permissions": "admin",
+                "edit_admin_status": "True"
+            }
+        )
+        data_api_client.update_user.assert_called_once()
+        assert data_api_client.update_user.call_args[1]["name"] == "Lady Myria Lejean"


### PR DESCRIPTION
Trello: [tech-debt#440](https://trello.com/c/WVJ3JPwg/440-fix-parts-of-admin-app-that-use-wtforms-for-validation-but-then-pull-the-final-values-from-the-raw-form-bypassing-any-sanitizati)

A quick fix on the "Edit Admin User" page form, where the whitespace stripping on the validator was being bypassed.