### PR TITLE
Fix unapproved services to fallback to supplierId

### DIFF
--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -45,7 +45,7 @@
               field_headings_visible=True
             ) %}
               {% call summary.row() %}
-                {{ summary.field_name(item.data.supplierName, wide=True) }}
+                {{ summary.field_name(item.data.get('supplierName', item.data.supplierId), wide=True) }}
                 {% call summary.field() %}
                   {{ item.data.serviceId }}
                 {% endcall %}
@@ -57,7 +57,7 @@
                 {{ summary.edit_link(
                   "View changes",
                   url_for('.service_updates', service_id=item.data.serviceId),
-                  hidden_text="for " + item.data.supplierName
+                  hidden_text="for " + item.data.get('supplierName', item.data.supplierId)
                 ) }}
               {% endcall %}
             {% endcall %}


### PR DESCRIPTION
https://trello.com/c/JSPtBsU5/933-bug-in-admin-frontend

Some audit events do not have supplierName but have supplierId. This PR changes the service approval flow to handle this case. As the ticket notes this is just a short term fix to get the admin frontend working again while we find out what's producing the bad audit events.