### PR TITLE
Download supplier and user CSVs from S3

### DIFF
--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -27,7 +27,7 @@
       {% endwith %}
 
       <div class="explanation-list">
-          <p class="lead">These lists contain details of all suppliers who:</p>
+          <p class="lede">These lists contain details of all suppliers who:</p>
           <ul class='list-bullet'>
             <li>started an application</li>
             <li>are on the framework</li>
@@ -41,19 +41,19 @@
         items = [
           {
               "title": "Official details for suppliers",
-              "link": url_for('.download_suppliers', framework_slug=framework['slug']),
+              "link": supplier_csv_url,
               "file_type": "CSV"
           },
           {
-              "title": "All email accounts for suppliers",
-              "link": url_for('.download_users', framework_slug=framework['slug']),
+              "title": "Supplier names and emails",
+              "link": user_csv_url,
               "file_type": "CSV"
           },
         ]
       %}
         {% include "toolkit/documents.html" %}
       {% endwith %}
-
+        <p class="lede">Lists are generated daily. </p>
     </div>
   </div>
 

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -24,7 +24,7 @@
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
     <p class="lede">
-    Check you've got the most recent version of the list before you contact users.
+    Lists are generated daily. Check you've got the most recent version of the list before you contact users.
 </p><br>
 
   {%

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ class Config(object):
 
     DM_AGREEMENTS_BUCKET = None
     DM_COMMUNICATIONS_BUCKET = None
+    DM_REPORTS_BUCKET = None
     DM_ASSETS_URL = None
 
     STATIC_URL_PATH = '/admin/static'
@@ -83,6 +84,7 @@ class Development(Config):
     DM_AGREEMENTS_BUCKET = 'digitalmarketplace-dev-uploads'
     DM_COMMUNICATIONS_BUCKET = 'digitalmarketplace-dev-uploads'
     DM_S3_DOCUMENT_BUCKET = "digitalmarketplace-dev-uploads"
+    DM_REPORTS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_ASSETS_URL = "https://{}.s3-eu-west-1.amazonaws.com".format(DM_S3_DOCUMENT_BUCKET)
 
     DM_DATA_API_URL = "http://localhost:5000"

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
-
-from freezegun import freeze_time
 import mock
 import pytest
 from lxml import html
@@ -207,6 +204,7 @@ class TestUsersView(LoggedInApplicationTest):
         assert document.xpath('//input[@value="Activate"][@type="submit"]')
 
 
+@mock.patch('app.main.views.users.s3')
 class TestUserListPage(LoggedInApplicationTest):
     user_role = 'admin-framework-manager'
 
@@ -232,14 +230,17 @@ class TestUserListPage(LoggedInApplicationTest):
         ("admin-framework-manager", 200),
         ("admin-manager", 403),
     ])
-    def test_get_user_lists_is_only_accessible_to_specific_user_roles(self, role, expected_code):
+    def test_get_user_lists_is_only_accessible_to_specific_user_roles(self, s3, role, expected_code):
         self.user_role = role
+
         response = self.client.get("/admin/frameworks/g-cloud-9/users")
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
-    def test_get_user_lists_shows_framework_name_in_heading(self):
+    def test_get_user_lists_shows_framework_name_in_heading(self, s3):
         self.data_api_client.get_framework.return_value = {"frameworks": self._framework}
+        self.app.config['DM_ASSETS_URL'] = 'http://example.com'
+
         response = self.client.get("/admin/frameworks/g-cloud-9/users")
         document = html.fromstring(response.get_data(as_text=True))
 
@@ -247,476 +248,36 @@ class TestUserListPage(LoggedInApplicationTest):
             '//h1//text()')[0].strip()
         assert page_heading == "Download supplier lists for G-Cloud 9"
 
+    @mock.patch('app.main.views.users.get_signed_url')
+    def test_download_supplier_user_account_list_report_redirects_to_s3_url(self, get_signed_url, s3):
+        get_signed_url.return_value = 'http://path/to/csv?querystring'
+        self.app.config['DM_ASSETS_URL'] = 'http://example.com'
 
-class TestUsersExport(LoggedInApplicationTest):
-    user_role = 'admin-framework-manager'
-    _bad_statuses = ['coming', 'expired']
+        response = self.client.get("/admin/frameworks/g-cloud-9/users/accounts/download")
+        assert response.status_code == 302
 
-    _valid_framework = {
-        'name': 'G-Cloud 7',
-        'slug': 'g-cloud-7',
-        'status': 'live'
-    }
-
-    _invalid_framework = {
-        'name': 'G-Cloud 8',
-        'slug': 'g-cloud-8',
-        'status': 'coming'
-    }
-
-    _supplier_user = {
-        "application_result": "fail",
-        "application_status": "no_application",
-        "declaration_status": "unstarted",
-        "framework_agreement": False,
-        "supplier_id": 1,
-        "email address": "test.user@sme.com",
-        "user_name": "Test User",
-        "variations_agreed": "var1",
-        "published_service_count": "0",
-        "user_research_opted_in": True
-    }
-
-    def setup_method(self, method):
-        super().setup_method(method)
-        self.data_api_client_patch = mock.patch('app.main.views.users.data_api_client', autospec=True)
-        self.data_api_client = self.data_api_client_patch.start()
-
-    def teardown_method(self, method):
-        self.data_api_client_patch.stop()
-        super().teardown_method(method)
-
-    @pytest.mark.parametrize("role, url_params, expected_code", [
-        ("admin", "?user_research_opted_in=True", 200),
-        ("admin", "?user_research_opted_in=False", 403),
-        ("admin-ccs-category", "", 200),
-        ("admin-ccs-category", "?user_research_opted_in=True", 403),
-        ("admin-ccs-sourcing", "", 403),
-        ("admin-framework-manager", "?user_research_opted_in=True", 403),
-        ("admin-framework-manager", "", 200),
-        ("admin-manager", "", 403),
-    ])
-    def test_supplier_user_csvs_are_only_accessible_to_specific_user_roles(self, role, url_params, expected_code):
-        self.user_role = role
-        users = [self._supplier_user]
-        self.data_api_client.export_users.return_value = {"users": copy.copy(users)}
-        self.data_api_client.find_frameworks.return_value = {"frameworks": [self._valid_framework]}
-        self.data_api_client.get_framework.return_value = {"frameworks": self._valid_framework}
-
-        response = self.client.get(
-            '/admin/frameworks/{}/users/download{}'.format(
-                self._valid_framework['slug'],
-                url_params
+        assert get_signed_url.call_args_list == [
+            mock.call(
+                s3.S3.return_value, 'g-cloud-9/all-email-accounts-for-suppliers-g-cloud-9.csv', 'http://example.com'
             ),
-            data={'framework_slug': self._valid_framework['slug']}
-        )
+        ]
 
-        assert response.status_code == expected_code
+    @mock.patch('app.main.views.users.get_signed_url')
+    def test_download_supplier_official_details_list_report_redirects_to_s3_url(self, get_signed_url, s3):
+        get_signed_url.return_value = 'http://path/to/csv?querystring'
+        self.app.config['DM_ASSETS_URL'] = 'http://example.com'
 
-    def test_download_csv_for_all_framework_users(self):
-        users = [self._supplier_user]
+        response = self.client.get("/admin/frameworks/g-cloud-9/users/official/download")
+        assert response.status_code == 302
 
-        self.data_api_client.export_users.return_value = {"users": copy.copy(users)}
-        self.data_api_client.find_frameworks.return_value = {"frameworks": [self._valid_framework]}
-
-        self.data_api_client.get_framework.return_value = {"frameworks": self._valid_framework}
-        response = self.client.get(
-            '/admin/frameworks/{}/users/download'.format(
-                self._valid_framework['slug']
+        assert get_signed_url.call_args_list == [
+            mock.call(
+                s3.S3.return_value, 'g-cloud-9/official-details-for-suppliers-g-cloud-9.csv', 'http://example.com'
             ),
-
-            data={'framework_slug': self._valid_framework['slug']}
-        )
-        assert response.status_code == 200
-        assert response.mimetype == 'text/csv'
-        assert (response.headers['Content-Disposition'] ==
-                'attachment;filename=all-email-accounts-for-suppliers-g-cloud-7.csv')
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-
-        assert len(rows) == len(users) + 1
-        expected_headings = [
-            'email address',
-            'user_name',
-            'supplier_id',
-            'declaration_status',
-            'application_status',
-            'application_result',
-            'framework_agreement',
-            'variations_agreed',
-            'published_service_count',
-        ]
-
-        assert rows[0] == expected_headings
-        # All users returned from the API should appear in the CSV
-        for index, user in enumerate(users):
-            assert sorted(
-                [str(val) for key, val in user.items() if key in expected_headings]
-            ) == sorted(rows[index + 1])
-
-
-class TestSuppliersExport(LoggedInApplicationTest):
-    user_role = 'admin-framework-manager'
-
-    _valid_framework = {
-        'name': 'Digital Outcomes and Specialists 2',
-        'slug': 'digital-outcomes-and-specialists-2',
-        'status': 'live',
-        'lots': [
-            {"id": 1, "slug": "digital-outcomes"},
-            {"id": 2, "slug": "digital-specialists"},
-            {"id": 3, "slug": "user-research-studios"},
-            {"id": 4, "slug": "user-research-participants"}
-        ]
-    }
-
-    def setup_method(self, method):
-        super().setup_method(method)
-        self.data_api_client_patch = mock.patch('app.main.views.users.data_api_client', autospec=True)
-        self.data_api_client = self.data_api_client_patch.start()
-
-    def teardown_method(self, method):
-        self.data_api_client_patch.stop()
-        super().teardown_method(method)
-
-    @pytest.mark.parametrize("role, expected_code", [
-        ("admin", 403),
-        ("admin-ccs-category", 200),
-        ("admin-ccs-sourcing", 403),
-        ("admin-framework-manager", 200),
-        ("admin-manager", 403),
-    ])
-    def test_supplier_csv_is_only_accessible_to_specific_user_roles(self, role, expected_code):
-        self.user_role = role
-        self.data_api_client.export_suppliers.return_value = {"suppliers": []}
-        self.data_api_client.find_frameworks.return_value = {"frameworks": [self._valid_framework]}
-        self.data_api_client.get_framework.return_value = {"frameworks": self._valid_framework}
-
-        response = self.client.get(
-            '/admin/frameworks/{}/suppliers/download'.format(self._valid_framework['slug'])
-        )
-
-        assert response.status_code == expected_code
-
-    def test_download_supplier_csv_for_framework_users(self):
-        list_of_expected_supplier_results = [
-            {
-                'supplier_id': 1,
-                'application_result': 'no result',
-                'application_status': 'no_application',
-                'declaration_status': 'unstarted',
-                'framework_agreement': False,
-                'supplier_name': "Supplier 1",
-                'supplier_organisation_size': "small",
-                'duns_number': "100000001",
-                'registered_name': 'Registered Supplier Name 1',
-                'companies_house_number': 'ABC123',
-                "published_services_count": {
-                    "digital-outcomes": 2,
-                    "digital-specialists": 0,
-                    "user-research-studios": 1,
-                    "user-research-participants": 0,
-                },
-                "contact_information": {
-                    'contact_name': 'Contact for Supplier 1',
-                    'contact_email': '1@contact.com',
-                    'contact_phone_number': '12345',
-                    'address_first_line': '7 Gem Lane',
-                    'address_city': 'Cantelot',
-                    'address_postcode': 'CN1A 1AA',
-                    'address_country': 'country:GB',
-                },
-                'variations_agreed': '',
-            },
-            {
-                'supplier_id': 2,
-                'application_result': 'pass',
-                'application_status': 'application',
-                'declaration_status': 'complete',
-                'framework_agreement': True,
-                'supplier_name': "Supplier 2",
-                'supplier_organisation_size': "micro",
-                'duns_number': "200000002",
-                'registered_name': 'Registered Supplier Name 2',
-                'companies_house_number': 'ABC456',
-                "published_services_count": {
-                    "digital-outcomes": 2,
-                    "digital-specialists": 2,
-                    "user-research-studios": 2,
-                    "user-research-participants": 2,
-                },
-                "contact_information": {
-                    'contact_name': 'Contact for Supplier 2',
-                    'contact_email': '2@contact.com',
-                    'contact_phone_number': '22345',
-                    'address_first_line': '27 Gem Lane',
-                    'address_city': 'Cantelot',
-                    'address_postcode': 'CN2A 2AA',
-                    'address_country': 'country:GB',
-                },
-                'variations_agreed': "1,2",
-            }
-        ]
-        self.data_api_client.export_suppliers.return_value = {"suppliers": list_of_expected_supplier_results}
-        self.data_api_client.find_frameworks.return_value = {"frameworks": [self._valid_framework]}
-
-        self.data_api_client.get_framework.return_value = {"frameworks": self._valid_framework}
-        response = self.client.get(
-            '/admin/frameworks/{}/suppliers/download'.format(
-                self._valid_framework['slug']
-            )
-        )
-        assert response.status_code == 200
-        assert response.mimetype == 'text/csv'
-        assert (response.headers['Content-Disposition'] ==
-                'attachment;filename=official-details-for-suppliers-digital-outcomes-and-specialists-2.csv')
-
-        rows = response.get_data(as_text=True).splitlines()
-
-        assert len(rows) == len(list_of_expected_supplier_results) + 1
-        expected_headings = [
-            "supplier_id",
-            "supplier_name",
-            "supplier_organisation_size",
-            "duns_number",
-            "companies_house_number",
-            "registered_name",
-            "declaration_status",
-            "application_status",
-            "application_result",
-            "framework_agreement",
-            "variations_agreed",
-            "total_number_of_services",
-            "service-count-digital-outcomes",
-            "service-count-digital-specialists",
-            "service-count-user-research-studios",
-            "service-count-user-research-participants",
-            'contact_name',
-            'contact_email',
-            'contact_phone_number',
-            'address_first_line',
-            'address_city',
-            'address_postcode',
-            'address_country',
-        ]
-
-        assert rows[0] == ",".join(expected_headings)
-        assert rows[1] == ",".join([
-            '1', 'Supplier 1', 'small', '100000001', 'ABC123', 'Registered Supplier Name 1',
-            'unstarted', 'no_application', 'no result', 'False', '',
-            '3',  # Total number of services
-            '2', '0', '1', '0',  # Services for each lot
-            'Contact for Supplier 1',
-            '1@contact.com', '12345',
-            '7 Gem Lane', 'Cantelot', 'CN1A 1AA', 'country:GB'
-        ])
-        assert rows[2] == ",".join([
-            '2', 'Supplier 2', 'micro', '200000002', 'ABC456', 'Registered Supplier Name 2',
-            'complete', 'application', 'pass', 'True',
-            '"1,2"',  # Comma separated list of agreed variations
-            '8',
-            '2', '2', '2', '2',
-            'Contact for Supplier 2',
-            '2@contact.com', '22345',
-            '27 Gem Lane', 'Cantelot', 'CN2A 2AA', 'country:GB'
-        ])
-
-
-class TestBuyersExport(LoggedInApplicationTest):
-    user_role = "admin-framework-manager"
-
-    def setup_method(self, method):
-        super().setup_method(method)
-        self.data_api_client_patch = mock.patch('app.main.views.users.data_api_client', autospec=True)
-        self.data_api_client = self.data_api_client_patch.start()
-
-    def teardown_method(self, method):
-        self.data_api_client_patch.stop()
-        super().teardown_method(method)
-
-    @pytest.mark.parametrize('user_role', ('admin', 'admin-framework-manager'))
-    def test_csv_is_sorted_by_name(self, user_role):
-        self.user_role = user_role
-        self.data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Zebedee",
-                "emailAddress": "zebedee@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-                "userResearchOptedIn": True
-            },
-            {
-                'id': 2,
-                "name": "Dougal",
-                "emailAddress": "dougal@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-05T12:00:00.000000Z",
-                "userResearchOptedIn": True
-            },
-            {
-                'id': 3,
-                "name": "Brian",
-                "emailAddress": "brian@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-06T12:00:00.000000Z",
-                "userResearchOptedIn": True
-            },
-            {
-                'id': 4,
-                "name": "Florence",
-                "emailAddress": "florence@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-07T12:00:00.000000Z",
-                "userResearchOptedIn": True
-            },
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-
-        assert [row[1] for row in rows[1:5]] == ['Brian', 'Dougal', 'Florence', 'Zebedee']
-
-    @pytest.mark.parametrize('user_role', ('admin', 'admin-framework-manager'))
-    def test_response_is_a_csv(self, user_role):
-        self.user_role = user_role
-        self.data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-                "userResearchOptedIn": True
-            },
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-
-        assert response.mimetype == 'text/csv'
-
-    @pytest.mark.parametrize('user_role', ('admin', 'admin-framework-manager'))
-    def test_filename_includes_a_timestamp(self, user_role):
-        self.user_role = user_role
-        with freeze_time("2016-08-05 16:00:00"):
-            self.data_api_client.find_users_iter.return_value = [
-                {
-                    'id': 1,
-                    "name": "Chris",
-                    "emailAddress": "chris@gov.uk",
-                    "phoneNumber": "01234567891",
-                    "createdAt": "2016-08-04T12:00:00.000000Z",
-                },
-            ]
-
-            response = self.client.get('/admin/users/download/buyers')
-            assert '2016-08-05-at-16-00-00' in response.headers['Content-Disposition']
-
-    @pytest.mark.parametrize("role, expected_code", [
-        ("admin", 200),
-        ("admin-ccs-category", 403),
-        ("admin-ccs-sourcing", 403),
-        ("admin-framework-manager", 200),
-        ("admin-manager", 403),
-    ])
-    def test_buyer_csv_is_only_accessible_to_specific_user_roles(self, role, expected_code):
-        self.user_role = role
-        self.data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-            }
-        ]
-
-        response = self.client.get('/admin/users/download/buyers')
-        actual_code = response.status_code
-        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
-
-    def test_response_data_has_correct_buyer_info_for_framework_manager_role(self):
-        self.user_role = "admin-framework-manager"
-        self.data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-            },
-            {
-                'id': 2,
-                "name": "Topher",
-                "emailAddress": "topher@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-05T12:00:00.000000Z",
-            },
-        ]
-        with freeze_time("2016-08-05 16:00:00"):
-            response = self.client.get('/admin/users/download/buyers')
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-
-        assert response.headers['Content-Disposition'] == 'attachment;filename=all-buyers-on-2016-08-05-at-16-00-00.csv'
-        assert len(rows) == 3
-        assert rows == [
-            ['email address', 'name'],
-            ['chris@gov.uk', 'Chris'],
-            ['topher@gov.uk', 'Topher'],
-        ]
-
-    def test_response_data_has_correct_buyer_info_for_admin_role(self):
-        self.user_role = "admin"
-
-        self.data_api_client.find_users_iter.return_value = [
-            {
-                'id': 1,
-                "name": "Chris",
-                "emailAddress": "chris@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-04T12:00:00.000000Z",
-                "userResearchOptedIn": True
-            },
-            {
-                'id': 2,
-                "name": "Topher",
-                "emailAddress": "topher@gov.uk",
-                "phoneNumber": "01234567891",
-                "createdAt": "2016-08-05T12:00:00.000000Z",
-                "userResearchOptedIn": False
-            },
-            {
-                'id': 3,
-                "name": "Winifred",
-                "emailAddress": "winifred@gov.uk",
-                "phoneNumber": "34567890987",
-                "createdAt": "2016-08-02T12:00:00.000000Z",
-                "userResearchOptedIn": True
-            },
-        ]
-        with freeze_time("2016-08-05 16:00:00"):
-            response = self.client.get('/admin/users/download/buyers')
-        assert response.status_code == 200
-
-        rows = [line.split(",") for line in response.get_data(as_text=True).splitlines()]
-
-        assert (
-            response.headers['Content-Disposition'] ==
-            'attachment;filename=user-research-buyers-on-2016-08-05-at-16-00-00.csv'
-        )
-        assert len(rows) == 3
-        assert rows == [
-            ['email address', 'name'],
-            ['chris@gov.uk', 'Chris'],
-            ['winifred@gov.uk', 'Winifred'],
         ]
 
 
+@mock.patch('app.main.views.users.s3')
 class TestUserResearchParticipantsExport(LoggedInApplicationTest):
     user_role = 'admin'
 
@@ -751,7 +312,7 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
             ('admin-framework-manager', False)
         )
     )
-    def test_correct_role_can_view_download_buyer_user_research_participants_link(self, role, exists):
+    def test_correct_role_can_view_download_buyer_user_research_participants_link(self, s3, role, exists):
         self.user_role = role
 
         xpath = "//a[@href='{href}'][normalize-space(text()) = '{selector_text}']".format(
@@ -775,7 +336,7 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
             ('admin-framework-manager', False)
         )
     )
-    def test_correct_role_can_view_supplier_user_research_participants_link(self, role, exists):
+    def test_correct_role_can_view_supplier_user_research_participants_link(self, s3, role, exists):
         self.user_role = role
 
         xpath = "//a[@href='{href}'][normalize-space(text()) = '{selector_text}']".format(
@@ -799,37 +360,38 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
             ('admin-framework-manager', 403)
         )
     )
-    def test_correct_role_can_view_supplier_user_research_participants_page(self, role, status_code):
+    def test_correct_role_can_view_supplier_user_research_participants_page(self, s3, role, status_code):
         self.user_role = role
 
         response = self.client.get('/admin/users/download/suppliers')
         assert response.status_code == status_code
 
-    def test_supplier_csvs_shown_for_valid_frameworks(self):
+    def test_supplier_csvs_shown_for_valid_frameworks(self, s3):
         self.data_api_client.find_frameworks.return_value = {
             'frameworks': [self._valid_framework, self._invalid_framework]
         }
+        s3.S3.return_value.get_signed_url.return_value = 'http://asseturl/path/to/csv?querystring'
 
         response = self.client.get('/admin/users/download/suppliers')
         assert response.status_code == 200
 
         text = response.get_data(as_text=True)
         document = html.fromstring(text)
-        href_xpath = "//a[@href='/admin/frameworks/{}/users/download?user_research_opted_in=True']"
+        href_xpath = "//a[@class='document-link-with-icon']"
 
-        assert document.xpath(href_xpath.format(self._valid_framework['slug']))
+        assert len(document.xpath(href_xpath)) == 1  # Invalid framework not shown
         assert 'User research participants on {}'.format(self._valid_framework['name']) in text
 
-        assert not document.xpath(href_xpath.format(self._invalid_framework['slug']))
-        assert not 'User research participants on {}'.format(self._invalid_framework['name']) in text
-
-    def test_supplier_csvs_shown_in_alphabetical_name_order(self):
+    def test_supplier_csvs_shown_in_alphabetical_name_order(self, s3):
         framework_1 = self._valid_framework.copy()
         framework_2 = self._valid_framework.copy()
         framework_3 = self._valid_framework.copy()
         framework_1['name'] = 'aframework_1'
+        framework_1['slug'] = 'a-fw-1'
         framework_2['name'] = 'bframework_1'
+        framework_2['slug'] = 'b-fw-1'
         framework_3['name'] = 'bframework_2'
+        framework_3['slug'] = 'b-fw-2'
 
         self.data_api_client.find_frameworks.return_value = {'frameworks': [framework_3, framework_1, framework_2]}
 
@@ -842,3 +404,15 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
         framework_2_link_text = 'User research participants on ' + framework_2['name']
         framework_3_link_text = 'User research participants on ' + framework_3['name']
         assert text.find(framework_1_link_text) < text.find(framework_2_link_text) < text.find(framework_3_link_text)
+
+    @mock.patch('app.main.views.users.get_signed_url')
+    def test_supplier_download_redirects_to_s3(self, get_signed_url, s3):
+        get_signed_url.return_value = 'http://asseturl/path/to/csv?querystring'
+        self.app.config['DM_ASSETS_URL'] = 'http://example.com'
+
+        response = self.client.get('/admin/frameworks/g-cloud-9/user-research/download')
+        assert response.status_code == 302
+
+        assert get_signed_url.call_args_list == [
+            mock.call(s3.S3.return_value, 'g-cloud-9/user-research-suppliers-on-g-cloud-9.csv', 'http://example.com'),
+        ]


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

- Removes the old (painfully slow) views that generate CSVs on demand.
- Adds links to signed S3 URLs for the three reports (in the same style as for framework agreement downloads)
- Updated copy on the download pages to let admin users know that the reports are generated daily, not on demand. Checked this with @constancecerf who suggested rewording one of the download links.

![admin-user-lists](https://user-images.githubusercontent.com/3492540/45957926-19385f00-c00e-11e8-9e9e-181aca6a64b5.png)

