### PR TITLE
Fix error build #20038

### DIFF
--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -86,7 +86,7 @@ def edit_admin_user(admin_user_id):
         try:
             edited_admin_name = edit_admin_user_form.edit_admin_name.data
             edited_admin_permissions = edit_admin_user_form.edit_admin_permissions.data
-            edited_admin_status = strtobool(edit_admin_user_form.edit_admin_status.data)
+            edited_admin_status = bool(strtobool(edit_admin_user_form.edit_admin_status.data))
 
             data_api_client.update_user(
                 admin_user_id,

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -443,3 +443,17 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
         )
         data_api_client.update_user.assert_called_once()
         assert data_api_client.update_user.call_args[1]["name"] == "Lady Myria Lejean"
+
+    def test_admin_user_active_to_bool(self, data_api_client):
+        self.user_role = "admin-manager"
+        data_api_client.get_user.return_value = self.admin_user_to_edit
+        self.client.post(
+            "/admin/admin-users/2345/edit",
+            data={
+                "edit_admin_name": "Lady Myria Lejean",
+                "edit_admin_permissions": "admin",
+                "edit_admin_status": "True"
+            }
+        )
+        data_api_client.update_user.assert_called_once()
+        assert data_api_client.update_user.call_args[1]["active"] is True


### PR DESCRIPTION
distutils.util.strtobool() returns 0 or 1, so it needs to be wrapped in
bool().

PR #383 dropped the bool() and caused regression bug, where the api was
sent an integer when a bool was expected.

This commit introduces a test and fixes the bug