### PR TITLE
Strip whitespace from DUNS number, or default to empty string

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -65,9 +65,11 @@ def find_suppliers():
         suppliers = [data_api_client.get_supplier(request.args.get("supplier_id"))['suppliers']]
         links = {}
     else:
+        duns_number = request.args.get("supplier_duns_number").strip() \
+            if request.args.get("supplier_duns_number") else None
         suppliers_response = data_api_client.find_suppliers(
             name=request.args.get("supplier_name"),
-            duns_number=request.args.get("supplier_duns_number"),
+            duns_number=duns_number,
             company_registration_number=request.args.get("supplier_company_registration_number"),
             page=request.args.get("page", 1)  # API will validate page number values
         )

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -451,9 +451,10 @@ class TestSuppliersListView(LoggedInApplicationTest):
             name="foo", duns_number=None, company_registration_number=None, page=1
         )
 
-    def test_should_search_by_duns_number(self):
+    @pytest.mark.parametrize("duns_number", ["987654321", " 987654321", "987654321 ", " 987654321 "])
+    def test_should_search_by_duns_number(self, duns_number):
         self.data_api_client.find_suppliers.side_effect = HTTPError(Response(404))
-        self.client.get("/admin/suppliers?supplier_duns_number=987654321")
+        self.client.get(f"/admin/suppliers?supplier_duns_number={duns_number}")
 
         self.data_api_client.find_suppliers.assert_called_once_with(
             name=None, duns_number="987654321", company_registration_number=None, page=1


### PR DESCRIPTION
We noticed that users were getting errors when they copy-pasted DUNS numbers as whitespaces were being introduced. This change will strip out trailing and leading whitespaces if the user has input a DUNS, and leave it as None if not.

I've also added a test to check that it works

[Ticket](https://trello.com/c/wKXRk59y/98-strip-whitespace-from-admin-duns-searches)