### PR TITLE
Refactor Admin FE tests

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -110,7 +110,7 @@ class LoggedInApplicationTest(BaseApplicationTest):
     user_role = 'admin'
 
     def setup_method(self, method):
-        super(LoggedInApplicationTest, self).setup_method(method)
+        super().setup_method(method)
 
         self.app.register_blueprint(login_for_tests)
 
@@ -150,7 +150,7 @@ class LoggedInApplicationTest(BaseApplicationTest):
 
     def teardown_method(self, method):
         login_manager.user_loader(self._user_callback)
-        super(LoggedInApplicationTest, self).teardown_method(method)
+        super().teardown_method(method)
 
     def _replace_whitespace(self, string, replacement_substring=""):
             # Replace all runs of whitespace with replacement_substring

--- a/tests/app/main/views/test_application.py
+++ b/tests/app/main/views/test_application.py
@@ -7,38 +7,42 @@ from ...helpers import LoggedInApplicationTest
 
 
 class TestApplication(LoggedInApplicationTest):
-    @mock.patch('app.main.views.services.data_api_client')
-    def test_main_index(self, data_api_client):
-        data_api_client.get_frameworks.return_value = {"frameworks": []}
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.services.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.find_frameworks.return_value = {"frameworks": []}
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
+    def test_main_index(self):
         response = self.client.get('/admin')
         assert response.status_code == 200
+        assert self.data_api_client.find_frameworks.call_args_list == [mock.call()]
 
     def test_404(self):
-        with self.app.app_context():
-            response = self.client.get('/admin/not-found')
-            assert response.status_code == 404
+        response = self.client.get('/admin/not-found')
+        assert response.status_code == 404
 
-    @mock.patch('app.main.views.services.data_api_client')
-    def test_headers(self, data_api_client):
-        data_api_client.get_frameworks.return_value = {"frameworks": []}
+    def test_headers(self):
         res = self.client.get('/admin')
         assert res.status_code == 200
         assert 'Secure;' in res.headers['Set-Cookie']
         assert 'DENY' in res.headers['X-Frame-Options']
+        assert self.data_api_client.find_frameworks.call_args_list == [mock.call()]
 
-    @mock.patch('app.main.views.services.data_api_client')
-    def test_response_headers(self, data_api_client):
-        data_api_client.get_frameworks.return_value = {"frameworks": []}
+    def test_response_headers(self):
         response = self.client.get('/admin')
-
         assert response.headers['cache-control'] == "no-cache"
+        assert self.data_api_client.find_frameworks.call_args_list == [mock.call()]
 
     @pytest.mark.parametrize('role', ['buyer', 'supplier'])
-    @mock.patch('app.main.views.services.data_api_client')
-    def test_only_admin_users_are_allowed(self, data_api_client, role):
+    def test_only_admin_users_are_allowed(self, role):
         self.user_role = role
-        data_api_client.get_frameworks.return_value = {"frameworks": []}
         response = self.client.get('/admin')
 
         assert response.status_code == 302
         assert response.location == 'http://localhost/user/login?next=%2Fadmin'
+        assert self.data_api_client.find_frameworks.call_args_list == []

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -6,8 +6,17 @@ from lxml import html
 from ...helpers import LoggedInApplicationTest, Response
 
 
-@mock.patch('app.main.views.buyers.data_api_client')
 class TestBuyersView(LoggedInApplicationTest):
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.buyers.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 200),
         ("admin-ccs-category", 200),
@@ -15,14 +24,14 @@ class TestBuyersView(LoggedInApplicationTest):
         ("admin-manager", 403),
         ("admin-framework-manager", 403),
     ])
-    def test_find_buyers_page_is_only_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+    def test_find_buyers_page_is_only_accessible_to_specific_user_roles(self, role, expected_code):
         self.user_role = role
         response = self.client.get('/admin/buyers?brief_id=1')
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_should_show_find_buyers_page(self, data_api_client):
-        data_api_client.get_brief.return_value = None
+    def test_should_show_find_buyers_page(self):
+        self.data_api_client.get_brief.return_value = None
         response = self.client.get('admin/buyers')
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
@@ -33,14 +42,14 @@ class TestBuyersView(LoggedInApplicationTest):
         assert "There are no opportunities with ID" not in page_html
         assert heading == "Find a buyer"
 
-    def test_should_be_a_404_if_no_brief_found(self, data_api_client):
-        data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
+    def test_should_be_a_404_if_no_brief_found(self):
+        self.data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
         response = self.client.get('admin/buyers?brief_id=1')
 
         assert response.status_code == 404
 
-    def test_should_display_a_useful_message_if_no_brief_found(self, data_api_client):
-        data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
+    def test_should_display_a_useful_message_if_no_brief_found(self):
+        self.data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
         response = self.client.get('admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
@@ -48,12 +57,12 @@ class TestBuyersView(LoggedInApplicationTest):
 
         assert banner_message == "There are no opportunities with ID 1"
 
-    def test_brief_not_found_flash_message_injection(self, data_api_client):
+    def test_brief_not_found_flash_message_injection(self):
         """
         Asserts that raw HTML in a bad brief ID cannot be injected into a flash message.
         """
         # impl copied from test_should_display_a_useful_message_if_no_brief_found
-        data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
+        self.data_api_client.get_brief.side_effect = HTTPError(Response(status_code=404))
         response = self.client.get('admin/buyers?brief_id=1%3Cimg%20src%3Da%20onerror%3Dalert%281%29%3E')
         assert response.status_code == 404
 
@@ -61,8 +70,8 @@ class TestBuyersView(LoggedInApplicationTest):
         assert "1<img src=a onerror=alert(1)>" not in html_response
         assert "1&lt;img src=a onerror=alert(1)&gt;" in html_response
 
-    def test_table_should_show_a_useful_message_if_no_users(self, data_api_client):
-        data_api_client.get_brief.return_value = {
+    def test_table_should_show_a_useful_message_if_no_users(self):
+        self.data_api_client.get_brief.return_value = {
             'briefs': {
                 'title': 'No users in here',
                 'users': list()
@@ -75,9 +84,9 @@ class TestBuyersView(LoggedInApplicationTest):
 
         assert table_content == "No buyers to show"
 
-    def test_should_show_brief_title(self, data_api_client):
+    def test_should_show_brief_title(self):
         brief = self.load_example_listing("brief_response")
-        data_api_client.get_brief.return_value = brief
+        self.data_api_client.get_brief.return_value = brief
         response = self.client.get('/admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
@@ -85,9 +94,9 @@ class TestBuyersView(LoggedInApplicationTest):
 
         assert title == "Individual Specialist-Buyer Requirements"
 
-    def test_should_show_buyers_contact_details(self, data_api_client):
+    def test_should_show_buyers_contact_details(self):
         brief = self.load_example_listing("brief_response")
-        data_api_client.get_brief.return_value = brief
+        self.data_api_client.get_brief.return_value = brief
         response = self.client.get('/admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
@@ -100,14 +109,23 @@ class TestBuyersView(LoggedInApplicationTest):
         assert phone == "02078888888"
 
 
-@mock.patch('app.main.views.buyers.data_api_client')
 class TestAddBuyerDomainsView(LoggedInApplicationTest):
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.buyers.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 200),
         ("admin-ccs-category", 403),
         ("admin-ccs-sourcing", 403),
     ])
-    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, role, expected_code):
         self.user_role = role
         response = self.client.get('/admin/buyers/add-buyer-domains')
         actual_code = response.status_code
@@ -118,7 +136,7 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
         ("admin-ccs-category", 403),
         ("admin-ccs-sourcing", 403)
     ])
-    def test_post_page_should_only_be_accessible_to_specific_user_roles(self, data_api_client, role, expected_code):
+    def test_post_page_should_only_be_accessible_to_specific_user_roles(self, role, expected_code):
         self.user_role = role
         response = self.client.post('/admin/buyers/add-buyer-domains',
                                     data={
@@ -128,55 +146,61 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_admin_user_can_add_a_new_buyer_domain(self, data_api_client):
+    def test_admin_user_can_add_a_new_buyer_domain(self):
         response1 = self.client.post('/admin/buyers/add-buyer-domains',
                                      data={'new_buyer_domain': 'kev.uk'}
                                      )
         assert response1.status_code == 302
         self.assert_flashes("You’ve added kev.uk.")
-        assert data_api_client.create_buyer_email_domain.call_args_list == [mock.call("kev.uk", "test@example.com")]
+        assert self.data_api_client.create_buyer_email_domain.call_args_list == [
+            mock.call("kev.uk", "test@example.com")
+        ]
 
         response2 = self.client.get(response1.location)
         assert "You’ve added kev.uk" in response2.get_data(as_text=True)
 
-    def test_post_empty_form_error(self, data_api_client):
+    def test_post_empty_form_error(self):
         response = self.client.post('/admin/buyers/add-buyer-domains',
                                     data={'new_buyer_domain': ''}
                                     )
         assert response.status_code == 400
         assert "The domain field can not be empty." in response.get_data(as_text=True)
-        assert data_api_client.create_buyer_email_domain.call_args_list == []
+        assert self.data_api_client.create_buyer_email_domain.call_args_list == []
 
-    def test_post_duplicate_domain_error(self, data_api_client):
+    def test_post_duplicate_domain_error(self):
         mock_api_error = mock.Mock(status_code=400)
         mock_api_error.json.return_value = {"error": "Domain name already-exists.org has already been approved"}
-        data_api_client.create_buyer_email_domain.side_effect = HTTPError(mock_api_error)
+        self.data_api_client.create_buyer_email_domain.side_effect = HTTPError(mock_api_error)
         response = self.client.post('/admin/buyers/add-buyer-domains',
                                     data={'new_buyer_domain': 'already-exists.org'}
                                     )
         assert response.status_code == 400
         assert "You cannot add this domain because it already exists." in response.get_data(as_text=True)
-        assert data_api_client.create_buyer_email_domain.call_args_list == [
+        assert self.data_api_client.create_buyer_email_domain.call_args_list == [
             mock.call("already-exists.org", "test@example.com")]
 
-    def test_post_bad_domain_error(self, data_api_client):
+    def test_post_bad_domain_error(self):
         mock_api_error = mock.Mock(status_code=400)
         mock_api_error.json.return_value = {"error": "JSON was not a valid format: 'inv@lid.co' does not match..."}
-        data_api_client.create_buyer_email_domain.side_effect = HTTPError(mock_api_error)
+        self.data_api_client.create_buyer_email_domain.side_effect = HTTPError(mock_api_error)
         response = self.client.post('/admin/buyers/add-buyer-domains',
                                     data={'new_buyer_domain': 'inv@lid.co'}
                                     )
         assert response.status_code == 400
         assert "‘inv@lid.co’ is not a valid format" in response.get_data(as_text=True)
-        assert data_api_client.create_buyer_email_domain.call_args_list == [mock.call("inv@lid.co", "test@example.com")]
+        assert self.data_api_client.create_buyer_email_domain.call_args_list == [
+            mock.call("inv@lid.co", "test@example.com")
+        ]
 
-    def test_raises_unexpected_api_error(self, data_api_client):
+    def test_raises_unexpected_api_error(self):
         mock_api_error = mock.Mock(status_code=418)
         mock_api_error.json.return_value = {"error": "Something happened that we don't understand"}
-        data_api_client.create_buyer_email_domain.side_effect = HTTPError(mock_api_error)
+        self.data_api_client.create_buyer_email_domain.side_effect = HTTPError(mock_api_error)
         response = self.client.post('/admin/buyers/add-buyer-domains',
                                     data={'new_buyer_domain': 'coffee.gov'}
                                     )
         assert response.status_code == 418
         assert "Sorry, we’re experiencing technical difficulties" in response.get_data(as_text=True)
-        assert data_api_client.create_buyer_email_domain.call_args_list == [mock.call("coffee.gov", "test@example.com")]
+        assert self.data_api_client.create_buyer_email_domain.call_args_list == [
+            mock.call("coffee.gov", "test@example.com")
+        ]

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -8,14 +8,21 @@ from lxml import html
 from ...helpers import LoggedInApplicationTest
 
 
-@mock.patch('app.main.views.communications.data_api_client.get_framework', return_value={"frameworks": []})
 class TestCommunicationsView(LoggedInApplicationTest):
     user_role = 'admin-framework-manager'
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.communications.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_framework.return_value = {"frameworks": []}
+
         self.dummy_file = BytesIO(u'Lorem ipsum dolor sit amet'.encode('utf8'))
         self.framework_slug = self.load_example_listing('framework_response')['frameworks']['slug']
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 403),
@@ -24,15 +31,15 @@ class TestCommunicationsView(LoggedInApplicationTest):
         ("admin-framework-manager", 200),
         ("admin-manager", 403),
     ])
-    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, get_framework_mock, role, expected_code):
+    def test_get_page_should_only_be_accessible_to_specific_user_roles(self, role, expected_code):
         self.user_role = role
         response = self.client.get("/admin/communications/{}".format(self.framework_slug))
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_page_shows_empty_messages_if_no_files_uploaded(self, get_framework_mock):
+    def test_page_shows_empty_messages_if_no_files_uploaded(self):
         self.s3.return_value.list.side_effect = ([], [])  # Empty lists for both communication and clarification files
-        get_framework_mock.return_value = {"frameworks": {"status": "open"}}
+        self.data_api_client.get_framework.return_value = {"frameworks": {"status": "open"}}
         response = self.client.get("/admin/communications/{}".format(self.framework_slug))
         document = html.fromstring(response.get_data(as_text=True))
         file_upload_messages = document.xpath('//p[@class="file-upload-existing-value"]')
@@ -41,7 +48,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         assert file_upload_messages[0].text_content().strip() == "No communications have been uploaded yet"
         assert file_upload_messages[1].text_content().strip() == "No clarification answers have been uploaded yet"
 
-    def test_page_shows_timestamp_from_last_file_in_list_if_some_files_already_uploaded(self, get_framework_mock):
+    def test_page_shows_timestamp_from_last_file_in_list_if_some_files_already_uploaded(self):
         # The first list is for communication files, the second for clarifications
         self.s3.return_value.list.side_effect = (
             [
@@ -69,7 +76,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
                 },
             ],
         )
-        get_framework_mock.return_value = {"frameworks": {"status": "open"}}
+        self.data_api_client.get_framework.return_value = {"frameworks": {"status": "open"}}
         response = self.client.get("/admin/communications/{}".format(self.framework_slug))
         document = html.fromstring(response.get_data(as_text=True))
         file_upload_messages = document.xpath('//p[@class="file-upload-existing-value"]')
@@ -78,7 +85,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         assert file_upload_messages[0].text_content().strip() == "Last modified Saturday 3 March 2018 at 3:03am GMT"
         assert file_upload_messages[1].text_content().strip() == "Last modified Wednesday 25 July 2018 at 3:02am BST"
 
-    def test_post_documents_for_framework(self, get_framework_mock):
+    def test_post_documents_for_framework(self):
 
         response = self.client.post(
             "/admin/communications/{}".format(self.framework_slug),
@@ -96,7 +103,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         assert response.status_code == 302
 
     @pytest.mark.parametrize("disallowed_role", ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-manager"])
-    def test_disallowed_roles_can_not_post_documents_for_framework(self, get_framework_mock, disallowed_role):
+    def test_disallowed_roles_can_not_post_documents_for_framework(self, disallowed_role):
 
         self.user_role = disallowed_role
 
@@ -109,7 +116,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         )
         assert response.status_code == 403
 
-    def test_post_bad_documents_for_framework(self, get_framework_mock):
+    def test_post_bad_documents_for_framework(self):
 
         self.client.post(
             "/admin/communications/{}".format(self.framework_slug),
@@ -122,7 +129,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
         self.assert_flashes('Communication file is not an open document format or a CSV.', expected_category='error')
         self.assert_flashes('Clarification file is not a PDF.', expected_category='error')
 
-    def test_communications_file_saves_with_correct_path(self, get_framework_mock):
+    def test_communications_file_saves_with_correct_path(self):
 
         response = self.client.post(
             "/admin/communications/{}".format(self.framework_slug),
@@ -139,7 +146,7 @@ class TestCommunicationsView(LoggedInApplicationTest):
             download_filename='test-comm.pdf'
         )
 
-    def test_clarification_file_saves_with_correct_path(self, get_framework_mock):
+    def test_clarification_file_saves_with_correct_path(self):
 
         response = self.client.post(
             "/admin/communications/{}".format(self.framework_slug),

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -12,8 +12,8 @@ from ...helpers import LoggedInApplicationTest
 class TestCommunicationsView(LoggedInApplicationTest):
     user_role = 'admin-framework-manager'
 
-    def setup_method(self, method, *args, **kwargs):
-        super(TestCommunicationsView, self).setup_method(method, *args, **kwargs)
+    def setup_method(self, method):
+        super().setup_method(method)
         self.dummy_file = BytesIO(u'Lorem ipsum dolor sit amet'.encode('utf8'))
         self.framework_slug = self.load_example_listing('framework_response')['frameworks']['slug']
 

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -7,6 +7,10 @@ from ...helpers import BaseApplicationTest
 
 @mock.patch('app.main.views.stats.data_api_client')
 class TestStats(BaseApplicationTest):
+
+    def setup_method(self, method):
+        super().setup_method(method)
+
     def test_get_page_should_be_publically_accessible(self, data_api_client):
         response = self.client.get('/admin/statistics/g-cloud-7')
         assert response.status_code == 200, "Expected 200 OK without logged-in user"

--- a/tests/app/main/views/test_stats.py
+++ b/tests/app/main/views/test_stats.py
@@ -5,23 +5,28 @@ from dmapiclient.audit import AuditTypes
 from ...helpers import BaseApplicationTest
 
 
-@mock.patch('app.main.views.stats.data_api_client')
 class TestStats(BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.stats.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
 
-    def test_get_page_should_be_publically_accessible(self, data_api_client):
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
+    def test_get_page_should_be_publicly_accessible(self):
         response = self.client.get('/admin/statistics/g-cloud-7')
         assert response.status_code == 200, "Expected 200 OK without logged-in user"
 
-    def test_get_stats_page(self, data_api_client):
-        data_api_client.find_audit_events.return_value = {
+    def test_get_stats_page(self):
+        self.data_api_client.find_audit_events.return_value = {
             'auditEvents': []
         }
         response = self.client.get('/admin/statistics/g-cloud-7')
 
-        data_api_client.find_audit_events.assert_called_once_with(
+        self.data_api_client.find_audit_events.assert_called_once_with(
             audit_type=AuditTypes.snapshot_framework_stats,
             object_type='frameworks',
             object_id='g-cloud-7',
@@ -30,20 +35,20 @@ class TestStats(BaseApplicationTest):
 
         assert response.status_code == 200
 
-    def test_get_stats_page_for_open_framework_includes_framework_stats(self, data_api_client):
-        data_api_client.find_audit_events.return_value = {
+    def test_get_stats_page_for_open_framework_includes_framework_stats(self):
+        self.data_api_client.find_audit_events.return_value = {
             'auditEvents': []
         }
-        data_api_client.get_framework.return_value = {
+        self.data_api_client.get_framework.return_value = {
             'frameworks': {'status': 'open', 'lots': []}
         }
         response = self.client.get('/admin/statistics/g-cloud-7')
 
-        data_api_client.get_framework_stats.assert_called_once_with('g-cloud-7')
+        self.data_api_client.get_framework_stats.assert_called_once_with('g-cloud-7')
         assert response.status_code == 200
 
-    def test_supplier_counts_on_stats_page(self, data_api_client):
-        data_api_client.find_audit_events.return_value = {
+    def test_supplier_counts_on_stats_page(self):
+        self.data_api_client.find_audit_events.return_value = {
             "auditEvents": [
                 {
                     "acknowledged": False,
@@ -90,7 +95,7 @@ class TestStats(BaseApplicationTest):
 
         response = self.client.get('/admin/statistics/g-cloud-7')
 
-        data_api_client.find_audit_events.assert_called_once_with(
+        self.data_api_client.find_audit_events.assert_called_once_with(
             audit_type=AuditTypes.snapshot_framework_stats,
             object_type='frameworks',
             object_id='g-cloud-7',
@@ -104,16 +109,16 @@ class TestStats(BaseApplicationTest):
         assert '<span>230</span>' in page_without_whitespace  # Completed services only 103 + 127
         assert '<span>109</span>' in page_without_whitespace  # Eligible application
 
-    def test_get_stats_page_for_invalid_framework(self, data_api_client):
+    def test_get_stats_page_for_invalid_framework(self):
         api_response = mock.Mock()
         api_response.status_code = 404
-        data_api_client.find_audit_events.side_effect = HTTPError(api_response)
+        self.data_api_client.find_audit_events.side_effect = HTTPError(api_response)
         response = self.client.get('/admin/statistics/g-cloud-11')
         assert response.status_code == 404
 
-    def test_get_stats_page_when_API_is_down(self, data_api_client):
+    def test_get_stats_page_when_API_is_down(self):
         api_response = mock.Mock()
         api_response.status_code = 500
-        data_api_client.find_audit_events.side_effect = HTTPError(api_response)
+        self.data_api_client.find_audit_events.side_effect = HTTPError(api_response)
         response = self.client.get('/admin/statistics/g-cloud-7')
         assert response.status_code == 500

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
-from datetime import datetime
 
+from freezegun import freeze_time
 import mock
 import pytest
 from lxml import html
@@ -441,8 +441,7 @@ class TestBuyersExport(LoggedInApplicationTest):
     @pytest.mark.parametrize('user_role', ('admin', 'admin-framework-manager'))
     def test_filename_includes_a_timestamp(self, user_role):
         self.user_role = user_role
-        with mock.patch('app.main.views.users.datetime') as mock_date:
-            mock_date.utcnow.return_value = datetime(2016, 8, 5, 16, 0, 0)
+        with freeze_time("2016-08-05 16:00:00"):
             self.data_api_client.find_users_iter.return_value = [
                 {
                     'id': 1,
@@ -497,8 +496,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "createdAt": "2016-08-05T12:00:00.000000Z",
             },
         ]
-        with mock.patch('app.main.views.users.datetime') as mock_date:
-            mock_date.utcnow.return_value = datetime(2016, 8, 5, 16, 0, 0)
+        with freeze_time("2016-08-05 16:00:00"):
             response = self.client.get('/admin/users/download/buyers')
         assert response.status_code == 200
 
@@ -541,8 +539,7 @@ class TestBuyersExport(LoggedInApplicationTest):
                 "userResearchOptedIn": True
             },
         ]
-        with mock.patch('app.main.views.users.datetime') as mock_date:
-            mock_date.utcnow.return_value = datetime(2016, 8, 5, 16, 0, 0)
+        with freeze_time("2016-08-05 16:00:00"):
             response = self.client.get('/admin/users/download/buyers')
         assert response.status_code == 200
 


### PR DESCRIPTION
Part of the ongoing refactor work for the FE apps (see here for the equivalent buyer FE refactoring https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/749):

- Consistently patching the `data_api_client` in the test class setup method
- Removing redundant `with app.app_context` context managers
- Using Python 3 `super()` syntax
- Using `freeze_time` instead of patching `datetime.utcnow()`

This looks like a huge number of commits but they are all straightforward - they are just split into manageable chunks (the `test_suppliers` file is particularly large!). Hopefully with Github's new ignore-whitespace functionality this should be easier to review now.