### PR TITLE
Enable Admin-specific analytics

### DIFF
--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -1,0 +1,1 @@
+//= include analytics/_init.js

--- a/app/assets/javascripts/analytics/_init.js
+++ b/app/assets/javascripts/analytics/_init.js
@@ -1,0 +1,24 @@
+//= require ../../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+//= include ../../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js
+
+; // JavaScript in the govuk_frontend_toolkit doesn't have trailing semicolons
+
+// Custom Admin FE analytics
+//= include _register.js
+
+// DM Frontend Toolkit analytics
+//= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_events.js
+//= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_pageViews.js
+//= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_virtualPageViews.js
+//= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_trackExternalLinks.js
+
+(function(root) {
+  "use strict";
+  root.GOVUK.GDM.analytics.init = function () {
+    this.register();
+    this.pageViews.init();
+    this.events.init();
+    this.virtualPageViews();
+    this.trackExternalLinks.init();
+  };
+})(window);

--- a/app/assets/javascripts/analytics/_register.js
+++ b/app/assets/javascripts/analytics/_register.js
@@ -1,0 +1,38 @@
+(function (root) {
+  "use strict";
+
+  root.GOVUK.GDM = root.GOVUK.GDM || {};
+  root.GOVUK.GDM.analytics = {
+    'register': function () {
+      var cookieDomain = (root.document.domain === 'www.digitalmarketplace.service.gov.uk') ? '.digitalmarketplace.service.gov.uk' : root.document.domain;
+
+      // Different analytics code for the Admin
+      var universalId = 'UA-49258698-7';
+
+      GOVUK.Analytics.load();
+      GOVUK.analytics = new GOVUK.Analytics({
+        universalId: universalId,
+        cookieDomain: cookieDomain
+      });
+    },
+
+    // wrapper around access to window.location
+    'location': {
+      'hostname': function () {
+        return root.location.hostname;
+      },
+      'href': function () {
+        return root.location.href;
+      },
+      'pathname': function () {
+        return root.location.pathname;
+      },
+      'protocol': function () {
+        return root.location.protocol;
+      },
+      'search': function () {
+        return root.location.search;
+      }
+    }
+  };
+})(window);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,9 +18,8 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/report-a-problem.js
-; // JavaScript in the govuk_frontend_toolkit doesn't have trailing semicolons
-
 //= require _scroll-through-statistics.js
 //= require _selection-buttons.js
 //= require _tables-to-charts.js
+//= require _analytics.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/module-loader.js


### PR DESCRIPTION
Trello: https://trello.com/c/SGzIvFfn/208-add-analytics-to-admin

For now Ash has created a separate GA tracking ID for the admin. The tracking ID for the other apps is hardcoded into the toolkit, which means we can't simply 'drop in' the current analytics shortcut from the toolkit (like we do for say, the User FE: https://github.com/alphagov/digitalmarketplace-user-frontend/blob/master/app/assets/javascripts/_analytics.js). With a bit of work we could parametrize this, but I'd rather not introduce new functionality into the toolkit analytics at this stage.

The simplest option looks to be including the individual FE toolkit javascript files for `_events.js`, `_virtualPageViews.js` etc. We just need to register and initialise the analytics explicitly, so they use the right tracking ID.

I've kept the structure of the `/analytics/_init.js` folder and files to match the other apps as closely as possible.

Also deleted the semi colon in the require list - everything seems to work fine without it.