### PR TITLE
Use supplier account details for company details view

### DIFF
--- a/app/main/helpers/supplier_details.py
+++ b/app/main/helpers/supplier_details.py
@@ -1,7 +1,7 @@
 DEPRECATED_FRAMEWORK_SLUGS = ['g-cloud-4', 'g-cloud-5', 'g-cloud-6']
 
 
-def company_details_from_supplier(supplier):
+def get_company_details_from_supplier(supplier):
     address = {"country": supplier.get("registrationCountry")}
     if len(supplier.get('contactInformation', [])) > 0:
         address.update({
@@ -18,21 +18,6 @@ def company_details_from_supplier(supplier):
         ),
         "registered_name": supplier.get("registeredName"),
         "address": address
-    }
-
-
-def company_details_from_supplier_framework_declaration(declaration):
-    return {
-        "duns_number": declaration.get("supplierDunsNumber"),
-        "registration_number": declaration.get("supplierCompanyRegistrationNumber"),
-        "trading_name": declaration.get("supplierTradingName"),
-        "registered_name": declaration.get("supplierRegisteredName"),
-        "address": {
-            "street_address_line_1": declaration.get("supplierRegisteredBuilding"),
-            "locality": declaration.get("supplierRegisteredTown"),
-            "postcode": declaration.get("supplierRegisteredPostcode"),
-            "country": declaration.get("supplierRegisteredCountry"),
-        },
     }
 
 
@@ -69,9 +54,3 @@ def get_supplier_frameworks_visible_for_role(supplier_frameworks, current_user, 
         visible_supplier_frameworks,
         key=lambda sf: framework_info[sf["frameworkSlug"]]['frameworkLiveAtUTC']
     )
-
-
-def get_company_details(supplier_framework, supplier):
-    if supplier_framework.get("declaration"):
-        return company_details_from_supplier_framework_declaration(supplier_framework["declaration"])
-    return company_details_from_supplier(supplier)

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -49,7 +49,7 @@
       </p>
       {% endif %}
       {% with
-        caption = 'Company details for {}'.format(most_recent_framework_interest.frameworkName) if most_recent_framework_interest else 'Company details'
+        caption = 'Company details for supplier account'
       %}
         {% include "suppliers/_company_details_table.html" %}
       {% endwith %}


### PR DESCRIPTION
Ticket: https://trello.com/c/fY2frqFG/490-supplier-company-details-always-show-admin-the-account-company-details

Using the most recent framework declaration was causing some confusion, and issues with changes between frameworks in how the company details were stored, so instead we are changing the behaviour so that the supplier account details are always shown.

This means we get to delete a load of code :fire: