### PR TITLE
digitalmarketplace-utils dependency: bump to 43.0.0, remove any featureflags references

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect
 
 import dmapiclient
-from dmutils import init_app, flask_featureflags, formats
+from dmutils import init_app, formats
 from dmutils.user import User
 from dmcontent.content_loader import ContentLoader
 
@@ -15,7 +15,6 @@ from config import configs
 
 csrf = CSRFProtect()
 data_api_client = dmapiclient.DataAPIClient()
-feature_flags = flask_featureflags.FeatureFlag()
 login_manager = LoginManager()
 
 content_loader = ContentLoader('app/content')
@@ -34,8 +33,7 @@ def create_app(config_name):
         application,
         configs[config_name],
         data_api_client=data_api_client,
-        feature_flags=feature_flags,
-        login_manager=login_manager
+        login_manager=login_manager,
     )
 
     for framework_data in data_api_client.find_frameworks().get('frameworks'):

--- a/config.py
+++ b/config.py
@@ -42,9 +42,6 @@ class Config(object):
     DM_PLAIN_TEXT_LOGS = False
     DM_APP_NAME = 'admin-frontend'
 
-    # Feature Flags
-    RAISE_ERROR_ON_MISSING_FEATURES = True
-
     SHARED_EMAIL_KEY = None
     INVITE_EMAIL_SALT = 'InviteEmailSalt'
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,12 +1,11 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@42.6.0#egg=digitalmarketplace-utils==42.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,15 +2,14 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@42.6.0#egg=digitalmarketplace-utils==42.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -19,6 +18,7 @@ botocore==1.8.50
 certifi==2018.8.13
 cffi==1.11.5
 chardet==3.0.4
+click==6.7
 contextlib2==0.4.0
 cryptography==2.3
 docopt==0.4.0


### PR DESCRIPTION
Trello https://trello.com/c/ZH9trgjH/419-snyk-alert-for-flask-010x-vulnerability

https://github.com/alphagov/digitalmarketplace-utils/pull/447

Again another app without much out of the ordinary.