### PR TITLE
Remove admin role from Supplier CSV download

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -122,7 +122,7 @@ def download_users(framework_slug):
 
 
 @main.route('/frameworks/<framework_slug>/suppliers/download', methods=['GET'])
-@role_required('admin-framework-manager', 'admin')
+@role_required('admin-framework-manager')
 def download_suppliers(framework_slug):
     framework = data_api_client.get_framework(framework_slug).get("frameworks")
 

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -386,7 +386,7 @@ class TestSuppliersExport(LoggedInApplicationTest):
         super().teardown_method(method)
 
     @pytest.mark.parametrize("role, expected_code", [
-        ("admin", 200),
+        ("admin", 403),
         ("admin-ccs-category", 403),
         ("admin-ccs-sourcing", 403),
         ("admin-framework-manager", 200),


### PR DESCRIPTION
Trello: https://trello.com/c/gVkJo8Zj/70-update-framework-manager-user-download-list-to-include-additional-fields

Following QA. The `admin` user role still had permissions to access the Supplier CSV download URL - this was left over from the user CSV where `admin` users could view a filtered version for user research purposes. The new CSV doesn't have 'users', let alone a user research filter, so the `admin` user should have no use for it. 