### PR TITLE
Fix bug where G8 suppliers would appear to have no company details

### DIFF
--- a/app/main/helpers/supplier_details.py
+++ b/app/main/helpers/supplier_details.py
@@ -22,18 +22,32 @@ def company_details_from_supplier(supplier):
 
 
 def company_details_from_supplier_framework_declaration(declaration):
-    return {
-        "duns_number": declaration.get("supplierDunsNumber"),
-        "registration_number": declaration.get("supplierCompanyRegistrationNumber"),
-        "trading_name": declaration.get("supplierTradingName"),
-        "registered_name": declaration.get("supplierRegisteredName"),
+    company_details_query = {
+        "duns_number": "supplierDunsNumber",
+        "registration_number": "supplierCompanyRegistrationNumber",
+        "trading_name": "supplierTradingName",
+        "registered_name": "supplierRegisteredName",
         "address": {
-            "street_address_line_1": declaration.get("supplierRegisteredBuilding"),
-            "locality": declaration.get("supplierRegisteredTown"),
-            "postcode": declaration.get("supplierRegisteredPostcode"),
-            "country": declaration.get("supplierRegisteredCountry"),
+            "street_address_line_1": "supplierRegisteredBuilding",
+            "locality": "supplierRegisteredTown",
+            "postcode": "supplierRegisteredPostcode",
+            "country": "supplierRegisteredCountry",
         },
     }
+
+    # only copy keys that are present in declaration
+    def dictq(d, q):
+        if isinstance(q, dict):
+            dd = {}
+            for k, qq in q.items():
+                v = dictq(d, qq)
+                if v:
+                    dd[k] = v
+            return dd
+        else:
+            return d.get(q)
+
+    return dictq(declaration, company_details_query)
 
 
 def get_supplier_frameworks_visible_for_role(supplier_frameworks, current_user, frameworks):
@@ -72,6 +86,7 @@ def get_supplier_frameworks_visible_for_role(supplier_frameworks, current_user, 
 
 
 def get_company_details(supplier_framework, supplier):
-    if supplier_framework.get("declaration"):
-        return company_details_from_supplier_framework_declaration(supplier_framework["declaration"])
-    return company_details_from_supplier(supplier)
+    return (
+        company_details_from_supplier_framework_declaration(supplier_framework.get("declaration", {}))
+        or company_details_from_supplier(supplier)
+    )

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -202,6 +202,57 @@ class TestSupplierDetailsView(LoggedInApplicationTest):
             }
         }
 
+    @mock.patch("app.main.views.suppliers.render_template", return_value="")
+    def test_if_most_recent_framework_has_old_declaration_show_account_company_details(self, render_template):
+        self.data_api_client.get_supplier_frameworks.return_value = {
+            "frameworkInterest": [
+                SupplierFrameworkStub(
+                    framework_slug="g-cloud-8",
+                    declaration={
+                        "dunsNumber": mock.sentinel.duns_number,
+                        "currentRegisteredCountry": "country:FR",
+                        "registeredVATNumber": "12345678",
+                        "registeredAddressBuilding": "123 Rue Morgue",
+                        "registeredAddressTown": "Paris",
+                        "registeredAddressPostcode": "76876",
+                    },
+                ).response(),
+            ]
+        }
+
+        self.data_api_client.get_supplier.return_value = {
+            "suppliers": {
+                "id": 1234,
+                "name": "ABC",
+                "dunsNumber": mock.sentinel.duns_number,
+                "registrationCountry": "country:FR",
+                "companiesHouseNumber": "12345678",
+                "contactInformation": [
+                    {
+                        "id": 999,
+                        "address1": "123 Rue Morgue",
+                        "city": "Paris",
+                        "postcode": "76876",
+                        "country": "not used"
+                    }
+                ]
+            }
+        }
+
+        self.client.get("/admin/suppliers/1234")
+        company_details = render_template.call_args[1]["company_details"]
+        assert company_details == {
+            "duns_number": mock.sentinel.duns_number,
+            "registration_number": "12345678",
+            "registered_name": None,
+            "address": {
+                'street_address_line_1': '123 Rue Morgue',
+                'locality': 'Paris',
+                'postcode': '76876',
+                'country': "country:FR"
+            }
+        }
+
 
 class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
 


### PR DESCRIPTION
Ticket: https://trello.com/c/fY2frqFG/490-supplier-company-details-dont-use-details-from-g8-or-earlier

If the supplier framework declaration is not in the expected format (as used in G9/DOS2 and upwards) then show the supplier account company details.