### PR TITLE
Supplier CSV download for admin framework manager

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -121,6 +121,61 @@ def download_users(framework_slug):
     )
 
 
+@main.route('/frameworks/<framework_slug>/suppliers/download', methods=['GET'])
+@role_required('admin-framework-manager', 'admin')
+def download_suppliers(framework_slug):
+    framework = data_api_client.get_framework(framework_slug).get("frameworks")
+
+    supplier_rows = data_api_client.export_suppliers(framework_slug).get('suppliers', [])
+
+    supplier_and_framework_headers = [
+        "supplier_id",
+        "supplier_name",
+        "supplier_organisation_size",
+        "duns_number",
+        "companies_house_number",
+        "registered_name",
+        "declaration_status",
+        "application_status",
+        "application_result",
+        "framework_agreement",
+        "variations_agreed",
+    ]
+    service_count_headers = [lot['slug'] for lot in framework['lots']]
+    contact_info_headers = [
+        'contact_name',
+        'contact_email',
+        'contact_phone_number',
+        'address_first_line',
+        'address_city',
+        'address_postcode',
+        'address_country',
+    ]
+
+    download_filename = "suppliers-on-{}.csv".format(framework_slug)
+
+    formatted_rows = [
+        supplier_and_framework_headers + [
+            "service-count-{}".format(h) for h in service_count_headers
+        ] + contact_info_headers
+    ]
+    for row in supplier_rows:
+        formatted_rows.append(
+            [row[heading] for heading in supplier_and_framework_headers] +
+            [row['published_services_count'][heading] for heading in service_count_headers] +
+            [row['contact_information'][heading] for heading in contact_info_headers]
+        )
+
+    return Response(
+        csv_generator.iter_csv(formatted_rows),
+        mimetype='text/csv',
+        headers={
+            "Content-Disposition": "attachment;filename={}".format(download_filename),
+            "Content-Type": "text/csv; header=present"
+        }
+    )
+
+
 @main.route('/users/download/buyers', methods=['GET'])
 @role_required('admin-framework-manager', 'admin')
 def download_buyers():

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -155,14 +155,20 @@ def download_suppliers(framework_slug):
     download_filename = "suppliers-on-{}.csv".format(framework_slug)
 
     formatted_rows = [
-        supplier_and_framework_headers + [
-            "service-count-{}".format(h) for h in service_count_headers
-        ] + contact_info_headers
+        supplier_and_framework_headers +
+        ["total_number_of_services"] +
+        ["service-count-{}".format(h) for h in service_count_headers] +
+        contact_info_headers
     ]
     for row in supplier_rows:
+        # Include an extra column with the total number of services across all lots
+        service_counts = [row['published_services_count'][heading] for heading in service_count_headers]
+        total_number_of_services = sum(service_counts)
+
         formatted_rows.append(
             [row[heading] for heading in supplier_and_framework_headers] +
-            [row['published_services_count'][heading] for heading in service_count_headers] +
+            [total_number_of_services] +
+            service_counts +
             [row['contact_information'][heading] for heading in contact_info_headers]
         )
 

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -18,28 +18,43 @@
 {% endblock %}
 
 {% block main_content %}
-  {%
-    with heading = "Download supplier lists for {}".format(framework['name'])
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {%
+        with heading = "Download supplier lists for {}".format(framework['name'])
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
 
-  {%
-    with
-    items = [
-      {
-          "title": "Suppliers who’ve applied or started an application",
-          "link": url_for('.download_users', framework_slug=framework['slug']),
-          "file_type": "CSV"
-      },
-      {
-          "title": "Suppliers on the framework",
-          "link": url_for('.download_users', framework_slug=framework['slug'], on_framework_only=True),
-          "file_type": "CSV"
-      },
-    ]
-  %}
-    {% include "toolkit/documents.html" %}
-  {% endwith %}
+      <div class="explanation-list">
+          <p class="lead">These lists contain details of all suppliers who:</p>
+          <ul class='list-bullet'>
+            <li>started an application</li>
+            <li>are on the framework</li>
+            <li>weren't accepted on the framework</li>
+            <li>have been excluded from the framework</li>
+          </ul>
+      </div>
+      <br />
+      {%
+        with
+        items = [
+          {
+              "title": "Official details for suppliers",
+              "link": url_for('.download_suppliers', framework_slug=framework['slug']),
+              "file_type": "CSV"
+          },
+          {
+              "title": "All email accounts for suppliers",
+              "link": url_for('.download_users', framework_slug=framework['slug']),
+              "file_type": "CSV"
+          },
+        ]
+      %}
+        {% include "toolkit/documents.html" %}
+      {% endwith %}
+
+    </div>
+  </div>
 
 {% endblock %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@36.12.0#egg=digitalmarketplace-utils==36.12.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.3.0#egg=digitalmarketplace-apiclient==16.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-utils.git@36.12.0#egg=digitalmarketplace-utils==36.12.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.3.0#egg=digitalmarketplace-apiclient==16.3.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -51,4 +51,4 @@ unicodecsv==0.14.1
 urllib3==1.22
 Werkzeug==0.14.1
 workdays==1.4
-WTForms==2.1
+WTForms==2.2

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -265,7 +265,7 @@ class TestUsersExport(LoggedInApplicationTest):
         ("admin-framework-manager", "?on_framework_only=False", 200),
         ("admin-manager", "", 403),
     ])
-    def test_supplier_csv_is_only_accessible_to_specific_user_roles(self, role,
+    def test_supplier_user_csv_is_only_accessible_to_specific_user_roles(self, role,
                                                                     url_params, expected_code):
         self.user_role = role
         users = [self._supplier_user]
@@ -360,6 +360,121 @@ class TestUsersExport(LoggedInApplicationTest):
         assert rows[0] == ["email address", "user_name", "supplier_id"]
         # Only users with application_result = "pass" should appear in the CSV
         assert rows[1] == ["test.user@sme2.com", "Test User 2", "2"]
+
+
+class TestSuppliersExport(LoggedInApplicationTest):
+    user_role = 'admin-framework-manager'
+
+    _valid_framework = {
+        'name': 'Digital Outcomes and Specialists 2',
+        'slug': 'digital-outcomes-and-specialists-2',
+        'status': 'live',
+        'lots': [
+            {"id": 1, "slug": "digital-outcomes"},
+            {"id": 2, "slug": "digital-specialists"},
+            {"id": 3, "slug": "user-research-studios"},
+            {"id": 4, "slug": "user-research-participants"}
+        ]
+    }
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.users.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
+    def test_supplier_csv_only_accessible_to_specific_roles(self):
+        pass
+
+    def test_download_supplier_csv_for_framework_users(self):
+        list_of_expected_supplier_results = [
+            {
+                'supplier_id': 1,
+                'application_result': 'no result',
+                'application_status': 'no_application',
+                'declaration_status': 'unstarted',
+                'framework_agreement': False,
+                'supplier_name': "Supplier 1",
+                'supplier_organisation_size': "small",
+                'duns_number': "100000001",
+                'registered_name': 'Registered Supplier Name 1',
+                'companies_house_number': 'ABC123',
+                "published_services_count": {
+                    "digital-outcomes": 0,
+                    "digital-specialists": 0,
+                    "user-research-studios": 0,
+                    "user-research-participants": 0,
+                },
+                "contact_information": {
+                    'contact_name': 'Contact for Supplier 1',
+                    'contact_email': '1@contact.com',
+                    'contact_phone_number': '12345',
+                    'address_first_line': '7 Gem Lane',
+                    'address_city': 'Cantelot',
+                    'address_postcode': 'CN1A 1AA',
+                    'address_country': 'country:GB',
+                },
+                'variations_agreed': '',
+            }
+        ]
+        self.data_api_client.export_suppliers.return_value = {"suppliers": list_of_expected_supplier_results}
+        self.data_api_client.find_frameworks.return_value = {"frameworks": [self._valid_framework]}
+
+        self.data_api_client.get_framework.return_value = {"frameworks": self._valid_framework}
+        response = self.client.get(
+            '/admin/frameworks/{}/suppliers/download'.format(
+                self._valid_framework['slug']
+            )
+        )
+        assert response.status_code == 200
+        assert response.mimetype == 'text/csv'
+        assert (response.headers['Content-Disposition'] ==
+                'attachment;filename=suppliers-on-digital-outcomes-and-specialists-2.csv')
+
+        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
+
+        assert len(rows) == len(list_of_expected_supplier_results) + 1
+        expected_top_level_headings = [
+            "supplier_id",
+            "supplier_name",
+            "supplier_organisation_size",
+            "duns_number",
+            "companies_house_number",
+            "registered_name",
+            "declaration_status",
+            "application_status",
+            "application_result",
+            "framework_agreement",
+            "variations_agreed",
+        ]
+        expected_service_count_headings = [
+            "service-count-digital-outcomes",
+            "service-count-digital-specialists",
+            "service-count-user-research-studios",
+            "service-count-user-research-participants",
+        ]
+        expected_contact_info_headings = [
+            'contact_name',
+            'contact_email',
+            'contact_phone_number',
+            'address_first_line',
+            'address_city',
+            'address_postcode',
+            'address_country',
+        ]
+
+        assert rows[0] == expected_top_level_headings + expected_service_count_headings + expected_contact_info_headings
+        # All suppliers returned from the API should appear in the CSV
+
+        for index, expected_supplier in enumerate(list_of_expected_supplier_results):
+            assert rows[index + 1] == (
+                [str(expected_supplier[key]) for key in expected_top_level_headings] +
+                ['0', '0', '0', '0'] +
+                [str(expected_supplier['contact_information'][key]) for key in expected_contact_info_headings]
+            )
 
 
 class TestBuyersExport(LoggedInApplicationTest):

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -265,8 +265,7 @@ class TestUsersExport(LoggedInApplicationTest):
         ("admin-framework-manager", "?on_framework_only=False", 200),
         ("admin-manager", "", 403),
     ])
-    def test_supplier_user_csvs_are_only_accessible_to_specific_user_roles(self, role,
-                                                                    url_params, expected_code):
+    def test_supplier_user_csvs_are_only_accessible_to_specific_user_roles(self, role, url_params, expected_code):
         self.user_role = role
         users = [self._supplier_user]
         self.data_api_client.export_users.return_value = {"users": copy.copy(users)}
@@ -434,6 +433,34 @@ class TestSuppliersExport(LoggedInApplicationTest):
                     'address_country': 'country:GB',
                 },
                 'variations_agreed': '',
+            },
+            {
+                'supplier_id': 2,
+                'application_result': 'pass',
+                'application_status': 'application',
+                'declaration_status': 'complete',
+                'framework_agreement': True,
+                'supplier_name': "Supplier 2",
+                'supplier_organisation_size': "micro",
+                'duns_number': "200000002",
+                'registered_name': 'Registered Supplier Name 2',
+                'companies_house_number': 'ABC456',
+                "published_services_count": {
+                    "digital-outcomes": 2,
+                    "digital-specialists": 2,
+                    "user-research-studios": 2,
+                    "user-research-participants": 2,
+                },
+                "contact_information": {
+                    'contact_name': 'Contact for Supplier 2',
+                    'contact_email': '2@contact.com',
+                    'contact_phone_number': '22345',
+                    'address_first_line': '27 Gem Lane',
+                    'address_city': 'Cantelot',
+                    'address_postcode': 'CN2A 2AA',
+                    'address_country': 'country:GB',
+                },
+                'variations_agreed': "1,2",
             }
         ]
         self.data_api_client.export_suppliers.return_value = {"suppliers": list_of_expected_supplier_results}
@@ -450,7 +477,7 @@ class TestSuppliersExport(LoggedInApplicationTest):
         assert (response.headers['Content-Disposition'] ==
                 'attachment;filename=suppliers-on-digital-outcomes-and-specialists-2.csv')
 
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
+        rows = response.get_data(as_text=True).splitlines()
 
         assert len(rows) == len(list_of_expected_supplier_results) + 1
         expected_headings = [
@@ -479,8 +506,8 @@ class TestSuppliersExport(LoggedInApplicationTest):
             'address_country',
         ]
 
-        assert rows[0] == expected_headings
-        assert rows[1] == [
+        assert rows[0] == ",".join(expected_headings)
+        assert rows[1] == ",".join([
             '1', 'Supplier 1', 'small', '100000001', 'ABC123', 'Registered Supplier Name 1',
             'unstarted', 'no_application', 'no result', 'False', '',
             '3',  # Total number of services
@@ -488,7 +515,17 @@ class TestSuppliersExport(LoggedInApplicationTest):
             'Contact for Supplier 1',
             '1@contact.com', '12345',
             '7 Gem Lane', 'Cantelot', 'CN1A 1AA', 'country:GB'
-        ]
+        ])
+        assert rows[2] == ",".join([
+            '2', 'Supplier 2', 'micro', '200000002', 'ABC456', 'Registered Supplier Name 2',
+            'complete', 'application', 'pass', 'True',
+            '"1,2"',  # Comma separated list of agreed variations
+            '8',
+            '2', '2', '2', '2',
+            'Contact for Supplier 2',
+            '2@contact.com', '22345',
+            '27 Gem Lane', 'Cantelot', 'CN2A 2AA', 'country:GB'
+        ])
 
 
 class TestBuyersExport(LoggedInApplicationTest):

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -419,9 +419,9 @@ class TestSuppliersExport(LoggedInApplicationTest):
                 'registered_name': 'Registered Supplier Name 1',
                 'companies_house_number': 'ABC123',
                 "published_services_count": {
-                    "digital-outcomes": 0,
+                    "digital-outcomes": 2,
                     "digital-specialists": 0,
-                    "user-research-studios": 0,
+                    "user-research-studios": 1,
                     "user-research-participants": 0,
                 },
                 "contact_information": {
@@ -453,7 +453,7 @@ class TestSuppliersExport(LoggedInApplicationTest):
         rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
 
         assert len(rows) == len(list_of_expected_supplier_results) + 1
-        expected_top_level_headings = [
+        expected_headings = [
             "supplier_id",
             "supplier_name",
             "supplier_organisation_size",
@@ -465,14 +465,11 @@ class TestSuppliersExport(LoggedInApplicationTest):
             "application_result",
             "framework_agreement",
             "variations_agreed",
-        ]
-        expected_service_count_headings = [
+            "total_number_of_services",
             "service-count-digital-outcomes",
             "service-count-digital-specialists",
             "service-count-user-research-studios",
             "service-count-user-research-participants",
-        ]
-        expected_contact_info_headings = [
             'contact_name',
             'contact_email',
             'contact_phone_number',
@@ -482,15 +479,16 @@ class TestSuppliersExport(LoggedInApplicationTest):
             'address_country',
         ]
 
-        assert rows[0] == expected_top_level_headings + expected_service_count_headings + expected_contact_info_headings
-        # All suppliers returned from the API should appear in the CSV
-
-        for index, expected_supplier in enumerate(list_of_expected_supplier_results):
-            assert rows[index + 1] == (
-                [str(expected_supplier[key]) for key in expected_top_level_headings] +
-                ['0', '0', '0', '0'] +
-                [str(expected_supplier['contact_information'][key]) for key in expected_contact_info_headings]
-            )
+        assert rows[0] == expected_headings
+        assert rows[1] == [
+            '1', 'Supplier 1', 'small', '100000001', 'ABC123', 'Registered Supplier Name 1',
+            'unstarted', 'no_application', 'no result', 'False', '',
+            '3',  # Total number of services
+            '2', '0', '1', '0',  # Services for each lot
+            'Contact for Supplier 1',
+            '1@contact.com', '12345',
+            '7 Gem Lane', 'Cantelot', 'CN1A 1AA', 'country:GB'
+        ]
 
 
 class TestBuyersExport(LoggedInApplicationTest):

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -265,7 +265,7 @@ class TestUsersExport(LoggedInApplicationTest):
         ("admin-framework-manager", "?on_framework_only=False", 200),
         ("admin-manager", "", 403),
     ])
-    def test_supplier_user_csv_is_only_accessible_to_specific_user_roles(self, role,
+    def test_supplier_user_csvs_are_only_accessible_to_specific_user_roles(self, role,
                                                                     url_params, expected_code):
         self.user_role = role
         users = [self._supplier_user]


### PR DESCRIPTION
Trello: https://trello.com/c/gVkJo8Zj/70-update-framework-manager-user-download-list-to-include-additional-fields

- Adds a new CSV download view for supplier info.
- Changes link URL and copy on `download_framework_users.html` template
![screenshot-localhost-2018 06 13-10-59-24](https://user-images.githubusercontent.com/3492540/41347839-cdde9bca-6f02-11e8-8710-74db207151f8.png)

This uses a new API client version (16.3.0 https://github.com/alphagov/digitalmarketplace-apiclient/pull/140) and a new API view (https://github.com/alphagov/digitalmarketplace-api/pull/797).