### PR TITLE
CCS sourcing admins can view declaration link

### DIFF
--- a/app/templates/suppliers/_frameworks_table.html
+++ b/app/templates/suppliers/_frameworks_table.html
@@ -10,13 +10,18 @@
 %}
   {% call summary.row() %}
     <td class="summary-item-field-heading-custom" scope="row"><strong><span>{{item.frameworkName}}</span></strong></td>
-  {% if not current_user.has_role('admin-ccs-sourcing') %}
+
+  {% if current_user.has_role('admin-ccs-sourcing') %}
+   {{ summary.edit_link("Edit declaration", url_for('.view_supplier_declaration', supplier_id=supplier_id, framework_slug=item.frameworkSlug)) }}
+  {% else %}
    {{ summary.edit_link("View services", url_for(".find_supplier_services", supplier_id=supplier_id,) + "#{}_services".format(item.frameworkSlug)) }}
   {% endif %}
+
   {% if item.frameworkSlug in old_interesting_framework_slugs %}
     {{ summary.edit_link("Download agreements", url_for(".download_signed_agreement_file", supplier_id=supplier_id, framework_slug=item.frameworkSlug)) }}
   {% else %}
    {{ summary.edit_link("View agreements", url_for(".view_signed_agreement", supplier_id=supplier_id, framework_slug=item.frameworkSlug)) }}
   {% endif %}
+
   {% endcall %}
 {% endcall %}

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -12,6 +12,13 @@
           {
               "link": url_for('.index'),
               "label": "Admin home"
+          },
+          {
+              "link": url_for('.supplier_details', supplier_id=supplier.id),
+              "label": supplier.name
+          },
+          {
+              "label": "{} declaration".format(framework.name)
           }
       ]
   %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -12,6 +12,13 @@
           {
               "link": url_for('.index'),
               "label": "Admin home"
+          },
+          {
+              "link": url_for('.supplier_details', supplier_id=supplier.id),
+              "label": supplier.name
+          },
+          {
+              "label": "{} declaration".format(framework.name)
           }
       ]
   %}

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -327,6 +327,37 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
             ]
         )
 
+    @pytest.mark.parametrize(
+        "role, link_should_be_visible", (
+            ("admin", False),
+            ("admin-ccs-category", False),
+            ("admin-ccs-data-controller", False),
+            ("admin-framework-manager", False),
+            ("admin-ccs-sourcing", True)
+        )
+    )
+    def test_sourcing_admins_see_edit_declaration_link(self, role, link_should_be_visible):
+        self.user_role = role
+        self.data_api_client.find_frameworks.return_value = {'frameworks': [
+            FrameworkStub(
+                status="pending",
+                slug="g-cloud-10"
+            ).response()
+        ]}
+
+        response = self.client.get("/admin/suppliers/1234")
+        document = html.fromstring(response.get_data(as_text=True))
+
+        expected_link_text = "Edit declaration"
+        expected_href = '/admin/suppliers/1234/edit/declarations/g-cloud-10'
+        expected_link = document.xpath('.//a[contains(@href,"{}")]'.format(expected_href))
+
+        link_is_visible = len(expected_link) > 0 and expected_link[0].text == expected_link_text
+
+        assert link_is_visible is link_should_be_visible, (
+            "Role {} {} see the link".format(role, "can not" if link_should_be_visible else "can")
+        )
+
 
 class TestSuppliersListView(LoggedInApplicationTest):
 


### PR DESCRIPTION
Trello: https://trello.com/c/luG6NuMT/481-ccs-sourcing-cant-see-view-declaration-link

This got accidentally refactored out here https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/488/files.

- Add the declaration link back in for Sourcing users
- Add some breadcrumbs to the declaration view/edit templates, so it's easier to get back to the supplier page once you've followed the link. 

![edit-declaration-admin](https://user-images.githubusercontent.com/3492540/57525210-06b33180-7322-11e9-8ae1-e00c3a0254de.png)
