### PR TITLE
find_user_by_email_address view: enable for admin-ccs-data-controller role

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -14,7 +14,7 @@ CLOSED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
 
 
 @main.route('/users', methods=['GET'])
-@role_required('admin', 'admin-ccs-category')
+@role_required('admin', 'admin-ccs-category', 'admin-ccs-data-controller')
 def find_user_by_email_address():
     users = None
     email_address = None

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,6 +18,10 @@
 
   {% if current_user.has_any_role('admin-ccs-data-controller') %}
         {# ADMIN CCS DATA CONTROLLER #}
+        <h3 class="heading-xmedium">Search for users</h3>
+        <p>
+            <a href="{{ url_for('.find_user_by_email_address') }}">Find a user by email</a>
+        </p>
         <h3 class="heading-xmedium">Search for suppliers</h3>
         <p>
             <a href="{{ url_for('.search_suppliers_and_services') }}">View and edit suppliers</a>

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -64,7 +64,7 @@ class TestIndex(LoggedInApplicationTest):
         ("admin-ccs-sourcing", False),
         ("admin-framework-manager", False),
         ("admin-manager", False),
-        ("admin-ccs-data-controller", False),
+        ("admin-ccs-data-controller", True),
     ])
     def test_find_a_user_by_email_link_is_shown_to_users_with_right_roles(self, role, link_should_be_visible):
         self.user_role = role

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -26,7 +26,7 @@ class TestUsersView(LoggedInApplicationTest):
         ("admin-ccs-sourcing", 403),
         ("admin-manager", 403),
         ("admin-framework-manager", 403),
-        ("admin-ccs-data-controller", 403),
+        ("admin-ccs-data-controller", 200),
     ])
     def test_find_users_page_is_only_accessible_to_specific_user_roles(self, role, expected_code):
         self.user_role = role


### PR DESCRIPTION
Straightforward fix for https://trello.com/c/dBEA3HaN

Required adding this to the data controller's front page, so now it looks like this:

![image](https://user-images.githubusercontent.com/807447/62631082-0ed23b80-b928-11e9-98ae-b650540d0067.png)
