### PR TITLE
Use frameworkFamily instead of frameworkFramework

### DIFF
--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -92,8 +92,8 @@
 
     {# links #}
     <ul class="list-no-bullet">
-      {% if service_data['frameworkFramework'] == 'g-cloud' %}
-        <li><a href="{{ '/{}/services/{}'.format(service_data['frameworkFramework'], service_id) }}">View service</a></li>
+      {% if service_data['frameworkFamily'] == 'g-cloud' %}
+        <li><a href="{{ '/{}/services/{}'.format(service_data['frameworkFamily'], service_id) }}">View service</a></li>
       {% endif %}
       {% if current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
         <li><a href="{{ url_for('.view_service', service_id=service_id, remove=True) }}">Remove service</a></li>

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -72,7 +72,7 @@
         ) %}
           {% call summary.row() %}
             {% if item.serviceName %}
-              {{ summary.service_link(item.serviceName, '/' + item.frameworkFramework + '/services/' + item.id|string) }}
+              {{ summary.service_link(item.serviceName, '/' + item.frameworkFamily + '/services/' + item.id|string) }}
             {% else %}
               {% call summary.field(first=True, wide=True) %}
                 {{ item.lotName }}

--- a/example_responses/brief_response.json
+++ b/example_responses/brief_response.json
@@ -24,6 +24,7 @@
     "createdAt": "2016-05-24T16:44:17.106766Z",
     "clarificationQuestionsAreClosed": true,
     "frameworkFramework": "digital-outcomes-and-specialists",
+    "frameworkFamily": "digital-outcomes-and-specialists",
     "clarificationQuestionsClosedAt": "2016-05-31T23:59:59.000000Z",
     "lotSlug": "digital-specialists",
     "clarificationQuestionsPublishedBy": "2016-06-06T23:59:59.000000Z",

--- a/example_responses/framework_response.json
+++ b/example_responses/framework_response.json
@@ -49,6 +49,7 @@
     },
     "slug":"g-cloud-8",
     "framework":"g-cloud",
+    "family": "g-cloud",
     "id":6
   }
 }

--- a/example_responses/services_response.json
+++ b/example_responses/services_response.json
@@ -73,6 +73,7 @@
       },
       "frameworkName": "G-Cloud 8",
       "frameworkFramework": "g-cloud",
+      "frameworkFamily": "g-cloud",
       "frameworkSlug": "g-cloud-8",
       "freeOption": false,
       "governanceFramework": {

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -422,6 +422,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'g-cloud-8',
             'frameworkFramework': 'g-cloud',
+            'frameworkFamily': 'g-cloud',
             'id': "1",
             'status': 'published'
         }}
@@ -443,6 +444,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'digital-outcomes-and-specialists-2',
             'frameworkFramework': 'digital-outcomes-and-specialists',
+            'frameworkFamily': 'digital-outcomes-and-specialists',
             'id': "1",
             'status': 'published'
         }}
@@ -463,6 +465,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'digital-outcomes-and-specialists-2',
             'frameworkFramework': 'digital-outcomes-and-specialists',
+            'frameworkFamily': 'digital-outcomes-and-specialists',
             'id': "1",
             'status': 'published'
         }}
@@ -486,6 +489,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'digital-outcomes-and-specialists-2',
             'frameworkFramework': 'digital-outcomes-and-specialists',
+            'frameworkFamily': 'digital-outcomes-and-specialists',
             'id': "1",
             'status': 'published'
         }}
@@ -501,6 +505,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'digital-outcomes-and-specialists-2',
             'frameworkFramework': 'digital-outcomes-and-specialists',
+            'frameworkFamily': 'digital-outcomes-and-specialists',
             'id': "1",
             'status': service_status
         }}
@@ -522,6 +527,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'digital-outcomes-and-specialists-2',
             'frameworkFramework': 'digital-outcomes-and-specialists',
+            'frameworkFamily': 'digital-outcomes-and-specialists',
             'id': "1",
             'status': 'disabled'
         }}
@@ -543,6 +549,7 @@ class TestServiceView(LoggedInApplicationTest):
             'supplierId': 1000,
             'frameworkSlug': 'digital-outcomes-and-specialists-2',
             'frameworkFramework': 'digital-outcomes-and-specialists',
+            'frameworkFamily': 'digital-outcomes-and-specialists',
             'id': "1",
             'status': 'published'
         }}


### PR DESCRIPTION
Trello: https://trello.com/c/R3DsCXFa/22-use-frameworkfamily-frameworkfamily-in-apps-apiclient-rather-than-frameworkframework-frameworkframework

Part of the ongoing work to deprecate `frameworkFramework` in favour of `frameworkFamily`.