### PR TITLE
Search suppliers registered name

### DIFF
--- a/app/main/helpers/pagination.py
+++ b/app/main/helpers/pagination.py
@@ -1,0 +1,33 @@
+from urllib.parse import urlparse, parse_qs
+
+
+def get_nav_args_from_api_response_links(links, prev_next_label, request_args, preserved_kwargs):
+    """
+    Get prev/next page numbers from object's API response, plus any extra request args for the URL
+    :param links: dict of links from the API response, e.g. {'self': ..., 'prev': ... 'next': ...}
+    :param prev_next_label: string, either 'prev' or 'next'
+    :param request: the request_args MultiDict with any GET args
+    :param preserved_kwargs: list of string kwargs that should be kept to build the prev/next URLs
+    :return: dict of URL params, or None if there's no prev/next link.
+
+    e.g. for the 'prev' link on page 2 of a supplier name search, we'd want
+             {'page': 1, 'supplier_name': 'foo'}
+
+    and on for the 'next' link we'd want {'page': 3, 'supplier_name': 'foo'}.
+
+    If there are no prev/next links in the response then return None - we don't want to build the URL.
+    """
+    if prev_next_label not in links:
+        return None
+
+    page_arg = parse_qs(urlparse(links[prev_next_label]).query)
+
+    navigation_args = {
+        'page': page_arg['page'][0] if page_arg else None
+    }
+
+    for kwarg in preserved_kwargs:
+        if request_args.get(kwarg):
+            navigation_args[kwarg] = request_args.get(kwarg)
+
+    return navigation_args

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -52,7 +52,7 @@ def find_suppliers():
         suppliers = [data_api_client.get_supplier(request.args.get("supplier_id"))['suppliers']]
     else:
         suppliers = data_api_client.find_suppliers(
-            prefix=request.args.get("supplier_name_prefix"),
+            name=request.args.get("supplier_name"),
             duns_number=request.args.get("supplier_duns_number"),
             company_registration_number=request.args.get("supplier_company_registration_number"),
         )['suppliers']

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -21,6 +21,7 @@ from flask_login import current_user
 from .. import main
 from ..auth import role_required
 from ..forms import EmailAddressForm, MoveUserForm
+from ..helpers.pagination import get_nav_args_from_api_response_links
 from ... import data_api_client, content_loader
 
 
@@ -50,12 +51,16 @@ OLD_SIGNING_FLOW_SLUGS = ['g-cloud-7', 'digital-outcomes-and-specialists']
 def find_suppliers():
     if request.args.get("supplier_id"):
         suppliers = [data_api_client.get_supplier(request.args.get("supplier_id"))['suppliers']]
+        links = {}
     else:
-        suppliers = data_api_client.find_suppliers(
+        suppliers_response = data_api_client.find_suppliers(
             name=request.args.get("supplier_name"),
             duns_number=request.args.get("supplier_duns_number"),
             company_registration_number=request.args.get("supplier_company_registration_number"),
-        )['suppliers']
+            page=request.args.get("page", 1)  # API will validate page number values
+        )
+        suppliers = suppliers_response['suppliers']
+        links = suppliers_response["links"]
 
     frameworks = data_api_client.find_frameworks()['frameworks']
     try:
@@ -79,6 +84,8 @@ def find_suppliers():
         agreement_filename=AGREEMENT_FILENAME,
         interesting_frameworks=interesting_frameworks,
         old_flow_slugs=OLD_SIGNING_FLOW_SLUGS,
+        prev_link=get_nav_args_from_api_response_links(links, 'prev', request.args, ['supplier_name']),
+        next_link=get_nav_args_from_api_response_links(links, 'next', request.args, ['supplier_name']),
     )
 
 

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -41,8 +41,8 @@
         {%
           with
           question = "Find a supplier by name",
-          name = "supplier_name_prefix",
-          hint = "You don’t have to put in the full name to get a result."
+          name = "supplier_name",
+          hint = "Enter any part of the supplier’s registered name or trading name."
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -74,7 +74,7 @@
                   with
                   question = "Find a supplier by name",
                   name = "supplier_name_prefix",
-                  hint = "You don’t have to put in the full name to get a result."
+                  hint = "Enter any part of the supplier’s registered name or trading name."
                 %}
                   {% include "toolkit/forms/textbox.html" %}
                 {% endwith %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -30,4 +30,19 @@
       {% include "_view_suppliers_edit_list.html" %}
     {% endif %}
   </div>
+
+{%
+  with
+      previous_page = {
+          "url": url_for('.find_suppliers', **prev_link),
+          "title": "Previous page"
+      } if prev_link else None,
+      next_page = {
+          "url": url_for('.find_suppliers', **next_link),
+          "title": "Next page"
+      } if next_link else None
+%}
+  {% include "toolkit/previous-next-navigation.html" %}
+{% endwith %}
+
 {% endblock %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,4 +11,4 @@ itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.3#egg=digitalmarketplace-content-loader==5.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.10.0#egg=digitalmarketplace-apiclient==19.10.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.13.0#egg=digitalmarketplace-apiclient==19.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.3#egg=digitalmarketplace-content-loader==5.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.10.0#egg=digitalmarketplace-apiclient==19.10.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.13.0#egg=digitalmarketplace-apiclient==19.13.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -45,7 +45,7 @@ pycparser==2.19
 PyJWT==1.7.1
 python-dateutil==2.7.5
 python-json-logger==0.1.10
-pytz==2018.7
+pytz==2018.9
 PyYAML==3.13
 requests==2.21.0
 s3transfer==0.1.13

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -45,7 +45,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
         self.data_api_client.find_suppliers.return_value = {
             "suppliers": [{"id": "12345"}]
         }
-        response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+        response = self.client.get('/admin/suppliers?supplier_name=foo')
         actual_code = response.status_code
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
@@ -60,7 +60,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
         self.data_api_client.find_suppliers.return_value = {
             "suppliers": [{"id": "12345"}]
         }
-        response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+        response = self.client.get('/admin/suppliers?supplier_name=foo')
         data = response.get_data(as_text=True)
         link_is_visible = "Services" in data and "/admin/suppliers/12345/services" in data
 
@@ -78,7 +78,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
         self.data_api_client.find_suppliers.return_value = {
             "suppliers": [{"id": "12345"}]
         }
-        response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+        response = self.client.get('/admin/suppliers?supplier_name=foo')
         data = response.get_data(as_text=True)
         link_is_visible = "Change name" in data and "/admin/suppliers/12345/edit/name" in data
 
@@ -104,7 +104,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
                 FrameworkStub(slug='g-cloud-10', id=2).response(),
             ]
         }
-        response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+        response = self.client.get('/admin/suppliers?supplier_name=foo')
         data = response.get_data(as_text=True)
         document = html.fromstring(data)
 
@@ -155,7 +155,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
             "suppliers": [{"id": "12345"}]
         }
         with mock.patch('app.main.views.suppliers.OLDEST_INTERESTING_FRAMEWORK_SLUG', new='sausage-cloud-2'):
-            response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+            response = self.client.get('/admin/suppliers?supplier_name=foo')
 
         data = response.get_data(as_text=True)
         document = html.fromstring(data)
@@ -179,7 +179,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
 
         with mock.patch('app.main.views.suppliers.OLDEST_INTERESTING_FRAMEWORK_SLUG', new='sausage-cloud-1'):
             with mock.patch('app.main.views.suppliers.OLD_SIGNING_FLOW_SLUGS', new=['sausage-cloud-1']):
-                response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+                response = self.client.get('/admin/suppliers?supplier_name=foo')
 
         data = response.get_data(as_text=True)
         document = html.fromstring(data)
@@ -206,7 +206,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
         }
 
         with mock.patch('app.main.views.suppliers.OLDEST_INTERESTING_FRAMEWORK_SLUG', new='sausage-cloud-1'):
-            response = self.client.get('/admin/suppliers?supplier_name_prefix=foo')
+            response = self.client.get('/admin/suppliers?supplier_name=foo')
 
         data = response.get_data(as_text=True)
         document = html.fromstring(data)
@@ -252,10 +252,10 @@ class TestSuppliersListView(LoggedInApplicationTest):
 
     def test_should_search_by_prefix(self):
         self.data_api_client.find_suppliers.side_effect = HTTPError(Response(404))
-        self.client.get("/admin/suppliers?supplier_name_prefix=foo")
+        self.client.get("/admin/suppliers?supplier_name=foo")
 
         self.data_api_client.find_suppliers.assert_called_once_with(
-            prefix="foo", duns_number=None, company_registration_number=None
+            name="foo", duns_number=None, company_registration_number=None
         )
 
     def test_should_search_by_duns_number(self):
@@ -263,7 +263,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
         self.client.get("/admin/suppliers?supplier_duns_number=987654321")
 
         self.data_api_client.find_suppliers.assert_called_once_with(
-            prefix=None, duns_number="987654321", company_registration_number=None
+            name=None, duns_number="987654321", company_registration_number=None
         )
 
     def test_should_search_by_company_registration_number(self):
@@ -271,7 +271,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
         self.client.get("/admin/suppliers?supplier_company_registration_number=11114444")
 
         self.data_api_client.find_suppliers.assert_called_once_with(
-            prefix=None, duns_number=None, company_registration_number="11114444"
+            name=None, duns_number=None, company_registration_number="11114444"
         )
 
     def test_should_find_by_supplier_id(self):

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -238,11 +238,13 @@ class TestSuppliersListView(LoggedInApplicationTest):
         assert response.status_code == 200
         assert len(document.cssselect('.summary-item-row')) == 2
 
-        page_content = response.get_data(as_text=True)
-        assert 'Previous page' in page_content
-        assert 'Next page' in page_content
-        assert '/admin/suppliers?page=1&amp;supplier_name=foo' in page_content
-        assert '/admin/suppliers?page=3&amp;supplier_name=foo' in page_content
+        assert len(document.xpath("//a[normalize-space(string())='Previous page']")) == 1
+        assert len(document.xpath("//a[normalize-space(string())='Next page']")) == 1
+
+        prev_href = '/admin/suppliers?page=1&supplier_name=foo'
+        assert len(document.xpath('.//a[contains(@href,"{}")]'.format(prev_href))) == 1
+        next_href = '/admin/suppliers?page=3&supplier_name=foo'
+        assert len(document.xpath('.//a[contains(@href,"{}")]'.format(next_href))) == 1
 
     def test_should_list_suppliers_with_no_pagination_for_single_page_of_results(self):
         self.data_api_client.find_suppliers.return_value = {
@@ -260,9 +262,9 @@ class TestSuppliersListView(LoggedInApplicationTest):
         response = self.client.get("/admin/suppliers?supplier_name=foo")
 
         assert response.status_code == 200
-        page_content = response.get_data(as_text=True)
-        assert 'Previous page' not in page_content
-        assert 'Next page' not in page_content
+        document = html.fromstring(response.get_data(as_text=True))
+        assert len(document.xpath("//a[normalize-space(string())='Previous page']")) == 0
+        assert len(document.xpath("//a[normalize-space(string())='Next page']")) == 0
 
     def test_should_search_by_prefix(self):
         self.data_api_client.find_suppliers.side_effect = HTTPError(Response(404))


### PR DESCRIPTION
Trello: https://trello.com/c/aSOduJAQ/319-admin-search-for-registered-name-as-well-as-supplier-name

Pulls in API client changes to search by supplier registered name using the `name` param. 

I changed the admin form name from `supplier_name_prefix` to `supplier_name` to be less misleading.

I've included a small update to the template copy to make it clear that a) registered names are included as well as trading name b) any part of the name will match, not just the prefix. The phrase 'trading name' might be meaningless for buyers/suppliers but user research with CCS reveals they use it to refer to the public name that appears on the Digital Marketplace. TL:DR I'm going to run this past content/product before merging 😸 

Copy change:
![admin-supplier-search-copy](https://user-images.githubusercontent.com/3492540/51320736-bbb29d00-1a58-11e9-9377-0bc3ae8d90b5.png)
