### PR TITLE
Add G-Cloud 10 management to ccs-sourcing

### DIFF
--- a/app/templates/_view_suppliers_agreements.html
+++ b/app/templates/_view_suppliers_agreements.html
@@ -6,6 +6,7 @@
   "G-Cloud 8",
   "Digital Outcomes and Specialists 2",
   "G-Cloud 9",
+  "G-Cloud 10",
 ]
 %}
 
@@ -18,7 +19,7 @@
 %}
 
   {% call summary.row() %}
-
+  
     {{ summary.field_name(item.name, rowspan=5) }}
 
     {% call summary.row() %}
@@ -37,6 +38,9 @@
       {% call summary.field() %}
         <a href="{{ url_for('.view_supplier_declaration', supplier_id=item.id, framework_slug='g-cloud-9') }}">Edit <span class="visually-hidden">G-Cloud 9 </span>declaration</a>
       {% endcall %}
+      {% call summary.field() %}
+        <a href="{{ url_for('.view_supplier_declaration', supplier_id=item.id, framework_slug='g-cloud-10') }}">Edit <span class="visually-hidden">G-Cloud 10 </span>declaration</a>
+      {% endcall %}
     {% endcall %}
 
     {% call summary.row(no_border=True) %}
@@ -47,13 +51,16 @@
         ⬇ <a href="{{ url_for('.download_agreement_file', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists', document_name=agreement_filename) }}" ><span class="visually-hidden">Download Digital Outcomes and Specialists </span>Agreement</a>
       {% endcall %}
       {% call summary.field(rowspan=3) %}
-        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='g-cloud-8') }}">View agreement<span class="visually-hidden"> for G-Cloud 8</span></a>
+        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='g-cloud-8') }}">View agreement <span class="visually-hidden"> for G-Cloud 8</span></a>
       {% endcall %}
       {% call summary.field(rowspan=3) %}
-        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists-2') }}">View agreement<span class="visually-hidden"> for Digital Outcomes and Specialists 2</span></a>
+        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='digital-outcomes-and-specialists-2') }}">View agreement <span class="visually-hidden"> for Digital Outcomes and Specialists 2</span></a>
       {% endcall %}
       {% call summary.field(rowspan=3) %}
-        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='g-cloud-9') }}">View agreement<span class="visually-hidden">for G-Cloud 9</span></a>
+        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='g-cloud-9') }}">View agreement <span class="visually-hidden">for G-Cloud 9</span></a>
+      {% endcall %}
+      {% call summary.field(rowspan=3) %}
+        <a href="{{ url_for('.view_signed_agreement', supplier_id=item.id, framework_slug='g-cloud-10') }}">View agreement <span class="visually-hidden">for G-Cloud 10</span></a>
       {% endcall %}
     {% endcall %}
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jquery": "1.12.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v9.3.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v12.0.0",
     "hogan.js": "3.0.2",
     "c3": "0.4.11"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,9 +525,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#v9.3.0":
-  version "0.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#53d93084e1361b553bf8623b48cd43d069008231"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#v12.0.0":
+  version "12.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#908c2bca2624c4d3a0f5085587ba90a953f7d08c"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0":
   version "28.15.0"


### PR DESCRIPTION
 ## Summary
CCS Sourcing need to be able to manage and edit declarations for G-Cloud
10. Until we have an opportunity to re-design this page/journey, we will
simply add G-Cloud 10 to the existing page. It does make things a little
tight and the design clearly doesn't hold up, but we have a ticket to
prioritise this work in the next sprint or so.

 ## Ticket
https://trello.com/c/Voz6ZjDV/216