### PR TITLE
Bump utils & docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:3.1.2
+FROM digitalmarketplace/base-frontend:3.2.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.12.0#egg=digitalmarketplace-utils==36.12.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.3.0#egg=digitalmarketplace-apiclient==16.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.12.0#egg=digitalmarketplace-utils==36.12.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.3.0#egg=digitalmarketplace-apiclient==16.3.0
 
 ## The following requirements were added by pip freeze:
@@ -26,7 +26,7 @@ docutils==0.14
 Flask-FeatureFlags==0.6
 Flask-Script==2.0.6
 future==0.16.0
-idna==2.6
+idna==2.7
 inflection==0.3.1
 itsdangerous==0.24
 Jinja2==2.10
@@ -51,4 +51,4 @@ unicodecsv==0.14.1
 urllib3==1.22
 Werkzeug==0.14.1
 workdays==1.4
-WTForms==2.2
+WTForms==2.2.1


### PR DESCRIPTION
Another double bump.

This should allow zipkin logging to work better in both the nginx and app logs.

This is skipping past the change suggested in `-utils` changelog for v37.0.0 (https://github.com/alphagov/digitalmarketplace-utils/blob/master/CHANGELOG.md#3700), for which I have instead created a tech debt ticket https://trello.com/c/SBnphyGp/491-refactor-admins-form-use-to-match-changes-in-utils-v3700