### PR TITLE
Show full dates with day and year

### DIFF
--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -50,7 +50,7 @@
                   {{ item.data.serviceId }}
                 {% endcall %}
                 {% call summary.field() %}
-                  {{ item.createdAt|shortdateformat }}<br />
+                  {{ item.createdAt|dateformat }}<br />
                   at {{ item.createdAt|timeformat }}
 
                 {% endcall %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -55,7 +55,7 @@
       {% call summary.field() %}
           {% if item.loggedInAt %}
               {{ item.loggedInAt|timeformat }}<br/>
-              {{ item.loggedInAt|shortdateformat }}
+              {{ item.loggedInAt|dateformat }}
           {% else %}
               Never
           {% endif %}
@@ -64,7 +64,7 @@
       {% call summary.field() %}
           {% if item.passwordChangedAt %}
               {{ item.passwordChangedAt|timeformat }}<br/>
-              {{ item.passwordChangedAt|shortdateformat }}
+              {{ item.passwordChangedAt|dateformat }}
           {% else %}
               Never
           {% endif %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -71,7 +71,7 @@
       {% call summary.field() %}
           {% if item.loggedInAt %}
               {{ item.loggedInAt|timeformat }}<br/>
-              {{ item.loggedInAt|shortdateformat }}
+              {{ item.loggedInAt|dateformat }}
           {% else %}
               Never
           {% endif %}
@@ -80,7 +80,7 @@
       {% call summary.field() %}
           {% if item.passwordChangedAt %}
               {{ item.passwordChangedAt|timeformat }}<br/>
-              {{ item.passwordChangedAt|shortdateformat }}
+              {{ item.passwordChangedAt|dateformat }}
           {% else %}
               Never
           {% endif %}

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -38,9 +38,9 @@ class TestServiceUpdates(LoggedInApplicationTest):
                 ('2017-04-25T14:43:46.061077Z', '597637931594387', u'Making £ Inc', '240701', '240684'),
             ),
             (
-                ('Company name', '1123456789012351', '15 July at 18:03:43', '/admin/services/1123456789012351/updates'),
-                (u'Testing Ltd', '1123456789012348', '5 March at 10:42:16', '/admin/services/1123456789012348/updates'),
-                (u'Making £ Inc', '597637931594387', '25 April at 14:43:46', '/admin/services/597637931594387/updates'),
+                ('Company name', '1123456789012351', 'Sunday 15 July 2012 at 18:03:43', '/admin/services/1123456789012351/updates'),  # noqa
+                ('Testing Ltd', '1123456789012348', 'Saturday 5 March 2016 at 10:42:16', '/admin/services/1123456789012348/updates'),  # noqa
+                ('Making £ Inc', '597637931594387', 'Tuesday 25 April 2017 at 14:43:46', '/admin/services/597637931594387/updates'),  # noqa
             ),
             '3 edited services',
         ),
@@ -50,8 +50,8 @@ class TestServiceUpdates(LoggedInApplicationTest):
                 ('2016-03-05T10:42:16.061077Z', '597637931590001', 'Ideal Health', '240699', '240682'),
             ),
             (
-                ('Company name', '597637931590002', '15 July at 18:03:43', '/admin/services/597637931590002/updates'),
-                ('Ideal Health', '597637931590001', '5 March at 10:42:16', '/admin/services/597637931590001/updates'),
+                ('Company name', '597637931590002', 'Sunday 15 July 2012 at 18:03:43', '/admin/services/597637931590002/updates'),  # noqa
+                ('Ideal Health', '597637931590001', 'Saturday 5 March 2016 at 10:42:16', '/admin/services/597637931590001/updates'),  # noqa
             ),
             '2 edited services',
         ),
@@ -65,7 +65,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
                 ('2012-07-15T18:03:43.061077Z', '597637931590002', 'Company name', '240697', '240680'),
             ),
             (
-                ('Company name', '597637931590002', '15 July at 18:03:43', '/admin/services/597637931590002/updates'),
+                ('Company name', '597637931590002', 'Sunday 15 July 2012 at 18:03:43', '/admin/services/597637931590002/updates'),  # noqa
             ),
             '1 edited service',
         ),

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -104,7 +104,7 @@ class TestUsersView(LoggedInApplicationTest):
 
         last_login_day = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[4].strip()
-        assert last_login_day == '23 July'
+        assert last_login_day == 'Thursday 23 July 2015'
 
         last_password_changed = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[5].strip()
@@ -112,7 +112,7 @@ class TestUsersView(LoggedInApplicationTest):
 
         last_password_changed_day = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[6].strip()
-        assert last_password_changed_day == '29 June'
+        assert last_password_changed_day == 'Monday 29 June 2015'
 
         locked = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/text()')[7].strip()


### PR DESCRIPTION
https://trello.com/c/R29k7LgW/558-include-the-year-in-a-users-last-login-date-on-the-admin

Before:
![before](https://user-images.githubusercontent.com/503614/59626528-07669100-9134-11e9-9bca-d3abf07db4cc.png)

After:
![after](https://user-images.githubusercontent.com/503614/59626865-daff4480-9134-11e9-9e0f-ef0782de0d4e.png)
