### PR TITLE
use url_for with external url scheme for direct award service page links

### DIFF
--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -32,7 +32,7 @@
   {% endwith %}
   {%
     with
-      url = "/g-cloud/services/{}".format(service.id),
+      url = url_for("external.direct_award_service_page", framework_family=service['frameworkFamily'], service_id=service["id"]),
       text = "View service"
   %}
     {% include "toolkit/secondary-action-link.html" %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -93,7 +93,7 @@
     {# links #}
     <ul class="list-no-bullet">
       {% if service_data['frameworkFamily'] == 'g-cloud' %}
-        <li><a href="{{ '/{}/services/{}'.format(service_data['frameworkFamily'], service_id) }}">View service</a></li>
+        <li><a href="{{ url_for('external.direct_award_service_page', framework_family=service_data['frameworkFamily'], service_id=service_id) }}">View service</a></li>
       {% endif %}
       {% if current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
         <li><a href="{{ url_for('.view_service', service_id=service_id, remove=True) }}">Remove service</a></li>

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,5 +8,5 @@ itsdangerous==0.24
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.9.0#egg=digitalmarketplace-utils==44.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ itsdangerous==0.24
 lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.9.0#egg=digitalmarketplace-utils==44.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0
 
 ## The following requirements were added by pip freeze:
@@ -20,12 +20,12 @@ certifi==2018.10.15
 cffi==1.11.5
 chardet==3.0.4
 Click==7.0
-contextlib2==0.4.0
-cryptography==2.3
+contextlib2==0.5.5
+cryptography==2.3.1
 docopt==0.4.0
 docutils==0.14
 Flask-Script==2.0.6
-future==0.17.0
+future==0.17.1
 idna==2.7
 inflection==0.3.1
 Jinja2==2.10
@@ -34,14 +34,14 @@ mailchimp3==2.0.11
 mandrill==1.0.57
 Markdown==2.6.7
 MarkupSafe==1.0
-monotonic==0.3
-notifications-python-client==4.1.0
+monotonic==1.5
+notifications-python-client==5.2.0
 odfpy==1.3.6
 pycparser==2.19
 PyJWT==1.6.4
 python-dateutil==2.7.5
-python-json-logger==0.1.4
-pytz==2015.4
+python-json-logger==0.1.9
+pytz==2018.7
 PyYAML==3.11
 requests==2.20.0
 s3transfer==0.1.13

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1523,6 +1523,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
             "151": {
                 "id": "151",
                 "frameworkSlug": "g-cloud-9",
+                "frameworkFamily": "g-cloud",
                 "lot": "cloud-hosting",
                 "status": status,
                 "supplierId": 909090,
@@ -1860,6 +1861,10 @@ class TestServiceUpdates(LoggedInApplicationTest):
 
         assert doc.xpath("normalize-space(string(//header//*[@class='context']))") == "Barrington's"
         assert doc.xpath("normalize-space(string(//header//h1))") == "Lemonflavoured soap"
+
+        assert tuple(
+            a.attrib["href"] for a in doc.xpath("//a[normalize-space(string())=$t]", t="View service")
+        ) == ("/g-cloud/services/151",)
 
         assert len(doc.xpath(
             "//*[@class='dummy-diff-table']"


### PR DESCRIPTION
https://trello.com/c/kjIZjvPz/224-external-route-for-public-g-cloud-service-page-frameworkfamily-services-serviceid

Depends on https://github.com/alphagov/digitalmarketplace-utils/pull/470

Seems to work, even.