### PR TITLE
Add supplier name alternative key

### DIFF
--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -26,7 +26,7 @@
   <div class="column-one-whole">
     {%
         with
-        heading = supplier_framework.declaration.nameOfOrganisation,
+        heading = supplier_framework.declaration.nameOfOrganisation or supplier_framework.declaration.supplierRegisteredName,
         smaller = True
     %}
     {% include "toolkit/page-heading.html" %}


### PR DESCRIPTION
 ## Summary
We changed the name of the key that stores the supplier's registered
name for G-Cloud 10 onwards, so we need to show this if the other key is
empty.