### PR TITLE
Pull in latest frameworks for new DOS roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jquery": "1.12.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v12.0.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v13.1.0",
     "hogan.js": "3.0.2",
     "c3": "0.4.11"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,9 +525,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#v12.0.0":
-  version "12.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#908c2bca2624c4d3a0f5085587ba90a953f7d08c"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#v13.1.0":
+  version "13.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0":
   version "28.15.0"


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/VkAyVrzT)

See [this PR on the frameworks repo.](https://github.com/alphagov/digitalmarketplace-frameworks/pull/531)

There are three new specialist roles for DOS3. The updated manifests
need pulling in.