### PR TITLE
"view supplier declaration": show value of onFramework as "Application status"

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -320,20 +320,21 @@ def view_supplier_declaration(supplier_id, framework_slug):
     if framework['status'] not in ['pending', 'standstill', 'live']:
         abort(403)
     try:
-        declaration = data_api_client.get_supplier_declaration(supplier_id, framework_slug)['declaration']
+        sf = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)["frameworkInterest"]
     except APIError as e:
         if e.status_code != 404:
             raise
-        declaration = {}
+        sf = {}
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration)
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf.get("declaration", {}))
 
     return render_template(
         "suppliers/view_declaration.html",
         supplier=supplier,
         framework=framework,
-        declaration=declaration,
-        content=content
+        supplier_framework=sf,
+        declaration=sf.get("declaration", {}),
+        content=content,
     )
 
 

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -39,6 +39,15 @@
       {% endwith %}
     </div>
   </div>
+  {% call summary.mapping_table(
+    caption="Application status",
+    field_headings_visible=False
+  ) %}
+    {% call summary.row() %}
+      {{ summary.field_name("Application status") }}
+      {{ summary.text("Pass" if supplier_framework.onFramework else ("Fail" if supplier_framework.onFramework is sameas false else "Pending")) }}
+    {% endcall %}
+  {% endcall %}
 
   {% for section in content.summary(declaration) %}
     {{ summary.heading(section.name) }}


### PR DESCRIPTION
https://trello.com/c/w90E7y1T

Not exceptionally pretty, but works. `True`/`False`/`None` are transformed into "Pass" "Fail" and "Pending" respectively.

![Spectacle X22828](https://user-images.githubusercontent.com/807447/62876122-280a2c00-bd1c-11e9-99cf-e49eeaee103c.png)
