### PR TITLE
digitalmarketplace-utils dependency: bump to 40.6.0 

### DIFF
--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -2,7 +2,8 @@ from distutils.util import strtobool
 
 from dmapiclient import HTTPError
 from dmutils.email.user_account_email import send_user_account_email
-from flask import render_template, request, redirect, url_for, flash
+from dmutils.flask import timed_render_template as render_template
+from flask import request, redirect, url_for, flash
 from flask_login import current_user
 
 from .. import main

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -2,8 +2,9 @@ from collections import OrderedDict
 
 from dateutil.parser import parse as parse_date
 from dmutils.documents import degenerate_document_path_and_return_doc_name
+from dmutils.flask import timed_render_template as render_template
 from dmutils.formats import datetimeformat
-from flask import render_template, redirect, url_for, abort, request
+from flask import redirect, url_for, abort, request
 
 from .. import main
 from ..auth import role_required

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -1,5 +1,6 @@
 from dmapiclient import HTTPError
-from flask import flash, redirect, render_template, request, url_for
+from dmutils.flask import timed_render_template as render_template
+from flask import flash, redirect, request, url_for
 from flask_login import current_user
 
 from .. import main

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -1,6 +1,7 @@
 from dmutils import s3  # this style of import so we only have to mock once
 from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
-from flask import render_template, redirect, url_for, current_app, request, flash
+from dmutils.flask import timed_render_template as render_template
+from flask import redirect, url_for, current_app, request, flash
 
 from .. import main
 from ..auth import role_required

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -1,4 +1,4 @@
-from flask import render_template
+from dmutils.flask import timed_render_template as render_template
 
 from .. import main
 from ..auth import role_required

--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -1,5 +1,6 @@
 from dmapiclient.audit import AuditTypes
-from flask import abort, flash, redirect, render_template, url_for
+from dmutils.flask import timed_render_template as render_template
+from flask import abort, flash, redirect, url_for
 from flask_login import current_user
 
 from .. import main

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -6,7 +6,8 @@ from dmapiclient.audit import AuditTypes
 from dmcontent.formats import format_service_price
 from dmutils import s3  # this style of import so we only have to mock once
 from dmutils.documents import upload_service_documents
-from flask import abort, current_app, flash, redirect, render_template, request, url_for
+from dmutils.flask import timed_render_template as render_template
+from flask import abort, current_app, flash, redirect, request, url_for
 from flask_login import current_user
 
 from .. import main

--- a/app/main/views/stats.py
+++ b/app/main/views/stats.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 
 from dmapiclient.audit import AuditTypes
+from dmutils.flask import timed_render_template as render_template
 from dmutils.formats import DATETIME_FORMAT
-from flask import render_template, request
+from flask import request
 
 from .. import public
 from ..helpers.sum_counts import format_snapshots

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -13,8 +13,9 @@ from dmutils.documents import (
     generate_timestamped_document_upload_path, degenerate_document_path_and_return_doc_name,
     generate_download_filename)
 from dmutils.email import send_user_account_email
+from dmutils.flask import timed_render_template as render_template
 from dmutils.formats import datetimeformat
-from flask import render_template, request, redirect, url_for, abort, current_app
+from flask import request, redirect, url_for, abort, current_app
 from flask_login import current_user, flash
 
 from .. import main

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 from dmutils import csv_generator
 from dmutils.config import convert_to_boolean
-from flask import abort, render_template, request, Response, url_for
+from dmutils.flask import timed_render_template as render_template
+from flask import abort, request, Response, url_for
 from flask_login import flash, current_user
 
 from .. import main

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,6 @@ Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0
+git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.1.0#egg=digitalmarketplace-apiclient==17.1.0
+git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -23,7 +24,6 @@ contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
 docutils==0.14
-Flask-FeatureFlags==0.6
 Flask-Script==2.0.6
 future==0.16.0
 idna==2.7


### PR DESCRIPTION
This brings a few logging niceties and also switches views to use `timed_render_template`.