### PR TITLE
Include reports folder in S3 download path

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -64,9 +64,9 @@ def download_supplier_user_list_report(framework_slug, report_type):
     reports_bucket = s3.S3(current_app.config['DM_REPORTS_BUCKET'])
 
     if report_type == 'official':
-        path = f"{framework_slug}/official-details-for-suppliers-{framework_slug}.csv"
+        path = f"{framework_slug}/reports/official-details-for-suppliers-{framework_slug}.csv"
     elif report_type == 'accounts':
-        path = f"{framework_slug}/all-email-accounts-for-suppliers-{framework_slug}.csv"
+        path = f"{framework_slug}/reports/all-email-accounts-for-suppliers-{framework_slug}.csv"
     else:
         abort(404)
 
@@ -103,7 +103,7 @@ def supplier_user_research_participants_by_framework():
 def download_supplier_user_research_report(framework_slug):
 
     reports_bucket = s3.S3(current_app.config['DM_REPORTS_BUCKET'])
-    path = "{framework_slug}/user-research-suppliers-on-{framework_slug}.csv"
+    path = "{framework_slug}/reports/user-research-suppliers-on-{framework_slug}.csv"
     url = get_signed_url(
         reports_bucket, path.format(framework_slug=framework_slug), current_app.config['DM_ASSETS_URL']
     )

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -258,7 +258,9 @@ class TestUserListPage(LoggedInApplicationTest):
 
         assert get_signed_url.call_args_list == [
             mock.call(
-                s3.S3.return_value, 'g-cloud-9/all-email-accounts-for-suppliers-g-cloud-9.csv', 'http://example.com'
+                s3.S3.return_value,
+                'g-cloud-9/reports/all-email-accounts-for-suppliers-g-cloud-9.csv',
+                'http://example.com'
             ),
         ]
 
@@ -272,7 +274,9 @@ class TestUserListPage(LoggedInApplicationTest):
 
         assert get_signed_url.call_args_list == [
             mock.call(
-                s3.S3.return_value, 'g-cloud-9/official-details-for-suppliers-g-cloud-9.csv', 'http://example.com'
+                s3.S3.return_value,
+                'g-cloud-9/reports/official-details-for-suppliers-g-cloud-9.csv',
+                'http://example.com'
             ),
         ]
 
@@ -414,5 +418,9 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
         assert response.status_code == 302
 
         assert get_signed_url.call_args_list == [
-            mock.call(s3.S3.return_value, 'g-cloud-9/user-research-suppliers-on-g-cloud-9.csv', 'http://example.com'),
+            mock.call(
+                s3.S3.return_value,
+                'g-cloud-9/reports/user-research-suppliers-on-g-cloud-9.csv',
+                'http://example.com'
+            ),
         ]


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

Includes the `.../reports/...` folder in the S3 download path (see the equivalent upload here: https://github.com/alphagov/digitalmarketplace-scripts/pull/282) 