### PR TITLE
Admin manager can invite CCS Data controller user

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -23,8 +23,8 @@ ADMIN_ROLES = [
     },
     {
         "value": 'admin-ccs-data-controller',
-        "label": 'Data Controller',
-        "description": 'Manages supplier details across frameworks.',
+        "label": 'Manage data',
+        "description": 'Helps create consistent supplier data and updates company details.',
     },
     {
         "value": 'admin',

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -22,6 +22,11 @@ ADMIN_ROLES = [
         "description": 'Helps with service problems and makes sure services are in scope.',
     },
     {
+        "value": 'admin-ccs-data-controller',
+        "label": 'Data Controller',
+        "description": 'Manages supplier details across frameworks.',
+    },
+    {
         "value": 'admin',
         "label": 'Support user accounts',
         "description": 'Helps buyers and suppliers solve problems with their accounts.'

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -23,7 +23,7 @@ ADMIN_ROLES = [
     },
     {
         "value": 'admin-ccs-data-controller',
-        "label": 'Manage data',
+        "label": 'Manage data (CCS Data Controller)',
         "description": 'Helps create consistent supplier data and updates company details.',
     },
     {

--- a/app/main/views/admin_manager.py
+++ b/app/main/views/admin_manager.py
@@ -30,11 +30,13 @@ def manage_admin_users():
     category_users = data_api_client.find_users_iter(role='admin-ccs-category')
     sourcing_users = data_api_client.find_users_iter(role='admin-ccs-sourcing')
     framework_manager_users = data_api_client.find_users_iter(role='admin-framework-manager')
+    data_controller_users = data_api_client.find_users_iter(role='admin-ccs-data-controller')
 
     # We want to sort so all Active users are above all Suspended users, and alphabetical by name within these groups.
     # In Python False < True (False is zero, True is one) so sorting on "active is False" puts Active users first.
     admin_users = sorted(
-        list(support_users) + list(category_users) + list(sourcing_users) + list(framework_manager_users),
+        list(support_users) + list(category_users) +
+        list(sourcing_users) + list(framework_manager_users) + list(data_controller_users),
         key=lambda k: (k['active'] is False, k['name'])
     )
 

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -28,6 +28,7 @@
       "admin-ccs-category": "Manage services",
       "admin-ccs-sourcing": "Audit framework",
       "admin-framework-manager": "Manage framework",
+      "admin-ccs-data-controller": "Manage data",
     }
   %}
 

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -66,6 +66,20 @@ class TestAdminManagerListView(LoggedInApplicationTest):
          "role": "admin-ccs-sourcing",
          },
     ]
+    DATA_CONTROLLER_USERS = [
+        {"active": False,
+         "emailAddress": "retired-admin-data-controller@example.com",
+         "id": 9095,
+         "name": "Suspended Admin Data Controller",
+         "role": "admin-ccs-data-controller",
+         },
+        {"active": True,
+         "emailAddress": "admin-data-controller@example.com",
+         "id": 9096,
+         "name": "Youthful Admin Data Controller",
+         "role": "admin-ccs-data-controller",
+         },
+    ]
 
     def setup_method(self, method):
         super().setup_method(method)
@@ -77,7 +91,8 @@ class TestAdminManagerListView(LoggedInApplicationTest):
         super().teardown_method(method)
 
     @pytest.mark.parametrize(
-        "role_not_allowed", ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-framework-manager"]
+        "role_not_allowed",
+        ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-framework-manager", "admin-ccs-data-controller"]
     )
     def test_should_403_forbidden_user_roles(self, role_not_allowed):
         self.user_role = role_not_allowed
@@ -95,12 +110,13 @@ class TestAdminManagerListView(LoggedInApplicationTest):
             iter(self.CATEGORY_USERS),
             iter(self.SOURCING_USERS),
             iter(self.FRAMEWORK_MANAGER_USERS),
+            iter(self.DATA_CONTROLLER_USERS),
         ]
         response = self.client.get("/admin/admin-users")
         document = html.fromstring(response.get_data(as_text=True))
 
         assert response.status_code == 200
-        assert len(document.cssselect(".summary-item-row")) == 8
+        assert len(document.cssselect(".summary-item-row")) == 10
 
     def test_should_list_alphabetically_with_all_suspended_users_below_active_users(self):
         self.data_api_client.find_users_iter.side_effect = [
@@ -108,6 +124,7 @@ class TestAdminManagerListView(LoggedInApplicationTest):
             iter(self.CATEGORY_USERS),
             iter(self.SOURCING_USERS),
             iter(self.FRAMEWORK_MANAGER_USERS),
+            iter(self.DATA_CONTROLLER_USERS),
         ]
         response = self.client.get("/admin/admin-users")
         document = html.fromstring(response.get_data(as_text=True))
@@ -139,21 +156,31 @@ class TestAdminManagerListView(LoggedInApplicationTest):
         assert "Wonderful Framework Manager" in rows[4].text_content()
         assert "Manage framework" in rows[4].text_content()
 
-        # Deactivated users in alphabetical order (status, name, role)
-        assert "Active" not in rows[5].text_content()
-        assert "Suspended" in rows[5].text_content()
-        assert "CCS Category Support - Retired" in rows[5].text_content()
-        assert "Manage services" in rows[5].text_content()
+        assert "Active" in rows[5].text_content()
+        assert "Suspended" not in rows[5].text_content()
+        assert "Youthful Admin Data Controller" in rows[5].text_content()
+        assert "Data Controller" in rows[5].text_content()
 
+        # Deactivated users in alphabetical order (status, name, role)
         assert "Active" not in rows[6].text_content()
         assert "Suspended" in rows[6].text_content()
-        assert "Has-been Framework Manager" in rows[6].text_content()
-        assert "Manage framework" in rows[6].text_content()
+        assert "CCS Category Support - Retired" in rows[6].text_content()
+        assert "Manage services" in rows[6].text_content()
 
         assert "Active" not in rows[7].text_content()
         assert "Suspended" in rows[7].text_content()
-        assert "Has-been Sourcing Support" in rows[7].text_content()
-        assert "Audit framework" in rows[7].text_content()
+        assert "Has-been Framework Manager" in rows[7].text_content()
+        assert "Manage framework" in rows[7].text_content()
+
+        assert "Active" not in rows[8].text_content()
+        assert "Suspended" in rows[8].text_content()
+        assert "Has-been Sourcing Support" in rows[8].text_content()
+        assert "Audit framework" in rows[8].text_content()
+
+        assert "Active" not in rows[9].text_content()
+        assert "Suspended" in rows[9].text_content()
+        assert "Suspended Admin Data Controller" in rows[9].text_content()
+        assert "Data Controller" in rows[9].text_content()
 
     def test_should_link_to_edit_admin_user_page(self):
         self.data_api_client.find_users_iter.side_effect = [
@@ -161,6 +188,7 @@ class TestAdminManagerListView(LoggedInApplicationTest):
             iter(self.CATEGORY_USERS),
             iter(self.SOURCING_USERS),
             iter(self.FRAMEWORK_MANAGER_USERS),
+            iter(self.DATA_CONTROLLER_USERS),
         ]
         response = self.client.get("/admin/admin-users")
         document = html.fromstring(response.get_data(as_text=True))
@@ -173,9 +201,11 @@ class TestAdminManagerListView(LoggedInApplicationTest):
             "/admin/admin-users/9087/edit",
             "/admin/admin-users/9092/edit",
             "/admin/admin-users/9093/edit",
+            "/admin/admin-users/9096/edit",
             "/admin/admin-users/9090/edit",
             "/admin/admin-users/9094/edit",
             "/admin/admin-users/9091/edit",
+            "/admin/admin-users/9095/edit",
         ]
 
     def test_should_have_invite_user_link(self):
@@ -254,7 +284,10 @@ class TestInviteAdminUserView(LoggedInApplicationTest):
         assert res.location == "http://localhost/admin/admin-users"
 
     @mock.patch('app.main.views.admin_manager.send_user_account_email')
-    @pytest.mark.parametrize('role', ('admin', 'admin-ccs-sourcing', 'admin-ccs-category', 'admin-framework-manager'))
+    @pytest.mark.parametrize(
+        'role',
+        ('admin', 'admin-ccs-sourcing', 'admin-ccs-category', 'admin-framework-manager', 'admin-ccs-data-controller')
+    )
     def test_post_is_successful_for_valid_roles(self, send_user_account_email, role):
         self.data_api_client.email_is_valid_for_admin_user.return_value = True
         res = self.client.post('/admin/admin-users/invite', data={'role': role, 'email_address': 'test@test.com'})
@@ -345,6 +378,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
             ("Manage framework applications", False),
             ("Audit framework applications (CCS Sourcing)", False),
             ("Manage services (CCS Category)", True),
+            ("Data Controller", False),
             ("Support user accounts", False)
         ]
         permission_descriptions = [
@@ -354,6 +388,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
             'Manages communications about the framework and publishes supplier clarification questions.',
             'Checks declarations and agreements.',
             'Helps with service problems and makes sure services are in scope.',
+            'Manages supplier details across frameworks.',
             'Helps buyers and suppliers solve problems with their accounts.'
         ]
 
@@ -378,6 +413,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
         ("admin", 403),
         ("admin-ccs-category", 403),
         ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
         ("admin-framework-manager", 403),
     ])
     def test_get_page_should_only_be_accessible_to_admin_manager(self, role, expected_code):
@@ -393,6 +429,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
         ("admin", 403),
         ("admin-ccs-category", 403),
         ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
         ("admin-framework-manager", 403),
     ])
     def test_post_page_should_only_be_accessible_to_admin_manager(self, role, expected_code):
@@ -410,7 +447,10 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(response.status_code, role)
 
-    @pytest.mark.parametrize('role', ['admin', 'admin-ccs-sourcing', 'admin-ccs-category', 'admin-framework-manager'])
+    @pytest.mark.parametrize(
+        'role',
+        ['admin', 'admin-ccs-sourcing', 'admin-ccs-category', 'admin-framework-manager', "admin-ccs-data-controller"]
+    )
     def test_admin_manager_can_edit_admin_user_details(self, role):
         self.data_api_client.get_user.return_value = self.admin_user_to_edit
         response1 = self.client.post(

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -159,7 +159,7 @@ class TestAdminManagerListView(LoggedInApplicationTest):
         assert "Active" in rows[5].text_content()
         assert "Suspended" not in rows[5].text_content()
         assert "Youthful Admin Data Controller" in rows[5].text_content()
-        assert "Data Controller" in rows[5].text_content()
+        assert "Manage data" in rows[5].text_content()
 
         # Deactivated users in alphabetical order (status, name, role)
         assert "Active" not in rows[6].text_content()
@@ -180,7 +180,7 @@ class TestAdminManagerListView(LoggedInApplicationTest):
         assert "Active" not in rows[9].text_content()
         assert "Suspended" in rows[9].text_content()
         assert "Suspended Admin Data Controller" in rows[9].text_content()
-        assert "Data Controller" in rows[9].text_content()
+        assert "Manage data" in rows[9].text_content()
 
     def test_should_link_to_edit_admin_user_page(self):
         self.data_api_client.find_users_iter.side_effect = [
@@ -378,7 +378,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
             ("Manage framework applications", False),
             ("Audit framework applications (CCS Sourcing)", False),
             ("Manage services (CCS Category)", True),
-            ("Data Controller", False),
+            ("Manage data", False),
             ("Support user accounts", False)
         ]
         permission_descriptions = [
@@ -388,7 +388,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
             'Manages communications about the framework and publishes supplier clarification questions.',
             'Checks declarations and agreements.',
             'Helps with service problems and makes sure services are in scope.',
-            'Manages supplier details across frameworks.',
+            'Helps create consistent supplier data and updates company details.',
             'Helps buyers and suppliers solve problems with their accounts.'
         ]
 

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -378,7 +378,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
             ("Manage framework applications", False),
             ("Audit framework applications (CCS Sourcing)", False),
             ("Manage services (CCS Category)", True),
-            ("Manage data", False),
+            ("Manage data (CCS Data Controller)", False),
             ("Support user accounts", False)
         ]
         permission_descriptions = [


### PR DESCRIPTION
Trello: https://trello.com/c/tZJCxC87/249-new-admin-search-box-for-suppliers

The Admin manager role needs to be able to create and edit new Data Controller admin users (the new role created in https://github.com/alphagov/digitalmarketplace-api/pull/847).

![admin-manager-new-role](https://user-images.githubusercontent.com/3492540/49022160-20095c80-f18c-11e8-896e-35dcf0f9fa4d.png)

Now updated with content from @constancecerf (thanks!).

A subsequent PR will handle what the Data Controller role can and can't do (currently nothing).