### PR TITLE
invite_admin_user: prevent this if email address already has user account associated with it

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -35,12 +35,20 @@ ADMIN_ROLES = [
 
 
 class AdminEmailAddressValidator(object):
-
     def __init__(self, message=None):
         self.message = message
 
     def __call__(self, form, field):
         if not data_api_client.email_is_valid_for_admin_user(field.data):
+            raise validators.StopValidation(self.message)
+
+
+class UserAccountDoesntAlreadyExistValidator(object):
+    def __init__(self, message=None):
+        self.message = message
+
+    def __call__(self, form, field):
+        if data_api_client.get_user(email_address=field.data) is not None:
             raise validators.StopValidation(self.message)
 
 
@@ -80,7 +88,8 @@ class InviteAdminForm(FlaskForm):
         validators=[
             validators.DataRequired(message='You must provide an email address'),
             validators.Email(message='Please enter a valid email address'),
-            AdminEmailAddressValidator(message='The email address must belong to an approved domain')
+            AdminEmailAddressValidator(message='The email address must belong to an approved domain'),
+            UserAccountDoesntAlreadyExistValidator("This email address already has a user account associated with it"),
         ]
     )
     role = DMRadioField(


### PR DESCRIPTION
Spawned from https://trello.com/c/Jr6uvi7d, leading to https://trello.com/c/jlwq3G9Z

Also flesh out assertions in tests a bit while we're here.

![screen1](https://user-images.githubusercontent.com/807447/51760141-b04b1b80-20c1-11e9-85ae-99bb3980f575.png)
