### PR TITLE
Pull in G11 content

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "c3": "0.4.11",
     "colors": "1.1.2",
     "del": "1.2.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v13.1.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v15.0.3",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.10.0",
     "govuk-elements-sass": "3.0.3",
     "govuk-frontend": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,9 +622,9 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#v13.1.0":
-  version "13.1.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#v15.0.3":
+  version "15.0.3"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#5594b7390f1446088c70a18ee2cbe1e18693487f"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.10.0":
   version "31.10.0"


### PR DESCRIPTION
Pulls in https://github.com/alphagov/digitalmarketplace-frameworks/pull/557 to the Admin. The `edit_service_as_admin` manifest is used by CCS users.

Breaking changes are search schema related and shouldn't affect this repo.