### PR TITLE
Admin edit supplier validation

### DIFF
--- a/app/templates/suppliers/_company_details_table.html
+++ b/app/templates/suppliers/_company_details_table.html
@@ -31,10 +31,10 @@
       )
   %}
     {% call summary.row() %}
-      <td class="summary-item-field-heading-custom" scope="row"><strong><span>{{item.name}}</span></strong></td>
+      {{ summary.field_name(item.name, wide=True) }}
       {{ summary.text(item.value or "None") }}
       {% if current_user.has_role('admin-ccs-data-controller') %}
-      <td class="summary-item-field"><a href="{{ item.edit_link }}">Change</a></td>
+          {{ summary.edit_link(label="Change", link=item.edit_link, hidden_text=item.name) }}
       {% endif %}
     {% endcall %}
   {% endcall %}

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -1,4 +1,5 @@
 {% extends "_base_page.html" %}
+{% import "toolkit/forms/macros/forms.html" as forms %}
 
 {% block page_title %}
   Change registered company address – {{ supplier.name }} – Digital Marketplace admin
@@ -29,6 +30,7 @@
 {% endblock %}
 
 {% block main_content %}
+  {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company address for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
@@ -50,7 +52,7 @@
 
       <div class="question" id="country">
         <span class="question-heading" id="country-label">Country</span>
-
+        {{ forms.field_errors(form.country.name, errors=form.country.errors) }}
         <select name="country" id="location-autocomplete" class="location-autocomplete-fallback">
         {% if not form.country.data %}
           <option value="" selected="selected"></option>

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -25,6 +25,7 @@
 {% endblock %}
 
 {% block main_content %}
+  {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company number for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -25,6 +25,7 @@
 {% endblock %}
 
 {% block main_content %}
+  {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company name for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}


### PR DESCRIPTION
Trello: https://trello.com/c/lw9XhnQS/403-data-controller-can-edit-supplier-details-in-admin

Following QA on Preview and attempting to write a functional test (see https://github.com/alphagov/digitalmarketplace-functional-tests/pull/622).

- uses the existing summary table macros to maximise accessibility (eg hidden text for screenreaders, future changes in styling)
- fixes functional test by removing the `<strong>` tag around the summary table header
- adds missing validation masthead and `country` field error message (to be in line with the same form on the Supplier FE).