### PR TITLE
CCS category admin given support permissions

### DIFF
--- a/app/main/helpers/user_downloads.py
+++ b/app/main/helpers/user_downloads.py
@@ -1,0 +1,14 @@
+from dmutils import csv_generator
+
+
+def generate_user_csv(users):
+    header_row = ("email address", "name")
+    user_attributes = ("emailAddress", "name")
+
+    def rows_iter():
+        """Iterator yielding header then rows."""
+        yield header_row
+        for user in sorted(users, key=lambda user: user["name"]):
+            yield (user.get(field_name, "") for field_name in user_attributes)
+
+    return csv_generator.iter_csv(rows_iter())

--- a/app/main/views/buyers.py
+++ b/app/main/views/buyers.py
@@ -35,7 +35,7 @@ def find_buyer_by_brief_id():
 
 
 @main.route('/buyers/add-buyer-domains', methods=['GET', 'POST'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def add_buyer_domains():
     email_domain_form = EmailDomainForm()
     status_code = 200

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -873,7 +873,7 @@ def toggle_supplier_services(supplier_id):
 
 
 @main.route('/suppliers/<int:supplier_id>/invite-user', methods=['POST'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def invite_user(supplier_id):
     invite_form = EmailAddressForm()
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -713,7 +713,7 @@ def find_supplier_users():
 
 
 @main.route('/suppliers/users/<int:user_id>/unlock', methods=['POST'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def unlock_user(user_id):
     user = data_api_client.update_user(user_id, locked=False, updater=current_user.email_address)
     if "source" in request.form:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -740,7 +740,7 @@ def deactivate_user(user_id):
 
 
 @main.route('/suppliers/<int:supplier_id>/move-existing-user', methods=['POST'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def move_user_to_new_supplier(supplier_id):
     move_user_form = MoveUserForm()
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -722,7 +722,7 @@ def unlock_user(user_id):
 
 
 @main.route('/suppliers/users/<int:user_id>/activate', methods=['POST'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def activate_user(user_id):
     user = data_api_client.update_user(user_id, active=True, updater=current_user.email_address)
     if "source" in request.form:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -731,7 +731,7 @@ def activate_user(user_id):
 
 
 @main.route('/suppliers/users/<int:user_id>/deactivate', methods=['POST'])
-@role_required('admin')
+@role_required('admin', 'admin-ccs-category')
 def deactivate_user(user_id):
     user = data_api_client.update_user(user_id, active=False, updater=current_user.email_address)
     if "source" in request.form:

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 
-from dmutils import csv_generator, s3
+from dmutils import s3
 from dmutils.documents import get_signed_url
 from dmutils.flask import timed_render_template as render_template
 from flask import abort, current_app, flash, redirect, request, Response, url_for
 from flask_login import current_user
 
+from ..helpers.user_downloads import generate_user_csv
 from .. import main
 from ..auth import role_required
 from ... import data_api_client
@@ -131,17 +132,8 @@ def download_buyers():
         download_filename = "user-research-buyers-on-{}.csv".format(datetime.utcnow().strftime('%Y-%m-%d-at-%H-%M-%S'))
         users = filter(lambda i: i['userResearchOptedIn'], users)
 
-    header_row = ("email address", "name")
-    user_attributes = ("emailAddress", "name")
-
-    def rows_iter():
-        """Iterator yielding header then rows."""
-        yield header_row
-        for user in sorted(users, key=lambda user: user["name"]):
-            yield (user.get(field_name, "") for field_name in user_attributes)
-
     return Response(
-        csv_generator.iter_csv(rows_iter()),
+        generate_user_csv(users),
         mimetype='text/csv',
         headers={
             "Content-Disposition": "attachment;filename={}".format(download_filename),

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -4,7 +4,6 @@ from dmutils import s3
 from dmutils.documents import get_signed_url
 from dmutils.flask import timed_render_template as render_template
 from flask import abort, current_app, flash, redirect, request, Response, url_for
-from flask_login import current_user
 
 from ..helpers.user_downloads import generate_user_csv
 from .. import main
@@ -81,7 +80,7 @@ def download_supplier_user_list_report(framework_slug, report_type):
 
 
 @main.route('/users/download/suppliers', methods=['GET'])
-@role_required('admin')
+@role_required('admin-framework-manager')
 def supplier_user_research_participants_by_framework():
     bad_statuses = ['coming', 'expired']
     frameworks = data_api_client.find_frameworks().get("frameworks")
@@ -106,7 +105,7 @@ def supplier_user_research_participants_by_framework():
 
 
 @main.route('/frameworks/<framework_slug>/user-research/download', methods=['GET'])
-@role_required('admin')
+@role_required('admin-framework-manager')
 def download_supplier_user_research_report(framework_slug):
 
     reports_bucket = s3.S3(current_app.config['DM_REPORTS_BUCKET'])
@@ -121,7 +120,7 @@ def download_supplier_user_research_report(framework_slug):
 
 
 @main.route('/users/download/buyers', methods=['GET'])
-@role_required('admin-framework-manager', 'admin')
+@role_required('admin-framework-manager')
 def download_buyers():
     """Download a list of all buyers"""
     download_filename = "all-buyers-on-{}.csv".format(datetime.utcnow().strftime('%Y-%m-%d-at-%H-%M-%S'))

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -43,9 +43,9 @@
         <a href="{{ url_for('.search_suppliers_and_services') }}">{{ find_supplier_and_services_link_text[current_user.role] }}</a>
       </p>
 
-    {% if current_user.has_any_role('admin') %}
+    {% if current_user.has_any_role('admin-framework-manager') %}
       <p>
-        <a href="{{ url_for('.supplier_user_research_participants_by_framework') }}">Download lists of potential user research participants</a>
+        <a href="{{ url_for('.supplier_user_research_participants_by_framework') }}">Download potential user research participants (suppliers)</a>
       </p>
     {% endif %}
   {% endif %}
@@ -60,7 +60,10 @@
   {% endif %}
   {% if current_user.has_any_role('admin-framework-manager') %}
       <p>
-        <a href="{{ url_for('.download_buyers') }}">Download buyers list</a>
+        <a href="{{ url_for('.download_buyers') }}">Download list of all buyers</a>
+      </p>
+      <p>
+        <a href="{{ url_for('.download_buyers_for_user_research') }}">Download potential user research participants (buyers)</a>
       </p>
   {% endif %}
   {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
@@ -69,11 +72,6 @@
       </p>
       <p>
         <a href="{{ url_for('.add_buyer_domains') }}">Add a buyer email domain</a>
-      </p>
-  {% endif %}
-  {% if current_user.has_role('admin') %}
-      <p>
-        <a href="{{ url_for('.download_buyers') }}">Download list of potential user research participants</a>
       </p>
   {% endif %}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -67,12 +67,11 @@
       <p>
         <a href="{{ url_for('.find_buyer_by_brief_id') }}">Find a buyer by opportunity ID</a>
       </p>
-  {% endif %}
-
-  {% if current_user.has_role('admin') %}
       <p>
         <a href="{{ url_for('.add_buyer_domains') }}">Add a buyer email domain</a>
       </p>
+  {% endif %}
+  {% if current_user.has_role('admin') %}
       <p>
         <a href="{{ url_for('.download_buyers') }}">Download list of potential user research participants</a>
       </p>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,124 +15,123 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="dmspeak">
-  {% if current_user.has_role('admin-manager') %}
-      <p>
-        <a href="{{ url_for('.manage_admin_users') }}">View and edit admin accounts</a>
-      </p>
-  {% endif %}
-  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager')  %}
-      <h2 class="heading-large">User support</h2>
-  {% endif %}
-
-  {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-      <a href="{{ url_for('.find_user_by_email_address') }}">Find a user by email</a>
-  {% endif %}
-
-  {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-sourcing', 'admin-framework-manager') %}
-
-      <h3 class="heading-xmedium">Suppliers</h3>
-
-    {% set find_supplier_and_services_link_text = {
-        'admin': 'Edit supplier accounts or view services',
-        'admin-ccs-category': 'Edit suppliers and services',
-        'admin-ccs-sourcing': 'Edit supplier declarations',
-        'admin-framework-manager': 'View suppliers and services',
-        }
-    %}
-      <p>
-        <a href="{{ url_for('.search_suppliers_and_services') }}">{{ find_supplier_and_services_link_text[current_user.role] }}</a>
-      </p>
-
-    {% if current_user.has_any_role('admin-framework-manager') %}
-      <p>
-        <a href="{{ url_for('.supplier_user_research_participants_by_framework') }}">Download potential user research participants (suppliers)</a>
-      </p>
-    {% endif %}
-  {% endif %}
-  {% if current_user.has_any_role('admin-ccs-category') %}
-      <p>
-        <a href="{{ url_for('.service_update_audits') }}">Review service changes</a>
-      </p>
-  {% endif %}
-
-  {% if current_user.has_any_role('admin','admin-ccs-category', 'admin-framework-manager') %}
-      <h3 class="heading-xmedium">Buyers</h3>
-  {% endif %}
-  {% if current_user.has_any_role('admin-framework-manager') %}
-      <p>
-        <a href="{{ url_for('.download_buyers') }}">Download list of all buyers</a>
-      </p>
-      <p>
-        <a href="{{ url_for('.download_buyers_for_user_research') }}">Download potential user research participants (buyers)</a>
-      </p>
-  {% endif %}
-  {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-      <p>
-        <a href="{{ url_for('.find_buyer_by_brief_id') }}">Find a buyer by opportunity ID</a>
-      </p>
-      <p>
-        <a href="{{ url_for('.add_buyer_domains') }}">Add a buyer email domain</a>
-      </p>
-  {% endif %}
-
-  {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager', 'admin-ccs-sourcing') %}
-      <h2 class="heading-large">Outcomes</h2>
-      <p>
-        <a href="{{ url_for('.download_outcomes') }}">Download Direct Award outcomes</a>
-      </p>
-  {% endif %}
-
-  {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager', 'admin-ccs-sourcing') %}
-      <h2 class="heading-large">Manage applications</h2>
-
-    {% for framework in frameworks %}
-      {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' or current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
-        <h3 class="heading-xmedium">{{framework.name}}</h3>
-
-        {% if framework.status in ["live", "standstill"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
-          {% set agreement_link_text = {
-              'admin-ccs-category': 'View agreements',
-              'admin-ccs-sourcing': 'Countersign agreements',
-              'admin-framework-manager': 'View agreements',
-              }
-          %}
-        <p>
-          <a href="{{ url_for('.list_agreements', framework_slug=framework['slug'], status='signed') }}">{{ agreement_link_text[current_user.role] }}</a>
-        </p>
-        {% endif %}
-
-        {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
-        <p>
-          <a href="{{ url_for('public.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
-        </p>
-        {% endif %}
-        {% if current_user.has_any_role('admin-framework-manager') %}
-        <p>
-          <a href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Upload communications</a>
-        </p>
-        {% endif %}
-        {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
-        <p>
-          <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">Contact suppliers</a>
-        </p>
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
 
   {% if current_user.has_any_role('admin-ccs-data-controller') %}
+        {# ADMIN CCS DATA CONTROLLER #}
         <h3 class="heading-xmedium">Search for suppliers</h3>
         <p>
             <a href="{{ url_for('.search_suppliers_and_services') }}">View and edit suppliers</a>
         </p>
         <h3 class="heading-xmedium">Download supplier lists</h3>
         {% for framework in frameworks %}
-        {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
-        <p>
-          <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">{{ framework.name }}</a>
-        </p>
-        {% endif %}
+            {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
+                <p>
+                  <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">{{ framework.name }}</a>
+                </p>
+            {% endif %}
         {% endfor %}
+
+  {% elif current_user.has_role('admin-manager') %}
+        {# ADMIN MANAGER #}
+        <p>
+            <a href="{{ url_for('.manage_admin_users') }}">View and edit admin accounts</a>
+        </p>
+
+  {% else %}
+        {# BUYERS, SUPPLIERS AND SERVICES #}
+        <h2 class="heading-large">User support</h2>
+            {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+                <a href="{{ url_for('.find_user_by_email_address') }}">Find a user by email</a>
+            {% endif %}
+
+            <h3 class="heading-xmedium">Suppliers</h3>
+
+            {% set find_supplier_and_services_link_text = {
+                'admin': 'Edit supplier accounts or view services',
+                'admin-ccs-category': 'Edit suppliers and services',
+                'admin-ccs-sourcing': 'Edit supplier declarations',
+                'admin-framework-manager': 'View suppliers and services',
+                }
+            %}
+              <p>
+                <a href="{{ url_for('.search_suppliers_and_services') }}">{{ find_supplier_and_services_link_text[current_user.role] }}</a>
+              </p>
+
+            {% if current_user.has_any_role('admin-framework-manager') %}
+              <p>
+                <a href="{{ url_for('.supplier_user_research_participants_by_framework') }}">Download potential user research participants (suppliers)</a>
+              </p>
+            {% elif current_user.has_any_role('admin-ccs-category') %}
+              <p>
+                <a href="{{ url_for('.service_update_audits') }}">Review service changes</a>
+              </p>
+            {% endif %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
+            <h3 class="heading-xmedium">Buyers</h3>
+
+            {% if current_user.has_any_role('admin-framework-manager') %}
+                <p>
+                    <a href="{{ url_for('.download_buyers') }}">Download list of all buyers</a>
+                </p>
+                <p>
+                    <a href="{{ url_for('.download_buyers_for_user_research') }}">Download potential user research participants (buyers)</a>
+                </p>
+            {% elif current_user.has_any_role('admin', 'admin-ccs-category') %}
+                <p>
+                    <a href="{{ url_for('.find_buyer_by_brief_id') }}">Find a buyer by opportunity ID</a>
+                </p>
+                <p>
+                    <a href="{{ url_for('.add_buyer_domains') }}">Add a buyer email domain</a>
+                </p>
+            {% endif %}
+        {% endif %}
+
+        {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager', 'admin-ccs-sourcing') %}
+            {# OUTCOMES #}
+            <h2 class="heading-large">Outcomes</h2>
+            <p>
+                <a href="{{ url_for('.download_outcomes') }}">Download Direct Award outcomes</a>
+            </p>
+
+            {# FRAMEWORKS AND APPLICATIONS #}
+            <h2 class="heading-large">Manage applications</h2>
+
+            {% for framework in frameworks %}
+                {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' or current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
+                    <h3 class="heading-xmedium">{{framework.name}}</h3>
+
+                    {% if framework.status in ["live", "standstill"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
+                      {% set agreement_link_text = {
+                          'admin-ccs-category': 'View agreements',
+                          'admin-ccs-sourcing': 'Countersign agreements',
+                          'admin-framework-manager': 'View agreements',
+                          }
+                      %}
+                        <p>
+                          <a href="{{ url_for('.list_agreements', framework_slug=framework['slug'], status='signed') }}">{{ agreement_link_text[current_user.role] }}</a>
+                        </p>
+                    {% endif %}
+
+                    {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
+                        <p>
+                          <a href="{{ url_for('public.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
+                        </p>
+                    {% endif %}
+                    {% if current_user.has_any_role('admin-framework-manager') %}
+                        <p>
+                          <a href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Upload communications</a>
+                        </p>
+                    {% endif %}
+                    {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
+                        <p>
+                          <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">Contact suppliers</a>
+                        </p>
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+
+        {% endif %}
+
   {% endif %}
 
     </div>

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -91,7 +91,7 @@
 
       {% call summary.field() %}
       {% if item.active %}
-        {% if current_user.has_role('admin') %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
           <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               {%

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -42,7 +42,7 @@
               'Last login',
               'Pwd changed',
               'Locked',
-              summary.hidden_field_heading("") if current_user.has_any_role('admin', 'admin-ccs-category') else summary.hidden_field_heading("Change status")
+              summary.hidden_field_heading("Change status") if current_user.has_any_role('admin', 'admin-ccs-category') else summary.hidden_field_heading("")
           ],
           field_headings_visible=True)
       %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -71,7 +71,7 @@
       {% endcall %}
 
       {% call summary.field() %}
-      {% if item.locked and current_user.has_role('admin') and not item.personalDataRemoved %}
+      {% if item.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
       <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {%

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -42,7 +42,7 @@
               'Last login',
               'Pwd changed',
               'Locked',
-              summary.hidden_field_heading("") if current_user.has_role('admin') else "Status"
+              summary.hidden_field_heading("") if current_user.has_any_role('admin', 'admin-ccs-category') else summary.hidden_field_heading("Change status")
           ],
           field_headings_visible=True)
       %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -106,7 +106,7 @@
           Active
         {% endif %}
       {% else %}
-        {% if current_user.has_role('admin') and not item.personalDataRemoved %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
           <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               {%

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -127,7 +127,7 @@
   </div>
 
 
-  {% if current_user.has_role('admin') %}
+  {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
   <div class='page-section'>
       <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
           <div class="grid-row">

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -124,7 +124,7 @@
               Active
             {% endif %}
           {% else %}
-            {% if current_user.has_role('admin') and not item.personalDataRemoved %}
+            {% if current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
               <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -108,7 +108,7 @@
 
       {% call summary.field() %}
           {% if item.active %}
-            {% if current_user.has_role('admin') %}
+            {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
               <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                   <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -87,7 +87,7 @@
       {% endcall %}
 
       {% call summary.field() %}
-      {% if item.locked and current_user.has_role('admin') and not item.personalDataRemoved %}
+      {% if item.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
       <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -122,8 +122,11 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 200),
-        ("admin-ccs-category", 403),
+        ("admin-ccs-category", 200),
         ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
     ])
     def test_get_page_should_only_be_accessible_to_specific_user_roles(self, role, expected_code):
         self.user_role = role
@@ -133,8 +136,11 @@ class TestAddBuyerDomainsView(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 302),
-        ("admin-ccs-category", 403),
-        ("admin-ccs-sourcing", 403)
+        ("admin-ccs-category", 302),
+        ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
     ])
     def test_post_page_should_only_be_accessible_to_specific_user_roles(self, role, expected_code):
         self.user_role = role

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -24,7 +24,7 @@ class TestIndex(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", True),
-        ("admin-ccs-category", False),
+        ("admin-ccs-category", True),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", False),
         ("admin-manager", False),

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -171,23 +171,33 @@ class TestIndex(LoggedInApplicationTest):
             link_text = document.xpath('.//a[@href="/admin/search"]//text()')[0]
             assert link_text == expected_link_text
 
+    @pytest.mark.parametrize("link_url, expected_link_text", [
+        ("/admin/users/download/buyers", "Download list of all buyers"),
+        ("/admin/users/download/buyers/user-research", "Download potential user research participants (buyers)"),
+        ("/admin/users/download/suppliers", "Download potential user research participants (suppliers)"),
+    ])
     @pytest.mark.parametrize("role, link_should_be_visible", [
-        ("admin", True),
+        ("admin", False),
         ("admin-ccs-category", False),
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", True),
         ("admin-manager", False),
         ("admin-ccs-data-controller", False),
     ])
-    def test_download_buyers_list_link_shown_to_users_with_right_roles(self, role, link_should_be_visible):
+    def test_links_to_download_buyer_and_user_research_lists_are_shown_with_role_dependent_text(
+        self, role, link_should_be_visible, link_url, expected_link_text
+    ):
         self.user_role = role
         response = self.client.get('/admin')
         document = html.fromstring(response.get_data(as_text=True))
-        link_is_visible = bool(document.xpath('.//a[@href="/admin/users/download/buyers"]'))
+        link_is_visible = bool(document.xpath('.//a[@href="{}"]'.format(link_url)))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "cannot" if link_should_be_visible else "can")
         )
+        if link_should_be_visible:
+            link_text = document.xpath('.//a[@href="{}"]//text()'.format(link_url))[0]
+            assert link_text == expected_link_text
 
 
 class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -787,6 +787,26 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 302
         assert response.location == "http://example.com"
 
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 302),
+        ("admin-ccs-category", 302),
+        ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
+    ])
+    def test_move_user_to_another_supplier_accessible_to_users_with_right_roles(self, role, expected_code):
+        self.user_role = role
+        self.data_api_client.get_user.return_value = self.load_example_listing("user_response")
+        self.data_api_client.update_user.return_value = self.load_example_listing("user_response")
+
+        response = self.client.post(
+            '/admin/suppliers/1000/move-existing-user',
+            data={'user_to_move_email_address': 'test.user@sme.com'}
+        )
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
     def test_should_call_api_to_move_user_to_another_supplier(self):
         self.data_api_client.get_user.return_value = self.load_example_listing("user_response")
         self.data_api_client.update_user.return_value = self.load_example_listing("user_response")

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -710,6 +710,22 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert response.status_code == 302
         assert response.location == "http://localhost/admin/suppliers/users?supplier_id=1000"
 
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 302),
+        ("admin-ccs-category", 302),
+        ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
+    ])
+    def test_activate_users_accessible_to_users_with_right_roles(self, role, expected_code):
+        self.user_role = role
+        self.data_api_client.update_user.return_value = self.load_example_listing("user_response")
+
+        response = self.client.post('/admin/suppliers/users/999/activate')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
     def test_should_call_api_to_activate_user(self):
         self.data_api_client.update_user.return_value = self.load_example_listing("user_response")
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -684,6 +684,22 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert not document.xpath('//form[@action="/admin/suppliers/users/999/activate"][@method="post"]')
         assert not document.xpath('//input[@value="Activate"][@type="submit"][@class="button-secondary"]')
 
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 302),
+        ("admin-ccs-category", 302),
+        ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
+    ])
+    def test_unlock_users_accessible_to_users_with_right_roles(self, role, expected_code):
+        self.user_role = role
+        self.data_api_client.update_user.return_value = self.load_example_listing("user_response")
+
+        response = self.client.post('/admin/suppliers/users/999/unlock')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
     def test_should_call_api_to_unlock_user(self):
         self.data_api_client.update_user.return_value = self.load_example_listing("user_response")
 

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -543,7 +543,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, can_edit", [
         ("admin", True),
-        ("admin-ccs-category", False),
+        ("admin-ccs-category", True),
         ("admin-framework-manager", False),
         ("admin-ccs-data-controller", False),
     ])
@@ -747,6 +747,22 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         assert response.status_code == 302
         assert response.location == "http://example.com"
+
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 302),
+        ("admin-ccs-category", 302),
+        ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
+    ])
+    def test_deactivate_users_accessible_to_users_with_right_roles(self, role, expected_code):
+        self.user_role = role
+        self.data_api_client.update_user.return_value = self.load_example_listing("user_response")
+
+        response = self.client.post('/admin/suppliers/users/999/deactivate')
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     def test_should_call_api_to_deactivate_user(self):
         self.data_api_client.update_user.return_value = self.load_example_listing("user_response")

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1163,6 +1163,27 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
+    @pytest.mark.parametrize("role, expected_code", [
+        ("admin", 302),
+        ("admin-ccs-category", 302),
+        ("admin-ccs-sourcing", 403),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 403),
+        ("admin-manager", 403),
+    ])
+    @mock.patch('app.main.views.suppliers.send_user_account_email')
+    def test_correct_roles_can_invite_user(self, send_user_account_email, role, expected_code):
+        self.user_role = role
+
+        response = self.client.post(
+            '/admin/suppliers/1234/invite-user',
+            data={
+                'email_address': 'email@example.com'
+            }
+        )
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
     def test_should_not_accept_bad_email_on_invite_user(self):
         response = self.client.post(
             "/admin/suppliers/1234/invite-user",

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -407,11 +407,11 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
     @pytest.mark.parametrize(
         ('role', 'status_code'),
         (
-            ('admin', 200),
+            ('admin', 403),
             ('admin-ccs-category', 403),
             ('admin-ccs-sourcing', 403),
             ('admin-manager', 403),
-            ('admin-framework-manager', 403),
+            ('admin-framework-manager', 200),
             ('admin-ccs-data-controller', 403),
         )
     )

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -3,6 +3,7 @@ import mock
 import pytest
 from lxml import html
 from dmtestutils.api_model_stubs import FrameworkStub
+from freezegun import freeze_time
 
 from ...helpers import LoggedInApplicationTest
 
@@ -311,7 +312,7 @@ class TestUserListPage(LoggedInApplicationTest):
 
 @mock.patch('app.main.views.users.s3')
 class TestUserResearchParticipantsExport(LoggedInApplicationTest):
-    user_role = 'admin'
+    user_role = 'admin-framework-manager'
 
     _valid_framework = {
         'name': 'G-Cloud 7',
@@ -330,59 +331,78 @@ class TestUserResearchParticipantsExport(LoggedInApplicationTest):
         self.data_api_client_patch = mock.patch('app.main.views.users.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
 
+        self.data_api_client.find_users_iter.return_value = [
+            {'id': 1, 'userResearchOptedIn': True, 'emailAddress': 'shania@example.com', 'name': "Shania Twain"},
+            {'id': 2, 'userResearchOptedIn': False, 'emailAddress': 'mariah@example.com', 'name': "Mariah Carey"},
+        ]
+
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     @pytest.mark.parametrize(
-        ('role', 'exists'),
+        ('role', 'status_code'),
         (
-            ('admin', True),
-            ('admin-ccs-category', False),
-            ('admin-ccs-sourcing', False),
-            ('admin-manager', False),
-            ('admin-framework-manager', False),
-            ('admin-ccs-data-controller', False),
+            ('admin', 403),
+            ('admin-ccs-category', 403),
+            ('admin-ccs-sourcing', 403),
+            ('admin-manager', 403),
+            ('admin-framework-manager', 200),
+            ('admin-ccs-data-controller', 403),
         )
     )
-    def test_correct_role_can_view_download_buyer_user_research_participants_link(self, s3, role, exists):
+    def test_correct_role_can_download_list_of_all_buyers(self, s3, role, status_code):
         self.user_role = role
 
-        xpath = "//a[@href='{href}'][normalize-space(text()) = '{selector_text}']".format(
-            href='/admin/users/download/buyers',
-            selector_text='Download list of potential user research participants'
-        )
+        with freeze_time('2019-01-01'):
+            response = self.client.get('/admin/users/download/buyers')
 
-        response = self.client.get('/admin')
-        assert response.status_code == 200
+        assert response.status_code == status_code
 
-        document = html.fromstring(response.get_data(as_text=True))
-        assert bool(document.xpath(xpath)) is exists
+    def test_download_list_of_all_buyers_includes_all_buyers(self, s3):
+        with freeze_time('2019-01-01'):
+            response = self.client.get('/admin/users/download/buyers')
+
+        assert response.mimetype == 'text/csv'
+        assert response.headers['Content-Disposition'] == "attachment;filename=all-buyers-on-2019-01-01-at-00-00-00.csv"
+        assert response.headers['Content-Type'] == "text/csv; charset=utf-8"
+        # Assert each line separately to avoid weird line break stuff
+        assert 'email address,name' in response.get_data(as_text=True)
+        assert 'shania@example.com,Shania Twain' in response.get_data(as_text=True)
+        assert 'mariah@example.com,Mariah Carey' in response.get_data(as_text=True)
+        self.data_api_client.find_users_iter.assert_called_once_with(role='buyer')
 
     @pytest.mark.parametrize(
-        ('role', 'exists'),
+        ('role', 'status_code'),
         (
-            ('admin', True),
-            ('admin-ccs-category', False),
-            ('admin-ccs-sourcing', False),
-            ('admin-manager', False),
-            ('admin-framework-manager', False),
-            ('admin-ccs-data-controller', False),
+            ('admin', 403),
+            ('admin-ccs-category', 403),
+            ('admin-ccs-sourcing', 403),
+            ('admin-manager', 403),
+            ('admin-framework-manager', 200),
+            ('admin-ccs-data-controller', 403),
         )
     )
-    def test_correct_role_can_view_supplier_user_research_participants_link(self, s3, role, exists):
+    def test_correct_role_can_download_list_of_buyer_user_research_participants(self, s3, role, status_code):
         self.user_role = role
 
-        xpath = "//a[@href='{href}'][normalize-space(text()) = '{selector_text}']".format(
-            href='/admin/users/download/suppliers',
-            selector_text='Download lists of potential user research participants'
-        )
+        with freeze_time('2019-01-01'):
+            response = self.client.get('/admin/users/download/buyers/user-research')
+        assert response.status_code == status_code
 
-        response = self.client.get('/admin')
-        assert response.status_code == 200
+    def test_download_list_of_all_buyer_user_research_partipants_filters_out_opted_out(self, s3):
+        with freeze_time('2019-01-01'):
+            response = self.client.get('/admin/users/download/buyers/user-research')
 
-        document = html.fromstring(response.get_data(as_text=True))
-        assert bool(document.xpath(xpath)) is exists
+        assert response.mimetype == 'text/csv'
+        assert response.headers['Content-Disposition'] == \
+            "attachment;filename=user-research-buyers-on-2019-01-01-at-00-00-00.csv"
+        assert response.headers['Content-Type'] == "text/csv; charset=utf-8"
+        # Assert each line separately to avoid weird line break stuff
+        assert 'email address,name' in response.get_data(as_text=True)
+        assert 'shania@example.com,Shania Twain' in response.get_data(as_text=True)
+        assert 'mariah@example.com,Mariah Carey' not in response.get_data(as_text=True)
+        self.data_api_client.find_users_iter.assert_called_once_with(role='buyer')
 
     @pytest.mark.parametrize(
         ('role', 'status_code'),


### PR DESCRIPTION
Trello: https://trello.com/c/vo2OA8oM/465-add-user-support-permissions-for-ccs-category-admins

CCS are taking over support duties from GDS. Existing `admin-ccs-category` users should be given the permissions that `admin` users have (there are already some shared permissions).

- add buyer domains
- invite users
- unlock users (who have exceeded the number of password attempts)
- activate users
- deactivate users
- move users from one supplier to another
- confirmed with Nicole that the support team does not need access to user research participant downloads, and that these can be transferred to the framework-manager role.

Functional tests: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/632