### PR TITLE
Updating service with no name (ie. DOS service)

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -122,7 +122,7 @@ def update_service_status(service_id):
     if frontend_status == 'public':
         flash(
             SERVICE_PUBLISHED_MESSAGE.format(
-                service_name=service['serviceName'] or service['frameworkName'] + ' - ' + service['lotName']
+                service_name=service.get('serviceName') or service['frameworkName'] + ' - ' + service['lotName']
             )
         )
     else:

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1359,6 +1359,23 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         assert response.location == 'http://localhost/admin/services/1'
         self.assert_flashes('Service status has been updated to: removed')
 
+    def test_status_update_to_service_with_no_name(self, data_api_client):
+        data_api_client.get_service.return_value = {'services': {
+            'frameworkName': 'G-cloud 7',
+            'lotName': 'Cloud Hosting',
+            'frameworkSlug': 'g-cloud-7',
+            'supplierId': 1000,
+            'status': 'published',
+        }}
+        data_api_client.find_audit_events.return_value = {'auditEvents': []}
+        data_api_client.get_framework.return_value = {'frameworks': {'slug': 'g-cloud-7', 'status': 'live'}}
+        response = self.client.post('/admin/services/status/1', data={'service_status': 'public'})
+        data_api_client.update_service_status.assert_called_with('1', 'published', 'test@example.com')
+
+        assert response.status_code == 302
+        assert response.location == 'http://localhost/admin/services/1'
+        self.assert_flashes("You published ‘G-cloud 7 - Cloud Hosting’.")
+
     def test_cannot_update_status_to_private(self, data_api_client):
         data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-8',


### PR DESCRIPTION
* Fix 500 when updating service with no name (ie. DOS service)

```
Traceback (most recent call last):
  File "/app/venv/lib/python3.6/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/app/venv/lib/python3.6/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/app/venv/lib/python3.6/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/app/venv/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/app/venv/lib/python3.6/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/app/venv/lib/python3.6/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "./app/main/auth.py", line 26, in decorated_view
    return func(*args, **kwargs)
  File "./app/main/views/services.py", line 125, in update_service_status
    service_name=service['serviceName'] or service['frameworkName'] + ' - ' + service['lotName']
KeyError: 'serviceName'
```