### PR TITLE
Do not allow admins to edit users whose personal data is removed

### DIFF
--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -67,7 +67,7 @@
       {% endcall %}
 
       {% call summary.field() %}
-      {% if item.locked and current_user.has_role('admin') %}
+      {% if item.locked and current_user.has_role('admin') and not item.personalDataRemoved %}
       <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {%
@@ -87,7 +87,7 @@
 
       {% call summary.field() %}
       {% if item.active %}
-        {% if current_user.has_role('admin') %}
+        {% if current_user.has_role('admin') and not item.personalDataRemoved %}
           <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               {%
@@ -102,7 +102,7 @@
           Active
         {% endif %}
       {% else %}
-        {% if current_user.has_role('admin') %}
+        {% if current_user.has_role('admin') and not item.personalDataRemoved %}
           <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               {%

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -87,7 +87,7 @@
 
       {% call summary.field() %}
       {% if item.active %}
-        {% if current_user.has_role('admin') and not item.personalDataRemoved %}
+        {% if current_user.has_role('admin') %}
           <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               {%

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -108,7 +108,7 @@
 
       {% call summary.field() %}
           {% if item.active %}
-            {% if current_user.has_role('admin') and not item.personalDataRemoved %}
+            {% if current_user.has_role('admin') %}
               <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -87,7 +87,7 @@
       {% endcall %}
 
       {% call summary.field() %}
-      {% if item.locked and current_user.has_role('admin') %}
+      {% if item.locked and current_user.has_role('admin') and not item.personalDataRemoved %}
       <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
@@ -108,7 +108,7 @@
 
       {% call summary.field() %}
           {% if item.active %}
-            {% if current_user.has_role('admin') %}
+            {% if current_user.has_role('admin') and not item.personalDataRemoved %}
               <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
@@ -124,7 +124,7 @@
               Active
             {% endif %}
           {% else %}
-            {% if current_user.has_role('admin') %}
+            {% if current_user.has_role('admin') and not item.personalDataRemoved %}
               <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>

--- a/example_responses/user_response.json
+++ b/example_responses/user_response.json
@@ -15,6 +15,7 @@
       "name": "SME Corp UK Limited",
       "supplierId": 1000
     },
-    "updatedAt": "2015-07-23T09:33:53.507659Z"
+    "updatedAt": "2015-07-23T09:33:53.507659Z",
+    "personalDataRemoved": false
   }
 }

--- a/example_responses/users_response.json
+++ b/example_responses/users_response.json
@@ -16,7 +16,8 @@
         "name": "SME Corp UK Limited",
         "supplierId": 1000
       },
-      "updatedAt": "2015-07-23T09:33:53.507659Z"
+      "updatedAt": "2015-07-23T09:33:53.507659Z",
+      "personalDataRemoved": false
     }
   ]
 }

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -186,10 +186,9 @@ class TestUsersView(LoggedInApplicationTest):
         assert deactivate_button == 'Deactivate'
         assert return_link.attrib['value'] == '/admin/users?email_address=test.user%40sme.com'
 
-    @pytest.mark.parametrize('case', ({'active': False}, {'personalDataRemoved': True}))
-    def test_should_not_show_deactivate_button_if_user_deactivated_or_personal_data_removed(self, case):
+    def test_should_not_show_deactivate_button_if_user_deactivated(self):
         buyer = self.load_example_listing("user_response")
-        buyer['users'].update(case)
+        buyer['users'].update({'active': False})
         self.data_api_client.get_user.return_value = buyer
 
         response = self.client.get('/admin/users?email_address=test.user@sme.com')

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -160,6 +160,16 @@ class TestUsersView(LoggedInApplicationTest):
         assert unlock_button == 'Unlock'
         assert return_link.attrib['value'] == '/admin/users?email_address=test.user%40sme.com'
 
+    def test_should_not_show_unlock_button_if_user_personal_data_removed(self):
+        buyer = self.load_example_listing("user_response")
+        buyer['users'].update({'locked': True, 'personalDataRemoved': True})
+        self.data_api_client.get_user.return_value = buyer
+
+        response = self.client.get('/admin/users?email_address=test.user@sme.com')
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert not document.xpath('//input[@value="Unlock"][@type="submit"]')
+
     def test_should_show_deactivate_button(self):
         response = self.client.get('/admin/users?email_address=test.user@sme.com')
         assert response.status_code == 200
@@ -175,6 +185,27 @@ class TestUsersView(LoggedInApplicationTest):
         assert deactivate_link.attrib['action'] == '/admin/suppliers/users/999/deactivate'
         assert deactivate_button == 'Deactivate'
         assert return_link.attrib['value'] == '/admin/users?email_address=test.user%40sme.com'
+
+    @pytest.mark.parametrize('case', ({'active': False}, {'personalDataRemoved': True}))
+    def test_should_not_show_deactivate_button_if_user_deactivated_or_personal_data_removed(self, case):
+        buyer = self.load_example_listing("user_response")
+        buyer['users'].update(case)
+        self.data_api_client.get_user.return_value = buyer
+
+        response = self.client.get('/admin/users?email_address=test.user@sme.com')
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert not document.xpath('//input[@value="Deactivate"][@type="submit"]')
+
+    def test_should_show_activate_button_if_user_deactivated_and_not_personal_data_removed(self):
+        buyer = self.load_example_listing("user_response")
+        buyer['users'].update({'active': False, 'personalDataRemoved': False})
+        self.data_api_client.get_user.return_value = buyer
+
+        response = self.client.get('/admin/users?email_address=test.user@sme.com')
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert document.xpath('//input[@value="Activate"][@type="submit"]')
 
 
 class TestUserListPage(LoggedInApplicationTest):


### PR DESCRIPTION
https://trello.com/c/F3Bp7CVV/57-can-admin-reactivate-copy-change

This removes the 'Activate'/ 'Deactivate' and 'Unlock' buttons in user tables in the admin app. These are on the 'supplier users' and 'users' pages.

The pages now will display the attribute value ('Active', 'Inactive/ Disabled', 'Locked') intead of giving the admins a button to perform the respective action. This is in line with the view that admin users without the deactivate/ activate, unlock permissions get.

### Before 

<img width="1425" alt="screen shot 2018-07-23 at 14 28 42" src="https://user-images.githubusercontent.com/3469840/43079361-d2f70074-8e84-11e8-85ed-03969c46be51.png">

<img width="1424" alt="screen shot 2018-07-23 at 14 28 52" src="https://user-images.githubusercontent.com/3469840/43079359-d2df3a3e-8e84-11e8-8cfc-4bfaa8745935.png">


### After

<img width="1424" alt="screen shot 2018-07-23 at 14 29 08" src="https://user-images.githubusercontent.com/3469840/43079387-e3a703ec-8e84-11e8-87d0-082922f0ab2d.png">

<img width="1423" alt="screen shot 2018-07-23 at 14 29 16" src="https://user-images.githubusercontent.com/3469840/43079386-e3917004-8e84-11e8-9f92-3083e90250d1.png">


