### PR TITLE
Check agreementPath exists before looking for it in S3

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -329,6 +329,8 @@ def unapprove_agreement_for_countersignature(agreement_id):
 def download_signed_agreement_file(supplier_id, framework_slug):
     # This route is used for pre-G-Cloud-8 agreement document downloads
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
+    if supplier_framework is None or not supplier_framework.get("agreementPath"):
+        abort(404)
     document_name = degenerate_document_path_and_return_doc_name(supplier_framework['agreementPath'])
     return download_agreement_file(supplier_id, framework_slug, document_name)
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1429,6 +1429,16 @@ class TestDownloadSignedAgreementFile(LoggedInApplicationTest):
         self.client.get('/admin/suppliers/1234/agreement/g-cloud-7')
         download_agreement_file.assert_called_once_with(1234, 'g-cloud-7', 'signed-agreement-file.pdf')
 
+    def test_should_404_if_supplier_agreement_has_no_agreement_path(self, download_agreement_file):
+        self.data_api_client.get_supplier_framework_info.return_value = {
+            'frameworkInterest': {'agreementPath': None}
+        }
+        response = self.client.get('/admin/suppliers/1234/agreement/g-cloud-8')
+
+        assert response.status_code == 404
+        self.data_api_client.get_supplier_framework_info.assert_called_once_with(1234, 'g-cloud-8')
+        assert download_agreement_file.called is False
+
 
 @mock.patch('app.main.views.suppliers.s3')
 class TestDownloadAgreementFile(LoggedInApplicationTest):


### PR DESCRIPTION
Trello: https://trello.com/c/y65kW2nf/651-admin-500

We don't check that the `agreementPath` exists before manipulating it in `degenerate_document_path_and_return_doc_name`. Let's 404 if the file isn't there.