### PR TITLE
CCS Category user can download supplier user csv

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -72,7 +72,6 @@ def supplier_user_research_participants_by_framework():
 @role_required('admin-framework-manager', 'admin', 'admin-ccs-category')
 def download_users(framework_slug):
     user_research_opted_in = convert_to_boolean(request.args.get('user_research_opted_in'))
-    on_framework_only = convert_to_boolean(request.args.get('on_framework_only'))
 
     if (
         current_user.role == 'admin' and not user_research_opted_in or
@@ -82,12 +81,10 @@ def download_users(framework_slug):
         abort(403)
 
     supplier_rows = data_api_client.export_users(framework_slug).get('users', [])
-    on_framework_only_headers = [
+    supplier_headers = [
         "email address",
         "user_name",
         "supplier_id",
-    ]
-    additional_full_headers = [
         "declaration_status",
         "application_status",
         "application_result",
@@ -95,17 +92,11 @@ def download_users(framework_slug):
         "variations_agreed",
         "published_service_count"
     ]
-
-    if on_framework_only:
-        supplier_headers = on_framework_only_headers
-        supplier_rows = [row for row in supplier_rows if row['application_result'] == 'pass']
-        download_filename = "suppliers-on-{}.csv".format(framework_slug)
-    elif user_research_opted_in:
-        supplier_headers = on_framework_only_headers
+    if user_research_opted_in:
         supplier_rows = [row for row in supplier_rows if row['user_research_opted_in']]
         download_filename = "user-research-suppliers-on-{}.csv".format(framework_slug)
     else:
-        supplier_headers = on_framework_only_headers + additional_full_headers
+
         download_filename = "all-email-accounts-for-suppliers-{}.csv".format(framework_slug)
     formatted_rows = []
     for row in supplier_rows:

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -69,14 +69,15 @@ def supplier_user_research_participants_by_framework():
 
 
 @main.route('/frameworks/<framework_slug>/users/download', methods=['GET'])
-@role_required('admin-framework-manager', 'admin')
+@role_required('admin-framework-manager', 'admin', 'admin-ccs-category')
 def download_users(framework_slug):
     user_research_opted_in = convert_to_boolean(request.args.get('user_research_opted_in'))
     on_framework_only = convert_to_boolean(request.args.get('on_framework_only'))
 
     if (
         current_user.role == 'admin' and not user_research_opted_in or
-        current_user.role == 'admin-framework-manager' and user_research_opted_in
+        current_user.role == 'admin-framework-manager' and user_research_opted_in or
+        current_user.role == 'admin-ccs-category' and user_research_opted_in
     ):
         abort(403)
 

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -262,6 +262,8 @@ class TestUsersExport(LoggedInApplicationTest):
         ("admin-ccs-category", "", 200),
         ("admin-ccs-category", "?user_research_opted_in=True", 403),
         ("admin-ccs-sourcing", "", 403),
+        ("admin-framework-manager", "?user_research_opted_in=True", 403),
+        ("admin-framework-manager", "", 200),
         ("admin-manager", "", 403),
     ])
     def test_supplier_user_csvs_are_only_accessible_to_specific_user_roles(self, role, url_params, expected_code):

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -259,7 +259,8 @@ class TestUsersExport(LoggedInApplicationTest):
     @pytest.mark.parametrize("role, url_params, expected_code", [
         ("admin", "?user_research_opted_in=True", 200),
         ("admin", "?user_research_opted_in=False", 403),
-        ("admin-ccs-category", "", 403),
+        ("admin-ccs-category", "", 200),
+        ("admin-ccs-category", "?user_research_opted_in=True", 403),
         ("admin-ccs-sourcing", "", 403),
         ("admin-framework-manager", "?on_framework_only=True", 200),
         ("admin-framework-manager", "?on_framework_only=False", 200),


### PR DESCRIPTION
Fixes a bug where the CCS Category could view the page with the link, but not actually download the file.

Also removes the `on_framework_only` logic, which isn't used anywhere anymore.