### PR TITLE
Allow CCS category admins to download supplier CSV

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -35,7 +35,7 @@ def find_user_by_email_address():
 
 
 @main.route('/frameworks/<framework_slug>/users', methods=['GET'])
-@role_required('admin-framework-manager')
+@role_required('admin-framework-manager', 'admin-ccs-category')
 def user_list_page_for_framework(framework_slug):
     bad_statuses = ['coming', 'expired']
     framework = data_api_client.get_framework(framework_slug).get("frameworks")

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -106,6 +106,8 @@
         <p>
           <a href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Upload communications</a>
         </p>
+        {% endif %}
+        {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
         <p>
           <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">Contact suppliers</a>
         </p>

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -285,7 +285,7 @@ class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", False),
-        ("admin-ccs-category", False),
+        ("admin-ccs-category", True),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", True),
         ("admin-manager", False),

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -197,7 +197,7 @@ class TestUserListPage(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 403),
-        ("admin-ccs-category", 403),
+        ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 403),
         ("admin-framework-manager", 200),
         ("admin-manager", 403),


### PR DESCRIPTION
Trello: https://trello.com/c/VMRlKAJU/158-add-user-list-download-feature-to-ccs-category-admin-role

- Adds the new role to the `@role_required` list for the download view and the user list page.
- Adds the link to the CCS Category user home page
