### PR TITLE
Suspend services should be available for live frameworks only

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -70,9 +70,9 @@ def view_service(service_id):
         flash(API_ERROR_MESSAGE.format(service_id=service_id), 'error')
         return redirect(url_for('.search_suppliers_and_services'))
 
-    # TODO remove `expired` from below. It's a temporary fix to allow access to DOS2 as it's expired.
-    # we don't actually need the framework here; using this to 404 if framework for the service is not live
-    get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live', 'expired'])
+    framework = get_framework_or_404(
+        data_api_client, service_data['frameworkSlug'], allowed_statuses=['live', 'expired']
+    )
 
     removed_by = removed_at = None
     if service_data['status'] != 'published':
@@ -91,6 +91,7 @@ def view_service(service_id):
 
     return render_template(
         "view_service.html",
+        framework=framework,
         sections=content.summary(service_data),
         service_data=service_data,
         service_id=service_id,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -850,6 +850,10 @@ def toggle_supplier_services(supplier_id):
     if not toggle_action['framework_slug']:
         abort(400, 'Invalid framework')
 
+    framework = data_api_client.get_framework(toggle_action['framework_slug'])['frameworks']
+    if framework['status'] != 'live':
+        abort(400, "Cannot toggle services for framework {}".format(toggle_action['framework_slug']))
+
     services = data_api_client.find_services(
         supplier_id=supplier_id,
         framework=toggle_action['framework_slug'],

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -28,7 +28,7 @@
   {% block before_heading %}
 
     {# banners #}
-    {% if publish and current_user.has_role('admin-ccs-category') and service_data['status'] != 'published' %}
+    {% if publish and current_user.has_role('admin-ccs-category') and service_data['status'] != 'published' and framework['status'] != 'expired' %}
         <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           <input type="hidden" name="service_status" value="public" />
@@ -45,7 +45,7 @@
         </form>
     {% endif %}
 
-    {% if remove and current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
+    {% if remove and current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' and framework['status'] != 'expired' %}
       <form action="{{ url_for('.update_service_status', service_id=service_id ) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="service_status" value="removed" />
@@ -62,7 +62,7 @@
       </form>
     {% endif %}
 
-    {% if service_data['status'] != 'published' and removed_by %}
+    {% if service_data['status'] != 'published' and removed_by and framework['status'] != 'expired' %}
       {%
         with
         type = "temporary-message",
@@ -95,7 +95,7 @@
       {% if service_data['frameworkFamily'] == 'g-cloud' %}
         <li><a href="{{ url_for('external.direct_award_service_page', framework_family=service_data['frameworkFamily'], service_id=service_id) }}">View service</a></li>
       {% endif %}
-      {% if current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' %}
+      {% if current_user.has_role('admin-ccs-category') and service_data['status'] == 'published' and framework['status'] != 'expired' %}
         <li><a href="{{ url_for('.view_service', service_id=service_id, remove=True) }}">Remove service</a></li>
       {% endif %}
     </ul>

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -97,7 +97,9 @@
             {{ summary.text(item.lotName) }}
             {% call summary.field() %}
               <span class="service-status-{{ item.status }}">
-                {% if item.status == "published" %}
+                {% if framework['status'] == "expired" %}
+                  Expired
+                {% elif item.status == "published" %}
                   Public
                 {% elif item.status == "enabled" %}
                   Private
@@ -109,7 +111,7 @@
               </span>
             {% endcall %}
             {{ summary.edit_link(
-                 'Edit' if current_user.has_role('admin-ccs-category') else 'View',
+                 'Edit' if (current_user.has_role('admin-ccs-category') and framework['status'] != 'expired') else 'View',
                  url_for('.view_service', service_id=item.id),
                  hidden_text=item.serviceName
                )

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -68,11 +68,13 @@
 
         {{ summary.heading(framework['name'], id="{}_services".format(framework['slug'])) }}
 
-        {% if current_user.has_role('admin-ccs-category') %}
-          {% if 'published' in frameworks_services[framework['slug']]|map(attribute='status')|list  %}
-            {{ summary.top_link("Suspend services", url_for(".find_supplier_services", supplier_id=supplier.id, remove=framework.slug)) }}
-          {% elif 'disabled' in frameworks_services[framework['slug']]|map(attribute='status')|list %}
-            {{ summary.top_link("Unsuspend services", url_for(".find_supplier_services", supplier_id=supplier.id, publish=framework.slug)) }}
+        {% if framework['status'] == 'live' %}
+          {% if current_user.has_role('admin-ccs-category') %}
+            {% if 'published' in frameworks_services[framework['slug']]|map(attribute='status')|list  %}
+              {{ summary.top_link("Suspend services", url_for(".find_supplier_services", supplier_id=supplier.id, remove=framework.slug)) }}
+            {% elif 'disabled' in frameworks_services[framework['slug']]|map(attribute='status')|list %}
+              {{ summary.top_link("Unsuspend services", url_for(".find_supplier_services", supplier_id=supplier.id, publish=framework.slug)) }}
+            {% endif %}
           {% endif %}
         {% endif %}
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -895,6 +895,18 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         assert "Private" in response.get_data(as_text=True)
         assert "Edit" in response.get_data(as_text=True)
 
+    def test_should_show_correct_fields_for_expired_framework(self):
+        framework = self.load_example_listing("framework_response")['frameworks']
+        framework['status'] = 'expired'
+        self.data_api_client.find_frameworks.return_value = {'frameworks': [framework]}
+
+        response = self.client.get('/admin/suppliers/1000/services')
+
+        assert response.status_code == 200
+        assert "Expired" in response.get_data(as_text=True)
+        assert "View" in response.get_data(as_text=True)
+        assert "Edit" not in response.get_data(as_text=True)
+
     def test_should_show_separate_tables_for_frameworks_if_supplier_has_service_on_framework(self):
 
         service_1 = self.load_example_listing("services_response")['services'][0]

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1060,6 +1060,7 @@ class TestToggleSupplierServicesView(LoggedInApplicationTest):
 
         self.data_api_client.get_supplier.return_value = self.load_example_listing('supplier_response')
         self.data_api_client.find_services.return_value = self.load_example_listing('services_response')
+        self.data_api_client.get_framework.return_value = self.load_example_listing('framework_response')
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -1077,6 +1078,15 @@ class TestToggleSupplierServicesView(LoggedInApplicationTest):
         self.data_api_client.find_services.return_value = {'services': []}
 
         response = self.client.post('/admin/suppliers/1000/services?remove={}'.format(framework))
+
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize('framework_status', ['coming', 'open', 'pending', 'standstill', 'expired'])
+    def test_400_if_framework_is_not_live(self, framework_status):
+        self.data_api_client.get_framework.return_value = {
+            'frameworks': {'status': framework_status}
+        }
+        response = self.client.post('/admin/suppliers/1000/services?remove=g-cloud-8')
 
         assert response.status_code == 400
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -945,6 +945,22 @@ class TestSupplierServicesView(LoggedInApplicationTest):
         expected_link = document.xpath('.//a[contains(@href,"{}")]'.format(expected_href))[0]
         assert expected_link.text == expected_link_text
 
+    @pytest.mark.parametrize(
+        'framework_status, links_shown',
+        [('coming', 0), ('open', 0), ('pending', 0), ('standstill', 0), ('live', 1), ('expired', 0)]
+    )
+    def test_remove_all_services_link_only_visible_for_live_framework(self, framework_status, links_shown):
+        framework = self.load_example_listing("framework_response")['frameworks']
+        framework['status'] = framework_status
+        self.data_api_client.find_frameworks.return_value = {'frameworks': [framework]}
+
+        response = self.client.get('/admin/suppliers/1000/services')
+        assert response.status_code == 200
+
+        document = html.fromstring(response.get_data(as_text=True))
+        expected_href = '/admin/suppliers/1234/services?remove=g-cloud-8'
+        assert len(document.xpath('.//a[contains(@href,"{}")]'.format(expected_href))) == links_shown
+
     @pytest.mark.parametrize('service_status, disallowed_actions', [
         ('enabled', ['publish']), ('disabled', ['enabled']), ('a_new_status', ['publish', 'enabled'])
     ])


### PR DESCRIPTION
Trello: https://trello.com/c/Gz6rXcY8/721-admin-suspending-all-services-for-a-non-live-framework-gives-500s-when-trying-to-delete-from-elasticsearch

Following a bunch of 500 errors when the API was trying to de-index the removed services from a non-existent index (g-cloud-8).

- Only show the `Suspend services / Unsuspend services` links for live frameworks
- Only show the `remove` and `publish` links for individual services for live frameworks
- Raise a 400 if the POST route is called with a non-live framework
- Change the display of expired services to not be 'public'

![expired-view-services-admi](https://user-images.githubusercontent.com/3492540/56282664-9bea4e00-6107-11e9-939c-53b9f93dc12e.png)

The tests around this still use G8 fixtures 😿 but these can be refactored another time.