### PR TITLE
Show link to pending framework supplier lists to data controller

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -24,7 +24,7 @@
         </p>
         <h3 class="heading-xmedium">Download supplier lists</h3>
         {% for framework in frameworks %}
-            {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
+            {% if framework.status in ["pending", "standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
                 <p>
                   <a href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">{{ framework.name }}</a>
                 </p>

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -390,8 +390,8 @@ class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):
         ("admin-manager", False),
         ("admin-ccs-data-controller", True),
     ])
-    @pytest.mark.parametrize('framework_status', ('live', 'standstill'))
-    def test_data_controller_can_download_supplier_lists_for_live_standstill_framework_statuses_and_dos2(
+    @pytest.mark.parametrize('framework_status', ('live', 'standstill', 'pending'))
+    def test_data_controller_can_download_supplier_lists_for_certain_framework_statuses_and_dos2(
         self, framework_status, role, link_should_be_visible
     ):
         self.user_role = role


### PR DESCRIPTION
Ticket: https://trello.com/c/oG5hh6xY/489-all-ccs-data-controller-to-view-csv-downloads-for-pending-frameworks