### PR TITLE
Supplier details page

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -18,6 +18,7 @@ $path: "/admin/static/images/";
 @import "toolkit/_breadcrumb";
 @import "toolkit/_browse-list";
 @import "toolkit/_buttons";
+@import "toolkit/_contact-details.scss";
 @import "toolkit/_document.scss";
 @import "toolkit/_footer";
 @import "toolkit/_grids";

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -30,7 +30,7 @@ def _get_supplier_frameworks(framework_slug, status=None):
 
 
 @main.route('/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-ccs-data-controller')
 def list_agreements(framework_slug):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
@@ -56,7 +56,7 @@ def list_agreements(framework_slug):
 
 
 @main.route('/suppliers/<int:supplier_id>/agreements/<framework_slug>/next', methods=('GET',))
-@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-ccs-data-controller')
 def next_agreement(supplier_id, framework_slug):
     status = request.args.get("status")
     if status and status not in status_labels:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -618,13 +618,10 @@ def find_supplier_services(supplier_id):
 
     frameworks = data_api_client.find_frameworks()['frameworks']
     supplier = data_api_client.get_supplier(supplier_id)["suppliers"]
-    # TODO replace this temporary fix for DOS2 when a better solution has been created.
+
     services = data_api_client.find_services(
         supplier_id=supplier_id,
-        framework=','.join(
-            [f['slug'] for f in frameworks if f['status'] == 'live'
-                or f['slug'] == 'digital-outcomes-and-specialists-2']
-        )
+        framework=','.join(f['slug'] for f in frameworks if f['status'] in ['live', 'expired'])
     )['services']
     frameworks_services = {
         framework_slug: list(framework_services)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -232,7 +232,7 @@ def view_signed_agreement(supplier_id, framework_slug):
     path = supplier_framework['agreementPath']
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
-        abort(404)
+        current_app.logger.info(f'No agreement file found for {path}')
     return render_template(
         "suppliers/view_signed_agreement.html",
         supplier=supplier,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -175,7 +175,7 @@ def update_supplier_name(supplier_id):
         supplier['suppliers']['id'], {'name': new_supplier_name}, current_user.email_address
     )
 
-    return redirect(url_for('.find_suppliers', supplier_id=supplier_id))
+    return redirect(url_for('.supplier_details', supplier_id=supplier_id))
 
 
 @main.route('/suppliers/<string:supplier_id>/edit/declarations/<string:framework_slug>', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -90,7 +90,7 @@ def find_suppliers():
 
 
 @main.route("/suppliers/<int:supplier_id>", methods=["GET"])
-@role_required("admin-ccs-category", "admin-ccs-data-controller")
+@role_required("admin", "admin-ccs-category", "admin-ccs-data-controller", "admin-framework-manager")
 def supplier_details(supplier_id):
     def company_details_from_supplier(supplier):
         return {
@@ -155,7 +155,7 @@ def supplier_details(supplier_id):
 
 
 @main.route('/suppliers/<string:supplier_id>/edit/name', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-data-controller')
 def edit_supplier_name(supplier_id):
     supplier = data_api_client.get_supplier(supplier_id)
 
@@ -166,7 +166,7 @@ def edit_supplier_name(supplier_id):
 
 
 @main.route('/suppliers/<string:supplier_id>/edit/name', methods=['POST'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-data-controller')
 def update_supplier_name(supplier_id):
     supplier = data_api_client.get_supplier(supplier_id)
     new_supplier_name = request.form.get('new_supplier_name', '')
@@ -204,7 +204,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-ccs-data-controller')
 def view_signed_agreement(supplier_id, framework_slug):
     # not properly validating this - all we do is pass it through
     next_status = request.args.get("next_status")
@@ -308,7 +308,7 @@ def unapprove_agreement_for_countersignature(agreement_id):
 
 
 @main.route('/suppliers/<supplier_id>/agreement/<framework_slug>', methods=['GET'])
-@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-ccs-data-controller')
 def download_signed_agreement_file(supplier_id, framework_slug):
     # This route is used for pre-G-Cloud-8 agreement document downloads
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
@@ -317,7 +317,7 @@ def download_signed_agreement_file(supplier_id, framework_slug):
 
 
 @main.route('/suppliers/<supplier_id>/agreements/<framework_slug>/<document_name>', methods=['GET'])
-@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')
+@role_required('admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager', 'admin-ccs-data-controller')
 def download_agreement_file(supplier_id, framework_slug, document_name):
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
     if supplier_framework is None or not supplier_framework.get("declaration"):
@@ -521,7 +521,7 @@ def update_supplier_declaration_section(supplier_id, framework_slug, section_id)
 
 
 @main.route('/suppliers/users', methods=['GET'])
-@role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
+@role_required('admin', 'admin-ccs-category', 'admin-framework-manager', 'admin-ccs-data-controller')
 def find_supplier_users():
 
     if not request.args.get('supplier_id'):
@@ -611,7 +611,7 @@ def move_user_to_new_supplier(supplier_id):
 
 
 @main.route('/suppliers/<int:supplier_id>/services', methods=['GET'])
-@role_required('admin', 'admin-ccs-category', 'admin-framework-manager')
+@role_required('admin', 'admin-ccs-category', 'admin-framework-manager', 'admin-ccs-data-controller')
 def find_supplier_services(supplier_id):
     remove_services_for_framework_slug = request.args.get('remove')
     publish_services_for_framework_slug = request.args.get('publish')

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -1,19 +1,9 @@
 {% set field_headings = [
-  "Name",
-  summary.hidden_field_heading("Change name"),
+  "Supplier Name",
   summary.hidden_field_heading("Users"),
   summary.hidden_field_heading("Services")
 ]
 %}
-
-{% if current_user.has_role('admin-framework-manager') %}
-  {% set field_headings = [
-      "Name",
-      summary.hidden_field_heading("Users"),
-      summary.hidden_field_heading("Services")
-    ]
-  %}
-{% endif %}
 
 {% call(item) summary.list_table(
   suppliers,
@@ -24,10 +14,7 @@
 %}
 
   {% call summary.row() %}
-    {{ summary.field_name(item.name) }}
-    {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-      {{ summary.edit_link("Change name", url_for(".edit_supplier_name", supplier_id=item.id)) }}
-    {% endif %}
+    {{ summary.service_link(item.name, url_for(".supplier_details", supplier_id=item.id)) }}
     {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
     {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
   {% endcall %}

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -12,6 +12,10 @@
         "label": "Admin home"
       },
       {
+        "label": supplier.name,
+        "link": url_for('.supplier_details', supplier_id=supplier.id)
+      },
+      {
         "label": supplier.name
       }
     ]

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -1,0 +1,61 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block page_title %}
+  {{ supplier.name }} - Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": url_for(".index"),
+        "label": "Admin home"
+      },
+      {
+        "label": supplier.name
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+  {%
+    with heading = supplier.name
+  %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-data-controller') %}
+  <p><a href="{{ url_for('.edit_supplier_name', supplier_id=supplier_id) }}">Edit supplier name</a></p>
+  {% endif %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {{ summary.heading("Company details") }}
+      {% with
+        caption = 'Company details for {}'.format(most_recent_framework_interest.framework.name) if most_recent_framework_interest else 'Company details'
+      %}
+        {% include "suppliers/_company_details_table.html" %}
+      {% endwith %}
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-one-whole">
+      {{ summary.heading("Frameworks") }}
+      {% include "suppliers/_frameworks_table.html" %}
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-one-whole">
+      {{ summary.heading("Users") }}
+      <a href="{{ url_for('.find_supplier_users', supplier_id=supplier_id) }}">Users</a>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/suppliers/_company_details_table.html
+++ b/app/templates/suppliers/_company_details_table.html
@@ -1,0 +1,38 @@
+{% import "toolkit/summary-table.html" as summary %}
+
+{% with %}
+  {% set address_value %}
+    {% if company_details.address %}
+      {%
+        with
+        street_address_line_1 = company_details.address.street_address_line_1,
+        street_address_line_2 = company_details.address.street_address_line_2,
+        locality = company_details.address.locality,
+        postcode = company_details.address.postcode,
+        country = company_details.address.country|sub_country_codes
+      %}
+        {% include "toolkit/contact-details.html" %}
+      {% endwith %}
+    {% else %}
+      {{ company_details.address }}
+    {% endif %}
+  {% endset %}
+
+  {%
+    call(item)
+      summary.list_table(
+        [
+          {"name": "Company registered name", "value": company_details.registered_name},
+          {"name": "Company registration number", "value": company_details.registration_number},
+          {"name": "DUNS Number", "value": company_details.duns_number},
+          {"name": "Address", "value": address_value}
+        ],
+        caption=caption,
+      )
+  %}
+    {% call summary.row() %}
+      <td class="summary-item-field-heading-custom" scope="row"><strong><span>{{item.name}}</span></strong></td>
+      {{ summary.text(item.value or "None") }}
+    {% endcall %}
+  {% endcall %}
+{% endwith %}

--- a/app/templates/suppliers/_frameworks_table.html
+++ b/app/templates/suppliers/_frameworks_table.html
@@ -1,0 +1,16 @@
+{% import "toolkit/summary-table.html" as summary %}
+
+{%
+  call(item)
+    summary.list_table(
+      supplier_frameworks|reverse,
+      caption="Frameworks",
+      empty_message="The supplier does not yet have any framework interests."
+    )
+%}
+  {% call summary.row() %}
+    <td class="summary-item-field-heading-custom" scope="row"><strong><span>{{item.framework.name}}</span></strong></td>
+   {{ summary.edit_link("View services", url_for(".find_supplier_services", supplier_id=supplier_id,) + "#{}_services".format(item.framework.slug)) }}
+   {{ summary.edit_link("View agreements", url_for(".view_signed_agreement", supplier_id=supplier_id, framework_slug=item.framework.slug)) }}
+  {% endcall %}
+{% endcall %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -135,10 +135,14 @@
   </div>
 
   <div class="column-two-thirds">
-      {% if agreement_ext == '.pdf' %}
-          <embed src="{{ agreement_url }}" class="border-image" height="930" type="application/pdf">
+      {% if agreement_url %}
+          {% if agreement_ext == '.pdf' %}
+              <embed src="{{ agreement_url }}" class="border-image" height="930" type="application/pdf">
+          {% else %}
+              <img src="{{ agreement_url }}" class="border-image" >
+          {% endif %}
       {% else %}
-          <img src="{{ agreement_url }}" class="border-image" >
+            <p>Agreement file not available.</p>
       {% endif %}
   </div>
 {% endblock %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -14,7 +14,11 @@
         "label": "Admin home"
       },
       {
-        "label": supplier.name
+        "label": supplier.name,
+        "link": url_for('.supplier_details', supplier_id=supplier.id)
+      },
+      {
+        "label": "Services"
       }
     ]
   %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -14,7 +14,11 @@
               "label": "Admin home"
           },
           {
-              "label": supplier.name
+              "label": supplier.name,
+              "link": url_for('.supplier_details', supplier_id=supplier.id)
+          },
+          {
+              "label": "Users"
           }
       ]
   %}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "colors": "1.1.2",
     "del": "1.2.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v13.1.0",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.9.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.10.0",
     "govuk-elements-sass": "3.0.3",
     "govuk-frontend": "^2.4.0",
     "govuk_frontend_toolkit": "5.0.3",

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,5 +10,5 @@ lxml==4.3.1
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.3#egg=digitalmarketplace-content-loader==5.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@46.1.1#egg=digitalmarketplace-utils==46.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.13.0#egg=digitalmarketplace-apiclient==19.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ lxml==4.3.1
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.1.3#egg=digitalmarketplace-content-loader==5.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@46.1.1#egg=digitalmarketplace-utils==46.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.13.0#egg=digitalmarketplace-apiclient==19.13.0
 
 ## The following requirements were added by pip freeze:
@@ -25,17 +25,17 @@ Click==7.0
 contextlib2==0.5.5
 cryptography==2.3.1
 defusedxml==0.5.0
-docopt==0.4.0
+docopt==0.6.2
 docutils==0.14
 Flask-Script==2.0.6
 fleep==1.0.1
 future==0.17.1
+govuk-country-register==0.2.2
 idna==2.8
 inflection==0.3.1
 Jinja2==2.10
 jmespath==0.9.3
-mailchimp3==2.0.18
-mandrill==1.0.57
+mailchimp3==3.0.6
 Markdown==2.6.11
 MarkupSafe==1.1.0
 monotonic==1.5

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -221,6 +221,7 @@ class TestListAgreements(LoggedInApplicationTest):
         ("admin", 403),
         ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 200),
+        ("admin-ccs-data-controller", 200),
         ("admin-framework-manager", 200),
         ("admin-manager", 403),
     ])
@@ -387,6 +388,7 @@ class TestNextAgreementRedirect(LoggedInApplicationTest):
         ("admin", 403),
         ("admin-ccs-category", 302),
         ("admin-ccs-sourcing", 302),
+        ("admin-ccs-data-controller", 302),
         ("admin-framework-manager", 302),
         ("admin-manager", 403),
     ])

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1280,7 +1280,7 @@ class TestUpdatingSupplierName(LoggedInApplicationTest):
             data={'new_supplier_name': 'Something New'}
         )
         assert response.status_code == 302
-        assert response.location == 'http://localhost/admin/suppliers?supplier_id=1234'
+        assert response.location == 'http://localhost/admin/suppliers/1234'
         self.data_api_client.update_supplier.assert_called_once_with(
             1234, {'name': "Something New"}, "test@example.com"
         )

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1978,11 +1978,12 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
             assert len(document.xpath('//p[contains(text(), "Uploader Name")]')) == 1
             assert len(document.xpath('//span[contains(text(), "uploader@email.com")]')) == 1
 
-    def test_should_404_if_no_signed_url(self, s3):
+    def test_should_show_error_message_if_no_signed_url(self, s3):
         with mock.patch('app.main.views.suppliers.get_signed_url') as mock_get_url:
             mock_get_url.return_value = None
             response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-8')
-            assert response.status_code == 404
+            assert response.status_code == 200
+            assert 'Agreement file not available' in response.get_data(as_text=True)
 
     def test_should_embed_for_pdf_file(self, s3):
         with mock.patch('app.main.views.suppliers.get_signed_url') as mock_get_url:

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -232,31 +232,23 @@ class TestSuppliersListView(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", True),
-        ("admin-ccs-category", False),
-        ("admin-ccs-data-controller", False),
-        ("admin-framework-manager", False),
-    ])
-    def test_change_name_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
-        self.user_role = role
-        response = self.client.get('/admin/suppliers?supplier_name=foo')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Change name" in data and "/admin/suppliers/12345/edit/name" in data
-
-        assert link_is_visible is link_should_be_visible, (
-            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
-        )
-
-    @pytest.mark.parametrize("role, link_should_be_visible", [
-        ("admin", False),
         ("admin-ccs-category", True),
         ("admin-ccs-data-controller", True),
-        ("admin-framework-manager", False),
+        ("admin-framework-manager", True),
+        ("admin-ccs-sourcing", False),
+        ("admin-manager", False),
     ])
     def test_details_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin/suppliers?supplier_name=foo')
-        data = response.get_data(as_text=True)
-        link_is_visible = "Details" in data and "/admin/suppliers/12345" in data
+
+        document = html.fromstring(response.get_data(as_text=True))
+
+        expected_link_text = "My Little Company"
+        expected_href = '/admin/suppliers/12345'
+        expected_link = document.xpath('.//a[contains(@href,"{}")]'.format(expected_href))
+
+        link_is_visible = len(expected_link) > 0 and expected_link[0].text == expected_link_text
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,9 +626,9 @@ detect-file@^1.0.0:
   version "13.1.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.9.0":
-  version "31.9.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#1c280c95d66d32266cbeae94dd717ba4309019b8"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.10.0":
+  version "31.10.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#987afa51294527833f00e5d0249419c6acf36460"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello: https://trello.com/c/3ZUU9xIn/340-supplier-details-admin-page

## What we did

- New view and template for supplier company details page
- Added permissions for CCS Data Controller to view (but not edit) supplier users, services and agreements
- Updated breadcrumbs
- Link the supplier name in search results (replacing 'Change name')
- Pulls in toolkit fix for displaying street address
- Pulls in utils for country code template filter
- Agreement page no longer 404s if the S3 url is not found (shows error message instead)

## What it should look like

![admin-company-details-page](https://user-images.githubusercontent.com/3492540/52960486-cc746c80-3390-11e9-9670-de575cf52abe.png)

## Associated PRs

Functional tests for new view https://github.com/alphagov/digitalmarketplace-functional-tests/pull/606