### PR TITLE
Add ability to delete/download communications

### DIFF
--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -1,11 +1,23 @@
+from pathlib import PurePath
+
 from dmutils import s3  # this style of import so we only have to mock once
 from dmutils.documents import file_is_pdf, file_is_csv, file_is_open_document_format
 from dmutils.flask import timed_render_template as render_template
-from flask import redirect, url_for, current_app, request, flash
+from flask import redirect, url_for, current_app, request, flash, abort
 
 from .. import main
 from ..auth import role_required
 from ... import data_api_client
+from ..helpers.frameworks import get_framework_or_404
+
+
+def _get_comm_type_root(framework_slug, comm_type):
+    # PurePath has the advantage that it doesn't handle ".." elements specially, and so we're safe from a whole
+    # category of tricks
+    return PurePath(framework_slug) / "communications" / "updates" / f"{comm_type}s"
+
+
+_comm_types = ("communication", "clarification",)
 
 
 @main.route('/communications/<framework_slug>', methods=['GET'])
@@ -65,3 +77,36 @@ def upload_communication(framework_slug):
             flash('New clarification was uploaded.')
 
     return redirect(url_for('.manage_communications', framework_slug=framework_slug))
+
+
+@main.route('/communications/<framework_slug>/delete/<string:comm_type>/<path:filepath>', methods=("GET", "POST",))
+@role_required('admin-framework-manager')
+def delete_communication(framework_slug, comm_type, filepath):
+    if comm_type not in _comm_types:
+        abort(404)
+
+    framework = get_framework_or_404(data_api_client, framework_slug)
+
+    if request.method == "POST":
+        if "confirm" not in request.form:
+            abort(400, "Expected 'confirm' parameter in POST request")
+
+        communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
+        full_path = _get_comm_type_root(framework_slug, comm_type) / filepath
+
+        # do this check ourselves - deleting an object in S3 silently has no effect, forwarding this behaviour to the
+        # user is a confusing thing to do
+        if not communications_bucket.path_exists(str(full_path)):
+            abort(404, f"{filepath} not present in S3 bucket")
+
+        communications_bucket.delete_key(str(full_path))
+
+        flash(f"{comm_type.capitalize()} ‘{filepath}’ was deleted for {framework['name']}.")
+        return redirect(url_for('.manage_communications', framework_slug=framework_slug))
+
+    return render_template(
+        'confirm_communications_deletion.html',
+        framework=framework,
+        comm_type=comm_type,
+        filepath=filepath,
+    )

--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -47,7 +47,7 @@ def manage_communications(framework_slug):
     )
 
 
-@main.route('/communications/<framework_slug>/files/<string:comm_type>/<path:filepath>', methods=['GET'])
+@main.route('/communications/<framework_slug>/files/<string:comm_type>/<safepurepath:filepath>', methods=['GET'])
 @role_required('admin-framework-manager')
 def download_communication(framework_slug, comm_type, filepath):
     if comm_type not in _comm_types:
@@ -100,7 +100,10 @@ def upload_communication(framework_slug):
     return redirect(url_for('.manage_communications', framework_slug=framework_slug))
 
 
-@main.route('/communications/<framework_slug>/delete/<string:comm_type>/<path:filepath>', methods=("GET", "POST",))
+@main.route(
+    '/communications/<framework_slug>/delete/<string:comm_type>/<safepurepath:filepath>',
+    methods=("GET", "POST",),
+)
 @role_required('admin-framework-manager')
 def delete_communication(framework_slug, comm_type, filepath):
     if comm_type not in _comm_types:

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -1,0 +1,48 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+  Confirm communications deletion - Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+      with items = [
+          {
+              "link": url_for('.index'),
+              "label": "Admin home"
+          },
+          {
+              "link": url_for('.manage_communications', framework_slug=framework.slug),
+              "label": "Manage {} communications".format(framework.name)
+          }
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  {% with heading = "Confirm communications deletion" %}
+    {% include "toolkit/page-heading.html" %}
+  {% endwith %}
+
+  <form method="POST" action="">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <div class="question">
+          Are you sure you want to delete the {{ framework.name }} {{ comm_type }} file ‘{{ filepath }}’?
+        </div>
+        {%
+          with
+          label="Delete file",
+          type="destructive",
+          name="confirm"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </div>
+    </div>
+  </form>
+
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -119,7 +119,7 @@
                     {% endif %}
                     {% if current_user.has_any_role('admin-framework-manager') %}
                         <p>
-                          <a href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Upload communications</a>
+                          <a href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Manage communications</a>
                         </p>
                     {% endif %}
                     {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -1,7 +1,8 @@
 {% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
 
 {% block page_title %}
-  Upload {{ framework.name }} communications - Digital Marketplace admin
+  Manage {{ framework.name }} communications - Digital Marketplace admin
 {% endblock %}
 
 {% block breadcrumb %}
@@ -16,43 +17,88 @@
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
 {% endblock %}
-
 {% block main_content %}
-  {% with heading = "Upload {} communications".format(framework.name) %}
+  {% with heading = "Manage {} communications".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}
 
   <form method="post" enctype="multipart/form-data">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    {% with
-       question="Communication",
-       hint="This must be an open document format (pdf, pda, odt, ods, odp) or CSV",
-       name="communication",
-       value="Last modified {}".format(communication.last_modified|datetimeformat) if communication else "No communications have been uploaded yet",
-       error=communication_error
-    %}
-      {% include "toolkit/forms/upload.html" %}
-    {% endwith %}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <div class="dmspeak"><h2 class="heading-large">Communication</h2></div>
+        {% call(item) summary.list_table(
+          comm_type_objs.communication,
+          caption="Communications present",
+          empty_message="No communications files",
+          field_headings=[
+            "Last modified",
+            "File"
+          ],
+          field_headings_visible=False
+        ) %}
+          {% call summary.row() %}
+          {{ summary.field_name(item.last_modified|dateformat) }}
+          {% call summary.field() %}
+            <a href="{{ url_for('.download_communication', comm_type="communication", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
+              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
+              {{ item.filename }}
+            </a>
+          {% endcall %}
+          {{ summary.remove_link(label="Delete", link=url_for('.delete_communication', framework_slug=framework.slug, comm_type="communication", filepath=item.rel_path)) }}
+          {% endcall %}
+        {% endcall %}
+        {% with
+          question="Upload communication",
+          hint="This must be an open document format (pdf, pda, odt, ods, odp) or CSV",
+          name="communication",
+          error=communication_error
+        %}
+          {% include "toolkit/forms/upload.html" %}
+        {% endwith %}
 
     {% if framework.status in ['open'] %}
-    {% with
-       question="Clarification answers",
-       hint="This must be PDF",
-       name="clarification",
-       value="Last modified {}".format(clarification.last_modified|datetimeformat) if clarification else "No clarification answers have been uploaded yet",
-       error=clarification_error
-    %}
-      {% include "toolkit/forms/upload.html" %}
-    {% endwith %}
+        <div class="dmspeak"><h2 class="heading-large">Clarification answers</h2></div>
+        {% call(item) summary.list_table(
+          comm_type_objs.clarification,
+          caption="Communications present",
+          empty_message="No clarification answers",
+          field_headings=[
+            "Last modified",
+            "File"
+          ],
+          field_headings_visible=False
+        ) %}
+          {% call summary.row() %}
+          {{ summary.field_name(item.last_modified|dateformat) }}
+          {% call summary.field() %}
+            <a href="{{ url_for('.download_communication', comm_type="clarification", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
+              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
+              {{ item.filename }}
+            </a>
+          {% endcall %}
+          {{ summary.remove_link(label="Delete", link=url_for('.delete_communication', framework_slug=framework.slug, comm_type="clarification", filepath=item.rel_path)) }}
+          {% endcall %}
+        {% endcall %}
+        {% with
+          question="Upload clarification answers",
+          hint="This must be a PDF",
+          name="clarification",
+          error=clarification_error
+        %}
+          {% include "toolkit/forms/upload.html" %}
+        {% endwith %}
     {% endif %}
 
-    {%
-      with
-      type = "save",
-      label = "Upload files"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
+        {%
+          with
+          type = "save",
+          label = "Upload files"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+        </div>
+      </div>
   </form>
 
 {% endblock %}

--- a/default.nix
+++ b/default.nix
@@ -7,12 +7,24 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceAdminFrontendEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-admin-frontend-env";
     shortName = "dm-adm-fe";
     buildInputs = [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       pkgs.nodejs-8_x
       pkgs.yarn

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,5 +10,5 @@ lxml==4.3.4
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ lxml==4.3.4
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 
 ## The following requirements were added by pip freeze:

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -80,6 +80,10 @@ class BaseApplicationTest(object):
             assert expected_message in messages.getlist(expected_category), \
                 "Didn't find '{}' in '{}'".format(expected_message, messages.getlist(expected_category))
 
+    def assert_no_flashes(self):
+        with self.client.session_transaction() as session:
+            assert '_flashes' not in session
+
     @staticmethod
     def _get_fixture_data(fixture_filename):
         test_root = os.path.abspath(

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -1,30 +1,43 @@
 # coding=utf-8
 from io import BytesIO
+from urllib.parse import urljoin
 
 import mock
 import pytest
 from lxml import html
 
+from dmtestutils.api_model_stubs import FrameworkStub
+from dmtestutils.comparisons import RestrictedAny
 from dmtestutils.fixtures import valid_pdf_bytes
 
 from ...helpers import LoggedInApplicationTest
 
 
-class TestCommunicationsView(LoggedInApplicationTest):
+class _BaseTestCommunicationsView(LoggedInApplicationTest):
     user_role = 'admin-framework-manager'
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.framework_slug = "g-things-23"
+        self.framework_stub = FrameworkStub(slug=self.framework_slug)
         self.data_api_client_patch = mock.patch('app.main.views.communications.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
-        self.data_api_client.get_framework.return_value = {"frameworks": []}
 
-        self.framework_slug = self.load_example_listing('framework_response')['frameworks']['slug']
+        # note how this evaluates .single_result_response() at call-time, allowing self.framework_stub to be
+        # overridden by test methods
+        self.data_api_client.get_framework.side_effect = lambda framework_slug: {
+            self.framework_slug: self.framework_stub.single_result_response()
+        }[framework_slug]
+
+        self.app.config["DM_COMMUNICATIONS_BUCKET"] = "flop-slop-slap"
+        self.app.config["DM_ASSETS_URL"] = "https://basket.market.net/"
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
+
+class TestManageCommunicationsView(_BaseTestCommunicationsView):
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 403),
         ("admin-ccs-category", 403),
@@ -39,57 +52,145 @@ class TestCommunicationsView(LoggedInApplicationTest):
         assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
 
     def test_page_shows_empty_messages_if_no_files_uploaded(self):
-        self.s3.return_value.list.side_effect = ([], [])  # Empty lists for both communication and clarification files
-        self.data_api_client.get_framework.return_value = {"frameworks": {"status": "open"}}
+        self.s3.return_value.list.side_effect = lambda *args, **kwargs: []  # return a fresh empty list every time
         response = self.client.get("/admin/communications/{}".format(self.framework_slug))
         document = html.fromstring(response.get_data(as_text=True))
-        file_upload_messages = document.xpath('//p[@class="file-upload-existing-value"]')
+        file_upload_messages = document.xpath('//p[@class="summary-item-no-content"]')
 
         assert len(file_upload_messages) == 2
-        assert file_upload_messages[0].text_content().strip() == "No communications have been uploaded yet"
-        assert file_upload_messages[1].text_content().strip() == "No clarification answers have been uploaded yet"
+        assert file_upload_messages[0].text_content().strip() == "No communications files"
+        assert file_upload_messages[1].text_content().strip() == "No clarification answers"
 
-    def test_page_shows_timestamp_from_last_file_in_list_if_some_files_already_uploaded(self):
-        # The first list is for communication files, the second for clarifications
-        self.s3.return_value.list.side_effect = (
-            [
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+        assert self.s3.mock_calls == [
+            mock.call("flop-slop-slap"),
+            mock.call().list('g-things-23/communications/updates/communications', load_timestamps=True),
+            mock.call().list('g-things-23/communications/updates/clarifications', load_timestamps=True),
+        ]
+
+    @pytest.mark.parametrize("framework_status", ("open", "standstill",))
+    def test_page_shows_timestamp_from_last_file_in_list_if_some_files_already_uploaded(self, framework_status):
+        self.framework_stub = FrameworkStub(slug=self.framework_slug, status=framework_status)
+        self.s3.return_value.list.side_effect = lambda prefix, *args, **kwargs: {
+            "g-things-23/communications/updates/communications": [
                 {
-                    "path": "g-things-23/communications/updates/communications/communication-1.pdf",
-                    "last_modified": "2018-01-01T01:01:01.000001Z"
+                    "path": "g-things-23/communications/updates/communications/communication-foo.pdf",
+                    "last_modified": "2018-01-01T01:01:01.000001Z",
+                    "filename": "clarification-foo.pdf",
                 },
                 {
-                    "path": "g-things-23/communications/updates/communications/communication-2.pdf",
-                    "last_modified": "2018-02-02T02:02:02.000002Z"
+                    "path": "g-things-23/communications/updates/communications/communication-bar.pdf",
+                    "last_modified": "2018-02-02T02:02:02.000002Z",
+                    "filename": "clarification-bar.pdf",
                 },
                 {
-                    "path": "g-things-23/communications/updates/communications/communication-3.pdf",
-                    "last_modified": "2018-03-03T03:03:03.000003Z"
+                    "path": "g-things-23/communications/updates/communications/communication-baz.pdf",
+                    "last_modified": "2018-03-03T03:03:03.000003Z",
+                    "filename": "clarification-baz.pdf",
                 },
             ],
-            [
+            "g-things-23/communications/updates/clarifications": [
                 {
-                    "path": "g-things-23/communications/updates/clarifiactions/clarification-1.pdf",
-                    "last_modified": "2018-04-04T01:01:01.000001Z"
+                    "path": "g-things-23/communications/updates/clarifications/clarification-qux.pdf",
+                    "last_modified": "2018-04-04T01:01:01.000001Z",
+                    "filename": "clarification-qux.pdf",
                 },
                 {
-                    "path": "g-things-23/communications/updates/clarifiactions/clarification-2.pdf",
-                    "last_modified": "2018-07-25T02:02:02.000002Z"  # Test GMT/BST pretty formatting while we're here
+                    "path": "g-things-23/communications/updates/clarifications/clarification-dax.pdf",
+                    "last_modified": "2018-07-25T02:02:02.000002Z",
+                    "filename": "clarification-dax.pdf",
                 },
             ],
+        }[prefix]
+        response = self.client.get("/admin/communications/{}".format(self.framework_slug))
+        assert response.status_code == 200
+        doc = html.fromstring(response.get_data(as_text=True))
+
+        assert tuple(
+            tuple(
+                (
+                    # date text
+                    row.xpath("normalize-space(string(./td[1]))"),
+                    # download href
+                    row.xpath("./td[2]//a/@href")[0],
+                    # download text
+                    row.xpath("normalize-space(string(./td[2]//a))"),
+                    # delete href
+                    row.xpath("./td[3]//a[normalize-space(string())='Delete']/@href")[0],
+                ) for row in table.xpath(".//tr[@class='summary-item-row']")
+            ) for table in doc.xpath("//table[./caption[normalize-space(text())='Communications present']]")
+        ) == (
+            (
+                (
+                    'Monday 1 January 2018',
+                    '/admin/communications/g-things-23/files/communication/communication-foo.pdf',
+                    'document: clarification-foo.pdf',
+                    '/admin/communications/g-things-23/delete/communication/communication-foo.pdf',
+                ),
+                (
+                    'Friday 2 February 2018',
+                    '/admin/communications/g-things-23/files/communication/communication-bar.pdf',
+                    'document: clarification-bar.pdf',
+                    '/admin/communications/g-things-23/delete/communication/communication-bar.pdf',
+                ),
+                (
+                    'Saturday 3 March 2018',
+                    '/admin/communications/g-things-23/files/communication/communication-baz.pdf',
+                    'document: clarification-baz.pdf',
+                    '/admin/communications/g-things-23/delete/communication/communication-baz.pdf',
+                ),
+            ),
+        ) + ((
+            (
+                (
+                    'Wednesday 4 April 2018',
+                    '/admin/communications/g-things-23/files/clarification/clarification-qux.pdf',
+                    'document: clarification-qux.pdf',
+                    '/admin/communications/g-things-23/delete/clarification/clarification-qux.pdf',
+                ),
+                (
+                    'Wednesday 25 July 2018',
+                    '/admin/communications/g-things-23/files/clarification/clarification-dax.pdf',
+                    'document: clarification-dax.pdf',
+                    '/admin/communications/g-things-23/delete/clarification/clarification-dax.pdf',
+                ),
+            ),
+        ) if framework_status == "open" else ())
+
+        # find the form that has our submit button
+        form = doc.xpath(
+            "//form[@method='post'][@enctype='multipart/form-data'][.//input[@type='submit'][@value='Upload files']]"
+        )[0]
+        # should be a self-posting form
+        assert urljoin(
+            f"http://localhost/admin/communications/{self.framework_slug}",
+            form.attrib.get("action", ""),
+        ) == f"http://localhost/admin/communications/{self.framework_slug}"
+
+        assert form.xpath(".//input[@name='csrf_token']")
+        assert form.xpath(
+            ".//input[@name='communication'][@type='file']"
         )
-        self.data_api_client.get_framework.return_value = {"frameworks": {"status": "open"}}
-        response = self.client.get("/admin/communications/{}".format(self.framework_slug))
-        document = html.fromstring(response.get_data(as_text=True))
-        file_upload_messages = document.xpath('//p[@class="file-upload-existing-value"]')
+        assert bool(doc.xpath(
+            ".//input[@name='clarification'][@type='file']"
+        )) == (framework_status == "open")
 
-        assert len(file_upload_messages) == 2
-        assert file_upload_messages[0].text_content().strip() == "Last modified Saturday 3 March 2018 at 3:03am GMT"
-        assert file_upload_messages[1].text_content().strip() == "Last modified Wednesday 25 July 2018 at 3:02am BST"
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+        assert self.s3.mock_calls == [
+            mock.call("flop-slop-slap"),
+            mock.call().list('g-things-23/communications/updates/communications', load_timestamps=True),
+            mock.call().list('g-things-23/communications/updates/clarifications', load_timestamps=True),
+        ]
 
+
+class TestUploadCommunicationsView(_BaseTestCommunicationsView):
     def test_post_documents_for_framework(self):
-
         response = self.client.post(
-            "/admin/communications/{}".format(self.framework_slug),
+            f"/admin/communications/{self.framework_slug}",
             data={
                 'communication': (BytesIO(valid_pdf_bytes), 'test-comm.pdf'),
                 'clarification': (BytesIO(valid_pdf_bytes), 'test-clar.pdf'),
@@ -97,30 +198,52 @@ class TestCommunicationsView(LoggedInApplicationTest):
         )
 
         # check that we did actually mock-send two files
-        assert self.s3.return_value.save.call_count == 2
+        assert self.s3.mock_calls == [
+            mock.call('flop-slop-slap'),
+            mock.call().save(
+                f'{self.framework_slug}/communications/updates/communications/test-comm.pdf',
+                RestrictedAny(lambda other: other.filename == "test-comm.pdf"),
+                acl='bucket-owner-full-control',
+                download_filename='test-comm.pdf',
+            ),
+            mock.call().save(
+                f'{self.framework_slug}/communications/updates/clarifications/test-clar.pdf',
+                RestrictedAny(lambda other: other.filename == "test-clar.pdf"),
+                acl='bucket-owner-full-control',
+                download_filename='test-clar.pdf',
+            ),
+        ]
         self.assert_flashes('New communication was uploaded.')
         self.assert_flashes('New clarification was uploaded.')
 
         assert response.status_code == 302
+        # should basically be redirecting back to ourselves
+        assert urljoin(
+            f"http://localhost/admin/communications/{self.framework_slug}",
+            response.location,
+        ) == f"http://localhost/admin/communications/{self.framework_slug}"
 
     @pytest.mark.parametrize("disallowed_role", ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-manager"])
     def test_disallowed_roles_can_not_post_documents_for_framework(self, disallowed_role):
-
         self.user_role = disallowed_role
 
         response = self.client.post(
-            "/admin/communications/{}".format(self.framework_slug),
+            f"/admin/communications/{self.framework_slug}",
             data={
                 'communication': (BytesIO(valid_pdf_bytes), 'test-comm.pdf'),
                 'clarification': (BytesIO(valid_pdf_bytes), 'test-clar.pdf'),
             }
         )
         assert response.status_code == 403
+        # nothing was uploaded
+        assert self.s3.mock_calls == []
+
+        self.assert_no_flashes()
 
     def test_post_bad_documents_for_framework(self):
 
-        self.client.post(
-            "/admin/communications/{}".format(self.framework_slug),
+        response = self.client.post(
+            f"/admin/communications/{self.framework_slug}",
             data={
                 'communication': (BytesIO(valid_pdf_bytes), 'test-comm.unknown'),
                 'clarification': (BytesIO(valid_pdf_bytes), 'test-clar.unknown'),
@@ -130,36 +253,266 @@ class TestCommunicationsView(LoggedInApplicationTest):
         self.assert_flashes('Communication file is not an open document format or a CSV.', expected_category='error')
         self.assert_flashes('Clarification file is not a PDF.', expected_category='error')
 
-    def test_communications_file_saves_with_correct_path(self):
+        assert response.status_code == 302
+        # should basically be redirecting back to ourselves
+        assert urljoin(
+            f"http://localhost/admin/communications/{self.framework_slug}",
+            response.location,
+        ) == f"http://localhost/admin/communications/{self.framework_slug}"
 
-        response = self.client.post(
-            "/admin/communications/{}".format(self.framework_slug),
-            data={
-                'communication': (BytesIO(valid_pdf_bytes), 'test-comm.pdf'),
-            }
+        # nothing was uploaded
+        assert self.s3.mock_calls == [mock.call('flop-slop-slap')]
+
+
+class TestDownloadCommunicationsView(_BaseTestCommunicationsView):
+    @pytest.mark.parametrize("disallowed_role", ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-manager"])
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_disallowed_roles(self, comm_type, disallowed_role):
+        self.user_role = disallowed_role
+
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/files/{comm_type}/floating/foampool.pdf",
+        )
+        assert response.status_code == 403
+
+        # no signed url was created
+        assert self.s3.mock_calls == []
+
+        assert self.data_api_client.mock_calls == []
+
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_happy_path(self, comm_type):
+        self.s3.return_value.get_signed_url.return_value = "https://bounded.in.barrels/green/goldenly/lagoons.pdf"
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/files/{comm_type}/floating/foampool.pdf",
         )
 
         assert response.status_code == 302
-        self.s3.return_value.save.assert_called_once_with(
-            '{}/communications/updates/communications/test-comm.pdf'.format(self.framework_slug),
-            mock.ANY,  # werkzeug.datastructures.FileStorage object we are saving to s3
-            acl='bucket-owner-full-control',
-            download_filename='test-comm.pdf'
+        assert response.location == "https://basket.market.net/green/goldenly/lagoons.pdf"
+
+        assert self.s3.mock_calls == [
+            mock.call('flop-slop-slap'),
+            mock.call().get_signed_url(
+                f'{self.framework_slug}/communications/updates/{comm_type}s/floating/foampool.pdf'
+            ),
+        ]
+        # should have checked framework exists
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+
+    def test_invalid_comm_type(self):
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/files/seasnakes/floating/foampool.pdf",
         )
 
-    def test_clarification_file_saves_with_correct_path(self):
+        assert response.status_code == 404
+
+        # no signed url was created
+        assert self.s3.mock_calls == []
+
+        assert self.data_api_client.mock_calls == []
+
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_non_present_file(self, comm_type):
+        self.s3.return_value.get_signed_url.return_value = None
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/files/{comm_type}/floating/foampool.pdf",
+        )
+
+        assert response.status_code == 404
+
+        assert self.s3.mock_calls == [
+            mock.call('flop-slop-slap'),
+            mock.call().get_signed_url(
+                f'{self.framework_slug}/communications/updates/{comm_type}s/floating/foampool.pdf'
+            ),
+        ]
+        # should have checked framework exists
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_spurious_double_dot(self, comm_type):
+        self.s3.return_value.get_signed_url.return_value = None
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/files/{comm_type}/../floating/foampool.pdf",
+        )
+
+        assert response.status_code == 404
+
+        assert self.s3.mock_calls == [
+            mock.call('flop-slop-slap'),
+            mock.call().get_signed_url(
+                # double-dots should be passed through to s3 which will similarly disregard them - no attempt to
+                # resolve them should be made
+                f'{self.framework_slug}/communications/updates/{comm_type}s/../floating/foampool.pdf'
+            ),
+        ]
+        # should have checked framework exists
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+
+
+class TestDeleteCommunicationsConfirmationPage(_BaseTestCommunicationsView):
+    @pytest.mark.parametrize("disallowed_role", ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-manager"])
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_disallowed_roles(self, comm_type, disallowed_role):
+        self.user_role = disallowed_role
+
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/delete/{comm_type}/floating/foampool.pdf",
+        )
+        assert response.status_code == 403
+
+        assert self.data_api_client.mock_calls == []
+        assert self.s3.mock_calls == []
+        self.assert_no_flashes()
+
+    def test_invalid_comm_type(self):
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/delete/seasnakes/floating/foampool.pdf",
+        )
+
+        assert response.status_code == 404
+        assert self.data_api_client.mock_calls == []
+        assert self.s3.mock_calls == []
+        self.assert_no_flashes()
+
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_happy_path(self, comm_type):
+        response = self.client.get(
+            f"/admin/communications/{self.framework_slug}/delete/{comm_type}/floating/foampool.pdf",
+        )
+        assert response.status_code == 200
+
+        doc = html.fromstring(response.get_data(as_text=True))
+        assert doc.xpath(
+            "//*[normalize-space(string())=$t]",
+            t=(
+                f"Are you sure you want to delete the {self.framework_stub.response()['name']} {comm_type} "
+                "file ‘floating/foampool.pdf’?"
+            ),
+        )
+
+        # find the form that has our submit button
+        form = doc.xpath(
+            "//form[@method='POST'][.//input[@name='csrf_token']]"
+            "[.//input[@type='submit'][@name='confirm'][@value='Delete file']]"
+        )[0]
+        # should be a self-posting form
+        assert urljoin(
+            f"http://localhost/admin/communications/{self.framework_slug}/delete/{comm_type}/floating/foampool.pdf",
+            form.attrib.get("action", ""),
+        ) == f"http://localhost/admin/communications/{self.framework_slug}/delete/{comm_type}/floating/foampool.pdf"
+
+        # should have checked framework exists
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+        # no use of bucket in GET request
+        assert self.s3.mock_calls == []
+        self.assert_no_flashes()
+
+
+class TestDeleteCommunicationsPost(_BaseTestCommunicationsView):
+    @pytest.mark.parametrize("disallowed_role", ["admin", "admin-ccs-category", "admin-ccs-sourcing", "admin-manager"])
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_disallowed_roles(self, comm_type, disallowed_role):
+        self.user_role = disallowed_role
 
         response = self.client.post(
-            "/admin/communications/{}".format(self.framework_slug),
-            data={
-                'clarification': (BytesIO(valid_pdf_bytes), 'test-comm.pdf'),
-            }
+            f"/admin/communications/{self.framework_slug}/delete/{comm_type}/floating/foampool.pdf",
+            data={"confirm": "Delete file"},
+        )
+        assert response.status_code == 403
+
+        assert self.data_api_client.mock_calls == []
+        assert self.s3.mock_calls == []
+        self.assert_no_flashes()
+
+    def test_invalid_comm_type(self):
+        response = self.client.post(
+            f"/admin/communications/{self.framework_slug}/delete/seasnakes/floating/foampool.pdf",
+            data={"confirm": "Delete file"},
         )
 
-        assert response.status_code == 302
-        self.s3.return_value.save.assert_called_once_with(
-            '{}/communications/updates/clarifications/test-comm.pdf'.format(self.framework_slug),
-            mock.ANY,  # werkzeug.datastructures.FileStorage object we are saving to s3
-            acl='bucket-owner-full-control',
-            download_filename='test-comm.pdf'
+        assert response.status_code == 404
+        assert self.data_api_client.mock_calls == []
+        assert self.s3.mock_calls == []
+        self.assert_no_flashes()
+
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    @pytest.mark.parametrize("file_path", (
+        "floating/foampool.pdf",
+        "floating/../../../foampool.pdf",  # spurious double-dots shouldn't be resolved
+    ))
+    def test_happy_path(self, comm_type, file_path):
+        self.s3.return_value.path_exists.return_value = True
+        response = self.client.post(
+            f"/admin/communications/{self.framework_slug}/delete/{comm_type}/{file_path}",
+            data={"confirm": "Delete file"},
         )
+        assert response.status_code == 302
+        assert urljoin(
+            f"http://localhost/admin/communications/{self.framework_slug}/delete/{comm_type}/{file_path}",
+            response.location,
+        ) == f"http://localhost/admin/communications/{self.framework_slug}"
+
+        # should have checked framework exists
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+
+        assert self.s3.mock_calls == [
+            mock.call('flop-slop-slap'),
+            mock.call().path_exists(
+                f'{self.framework_slug}/communications/updates/{comm_type}s/{file_path}'
+            ),
+            mock.call().delete_key(f'{self.framework_slug}/communications/updates/{comm_type}s/{file_path}'),
+        ]
+        self.assert_flashes(
+            f"{comm_type.capitalize()} ‘{file_path}’ was "
+            f"deleted for {self.framework_stub.response()['name']}."
+        )
+
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_file_not_present(self, comm_type):
+        self.s3.return_value.path_exists.return_value = False
+        response = self.client.post(
+            f"/admin/communications/{self.framework_slug}/delete/{comm_type}/floating/foampool.pdf",
+            data={"confirm": "Delete file"},
+        )
+        assert response.status_code == 404
+
+        # should have checked framework exists
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+
+        assert self.s3.mock_calls == [
+            mock.call('flop-slop-slap'),
+            mock.call().path_exists(f'{self.framework_slug}/communications/updates/{comm_type}s/floating/foampool.pdf'),
+            # no deletion call
+        ]
+        self.assert_no_flashes()
+
+    @pytest.mark.parametrize("comm_type", ("communication", "clarification",))
+    def test_not_confirmed(self, comm_type):
+        self.s3.return_value.path_exists.return_value = True
+        response = self.client.post(
+            f"/admin/communications/{self.framework_slug}/delete/{comm_type}/floating/foampool.pdf",
+            data={"maybe": "perhaps"},
+        )
+        assert response.status_code == 400
+
+        # should have checked framework exists
+        assert self.data_api_client.mock_calls == [
+            mock.call.get_framework(self.framework_slug)
+        ]
+
+        # no bucket actions took place
+        assert self.s3.mock_calls == []
+        self.assert_no_flashes()

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -303,7 +303,7 @@ class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):
 
         assert bool(document.xpath('.//a[contains(text(),"agreements")]')) == agreements_shown
         assert bool(document.xpath('.//a[contains(text(),"View application statistics")]')) == stats_shown
-        assert bool(document.xpath('.//a[contains(text(),"Upload communications")]')) == comms_shown
+        assert bool(document.xpath('.//a[contains(text(),"Manage communications")]')) == comms_shown
         assert bool(document.xpath('.//a[contains(text(),"Contact suppliers")]')) == contact_shown
 
     @pytest.mark.parametrize("role, link_should_be_visible, expected_link_text", [
@@ -354,11 +354,11 @@ class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):
         ("admin-manager", False),
         ("admin-ccs-data-controller", False),
     ])
-    def test_framework_action_list_includes_upload_communications(self, role, link_should_be_visible):
+    def test_framework_action_list_includes_manage_communications(self, role, link_should_be_visible):
         self.user_role = role
         response = self.client.get('/admin')
         document = html.fromstring(response.get_data(as_text=True))
-        link_is_visible = bool(document.xpath('.//a[contains(text(),"Upload communications")]'))
+        link_is_visible = bool(document.xpath('.//a[contains(text(),"Manage communications")]'))
 
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "cannot" if link_should_be_visible else "can")


### PR DESCRIPTION
https://trello.com/c/jZVhvJRA

I doing this I had to implement a number of extra things that weren't in the original card. The existing upload interface was extremely minimal.

To allow admins to choose a file to delete we first have to give them a listing of files which it didn't previously have.

![image](https://user-images.githubusercontent.com/807447/60348292-29270a00-99b7-11e9-9430-2e70844d536d.png)


Then if admins are supposed to be certain about the file they're about to delete, we really _have_ to give them the ability to download that file first, an ability it was missing.

Then of course the delete interface really did need to have a "confirm" page.

![image](https://user-images.githubusercontent.com/807447/60348345-48259c00-99b7-11e9-90ff-c843d3e50695.png)

~The code is basically done, when I'm still working on is the element layout etc - I'll add more details of this on the trello card because I could do with some opinions...~