### PR TITLE
Temporarily re-enable dos2

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -61,7 +61,7 @@ def view_service(service_id):
         return redirect(url_for('.find_suppliers_and_services'))
 
     # we don't actually need the framework here; using this to 404 if framework for the service is not live
-    get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live'])
+    get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
     removed_by = removed_at = None
     if service_data['status'] != 'published':
@@ -96,7 +96,7 @@ def update_service_status(service_id):
 
     # Only services on live frameworks should have their status changed.
     service = data_api_client.get_service(service_id)['services']
-    get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live'])
+    get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
     frontend_status = request.form['service_status']
 
@@ -141,7 +141,7 @@ def edit_service(service_id, section_id, question_slug=None):
     service_data = data_api_client.get_service(service_id)['services']
 
     # we don't actually need the framework here; using this to 404 if framework for the service is not live
-    get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live'])
+    get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
     content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
 
@@ -172,7 +172,7 @@ def update_service(service_id, section_id, question_slug=None):
     service = service['services']
 
     # we don't actually need the framework here; using this to 404 if framework for the service is not live
-    get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live'])
+    get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
     content = content_loader.get_manifest(service['frameworkSlug'], 'edit_service_as_admin').filter(service)
     section = content.get_section(section_id)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -30,6 +30,7 @@ SERVICE_PUBLISHED_MESSAGE = "You published ‘{service_name}’."
 @role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-manager')
 def index():
     frameworks = data_api_client.find_frameworks()['frameworks']
+    # TODO replace this temporary fix for DOS2 when a better solution has been created.
     frameworks = [
         fw for fw in frameworks if fw['status'] not in ('coming', 'expired')
         or fw['slug'] == 'digital-outcomes-and-specialists-2'
@@ -60,6 +61,7 @@ def view_service(service_id):
         flash(API_ERROR_MESSAGE.format(service_id=service_id), 'error')
         return redirect(url_for('.find_suppliers_and_services'))
 
+    # TODO remove `expired` from below. It's a temporary fix to allow access to DOS2 as it's expired.
     # we don't actually need the framework here; using this to 404 if framework for the service is not live
     get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
@@ -96,6 +98,7 @@ def update_service_status(service_id):
 
     # Only services on live frameworks should have their status changed.
     service = data_api_client.get_service(service_id)['services']
+    # TODO remove `expired` from below. It's a temporary fix to allow access to DOS2 as it's expired.
     get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
     frontend_status = request.form['service_status']
@@ -141,6 +144,8 @@ def edit_service(service_id, section_id, question_slug=None):
     service_data = data_api_client.get_service(service_id)['services']
 
     # we don't actually need the framework here; using this to 404 if framework for the service is not live
+    # TODO remove `expired` from below. It's a temporary fix to allow access to DOS2 as it's expired.
+
     get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
     content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
@@ -172,6 +177,7 @@ def update_service(service_id, section_id, question_slug=None):
     service = service['services']
 
     # we don't actually need the framework here; using this to 404 if framework for the service is not live
+    # TODO remove `expired` from below. It's a temporary fix to allow access to DOS2 as it's expired.
     get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
     content = content_loader.get_manifest(service['frameworkSlug'], 'edit_service_as_admin').filter(service)

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -30,7 +30,10 @@ SERVICE_PUBLISHED_MESSAGE = "You published ‘{service_name}’."
 @role_required('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-manager')
 def index():
     frameworks = data_api_client.find_frameworks()['frameworks']
-    frameworks = [fw for fw in frameworks if fw['status'] not in ('coming', 'expired')]
+    frameworks = [
+        fw for fw in frameworks if fw['status'] not in ('coming', 'expired')
+        or fw['slug'] == 'digital-outcomes-and-specialists-2'
+    ]
     frameworks = sorted(frameworks, key=lambda x: x['id'], reverse=True)
     return render_template("index.html", frameworks=frameworks)
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -541,6 +541,7 @@ def find_supplier_services(supplier_id):
 
     frameworks = data_api_client.find_frameworks()['frameworks']
     supplier = data_api_client.get_supplier(supplier_id)["suppliers"]
+    # TODO replace this temporary fix for DOS2 when a better solution has been created.
     services = data_api_client.find_services(
         supplier_id=supplier_id,
         framework=','.join(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -541,8 +541,13 @@ def find_supplier_services(supplier_id):
 
     frameworks = data_api_client.find_frameworks()['frameworks']
     supplier = data_api_client.get_supplier(supplier_id)["suppliers"]
-    services = data_api_client.find_services(supplier_id)['services']
-
+    services = data_api_client.find_services(
+        supplier_id=supplier_id,
+        framework=','.join(
+            [f['slug'] for f in frameworks if f['status'] == 'live'
+                or f['slug'] == 'digital-outcomes-and-specialists-2']
+        )
+    )['services']
     frameworks_services = {
         framework_slug: list(framework_services)
         for framework_slug, framework_services in

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -40,6 +40,7 @@ def find_user_by_email_address():
 def user_list_page_for_framework(framework_slug):
     bad_statuses = ['coming', 'expired']
     framework = data_api_client.get_framework(framework_slug).get("frameworks")
+    # TODO replace this temporary fix for DOS2 when a better solution has been created.
     if not framework or \
             (framework['status'] in bad_statuses and framework['slug'] != 'digital-outcomes-and-specialists-2'):
         abort(404)

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -40,7 +40,8 @@ def find_user_by_email_address():
 def user_list_page_for_framework(framework_slug):
     bad_statuses = ['coming', 'expired']
     framework = data_api_client.get_framework(framework_slug).get("frameworks")
-    if not framework or framework['status'] in bad_statuses:
+    if not framework or \
+            (framework['status'] in bad_statuses and framework['slug'] != 'digital-outcomes-and-specialists-2'):
         abort(404)
 
     supplier_csv_url = url_for(
@@ -82,7 +83,11 @@ def download_supplier_user_list_report(framework_slug, report_type):
 def supplier_user_research_participants_by_framework():
     bad_statuses = ['coming', 'expired']
     frameworks = data_api_client.find_frameworks().get("frameworks")
-    frameworks = sorted(filter(lambda i: i['status'] not in bad_statuses, frameworks), key=lambda i: i['name'])
+    frameworks = sorted(
+        filter(
+            lambda i: i['status'] not in bad_statuses or i['slug'] == 'digital-outcomes-and-specialists-2', frameworks
+        ), key=lambda i: i['name']
+    )
 
     items = [
         {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -89,10 +89,10 @@
       <h2 class="heading-large">Manage applications</h2>
 
     {% for framework in frameworks %}
-      {% if framework.status in ["standstill", "live"] or current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
+      {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' or current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
         <h3 class="heading-xmedium">{{framework.name}}</h3>
 
-        {% if framework.status in ["live", "standstill"] %}
+        {% if framework.status in ["live", "standstill"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
           {% set agreement_link_text = {
               'admin-ccs-category': 'View agreements',
               'admin-ccs-sourcing': 'Countersign agreements',

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -82,9 +82,9 @@ class TestServiceView(LoggedInApplicationTest):
         ("pending", 404),
         ("standstill", 404),
         ("live", 200),
-        ("expired", 404),
+        ("expired", 200),
     ])
-    def test_view_service_only_accessible_for_live_framework_services(self, fwk_status, expected_code):
+    def test_view_service_only_accessible_for_live_and_expired_framework_services(self, fwk_status, expected_code):
         self.data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-8',
             'serviceName': 'test',
@@ -622,9 +622,9 @@ class TestServiceEdit(LoggedInApplicationTest):
         ("pending", 404),
         ("standstill", 404),
         ("live", 200),
-        ("expired", 404),
+        ("expired", 200),
     ])
-    def test_edit_service_only_accessible_for_live_framework_services(self, fwk_status, expected_code):
+    def test_edit_service_only_accessible_for_live_and_expired_framework_services(self, fwk_status, expected_code):
         service = {
             "id": 123,
             "frameworkSlug": "digital-outcomes-and-specialists",
@@ -899,9 +899,9 @@ class TestServiceUpdate(LoggedInApplicationTest):
         ("pending", 404),
         ("standstill", 404),
         ("live", 302),
-        ("expired", 404),
+        ("expired", 302),
     ])
-    def test_post_service_update_only_for_live_framework_services(self, fwk_status, expected_code):
+    def test_post_service_update_only_for_live_and_expired_framework_services(self, fwk_status, expected_code):
         self.data_api_client.get_service.return_value = {'services': {
             'id': 1,
             'supplierId': 2,
@@ -1345,9 +1345,9 @@ class TestServiceStatusUpdate(LoggedInApplicationTest):
         ("pending", 404),
         ("standstill", 404),
         ("live", 302),
-        ("expired", 404),
+        ("expired", 302),
     ])
-    def test_post_status_update_only_for_live_framework_services(self, fwk_status, expected_code):
+    def test_post_status_update_only_for_live_and_expired_framework_services(self, fwk_status, expected_code):
         self.data_api_client.get_service.return_value = {'services': {
             'frameworkSlug': 'g-cloud-9',
             'serviceName': 'bad service',

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -567,7 +567,9 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert response.status_code == 200
 
         self.data_api_client.get_supplier.assert_called_once_with(1000)
-        self.data_api_client.find_services.assert_called_once_with(1000)
+        assert self.data_api_client.find_services.call_args_list == [
+            mock.call(framework='g-cloud-8', supplier_id=1000)
+        ]
 
     def test_should_indicate_if_supplier_has_no_services(self):
         self.data_api_client.find_services.return_value = {'services': []}

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -260,7 +260,7 @@ class TestUserListPage(LoggedInApplicationTest):
     def test_dos2_framework_only_expired_framework_available(self, s3, slug_suffix, name_suffix, should_be_shown):
         self.data_api_client.get_framework.return_value = api_stubs.framework(
             status='expired',
-            slug= f'digital-outcomes-and-specialists{slug_suffix}',
+            slug=f'digital-outcomes-and-specialists{slug_suffix}',
             name=f'Digital Outcomes and Specialists{name_suffix}',
         )
 
@@ -429,7 +429,6 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
         assert response.status_code == 200
 
         document = html.fromstring(response.get_data(as_text=True))
-        href_xpath = "//a[@class='document-link-with-icon']"
         links = document.xpath("//a[@class='document-link-with-icon']")
 
         assert len(links) == 1  # Invalid frameworks not shown


### PR DESCRIPTION
For [this trello card](https://trello.com/c/oEYKxqDK).

Expiring DOS2 caused it to disappear in important places from the admin app. CCS need access to some of the functionality for the framework so they can do their job.

DOS2 doesn't legally close for a while and CCS need to be able to remove suppliers from the framework if they don't submit their MI for three months in a row. They remove them by disabling their services.