### PR TITLE
Fix query param on new search form

### DIFF
--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -73,7 +73,7 @@
                 {%
                   with
                   question = "Find a supplier by name",
-                  name = "supplier_name_prefix",
+                  name = "supplier_name",
                   hint = "Enter any part of the supplier’s registered name or trading name."
                 %}
                   {% include "toolkit/forms/textbox.html" %}


### PR DESCRIPTION
Trello: https://trello.com/c/aSOduJAQ/319-admin-search-for-registered-name-as-well-as-supplier-name

Small fix for the supplier registered name search, found during QA - the new Data Controller search box form wasn't using the right query parameter.