### PR TITLE
Fix bug when framework has no declaration

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -138,10 +138,13 @@ def supplier_details(supplier_id):
 
     if supplier_frameworks:
         most_recent_framework_interest = supplier_frameworks[-1]
+    else:
+        most_recent_framework_interest = {}
+
+    if most_recent_framework_interest.get("declaration"):
         company_details = \
             company_details_from_supplier_framework_declaration(most_recent_framework_interest["declaration"])
     else:
-        most_recent_framework_interest = {}
         company_details = company_details_from_supplier(supplier)
 
     return render_template(


### PR DESCRIPTION
Frameworks older than G-Cloud 9 have `None` as the value for the
declaration field; this was causing an exception.

This commit adds a test for this case and a fix.