### PR TITLE
view_supplier_declaration: enable view for "expired" frameworks 

### DIFF
--- a/app/main/helpers/supplier_details.py
+++ b/app/main/helpers/supplier_details.py
@@ -46,7 +46,10 @@ def get_supplier_frameworks_visible_for_role(supplier_frameworks, current_user, 
 
     visible_supplier_frameworks = []
     for supplier_framework in supplier_frameworks:
-        if framework_info.get(supplier_framework["frameworkSlug"], {}).get("status") in useful_statuses:
+        if (
+            framework_info.get(supplier_framework["frameworkSlug"], {}).get("status") in useful_statuses
+            and supplier_framework.get("declaration")
+        ):
             # Save the framework name to the SupplierFramework for use in template
             supplier_framework['frameworkName'] = framework_info.get(supplier_framework["frameworkSlug"], {})['name']
             visible_supplier_frameworks.append(supplier_framework)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -31,7 +31,8 @@ from ..helpers.countries import COUNTRY_TUPLE
 from ..helpers.pagination import get_nav_args_from_api_response_links
 from ..helpers.supplier_details import (
     get_supplier_frameworks_visible_for_role,
-    get_company_details_from_supplier
+    get_company_details_from_supplier,
+    DEPRECATED_FRAMEWORK_SLUGS,
 )
 from ... import data_api_client, content_loader
 
@@ -315,9 +316,12 @@ def edit_supplier_duns_number(supplier_id):
 @main.route('/suppliers/<int:supplier_id>/edit/declarations/<string:framework_slug>', methods=['GET'])
 @role_required('admin-ccs-sourcing')
 def view_supplier_declaration(supplier_id, framework_slug):
+    if framework_slug in DEPRECATED_FRAMEWORK_SLUGS:
+        abort(404)
+
     supplier = data_api_client.get_supplier(supplier_id)['suppliers']
     framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if framework['status'] not in ['pending', 'standstill', 'live']:
+    if framework['status'] not in ('pending', 'standstill', 'live', 'expired',):
         abort(403)
     try:
         sf = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)["frameworkInterest"]

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -141,9 +141,12 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
         self.data_api_client = self.data_api_client_patch.start()
         self.data_api_client.get_supplier_frameworks.return_value = {
             "frameworkInterest": [
-                SupplierFrameworkStub(framework_slug="g-cloud-10").response(),
-                SupplierFrameworkStub(framework_slug="digital-outcomes-and-specialists-3").response(),
-                SupplierFrameworkStub(framework_slug="g-cloud-11").response(),
+                SupplierFrameworkStub(framework_slug="g-cloud-10", declaration={"foo": "bar"}).response(),
+                SupplierFrameworkStub(
+                    framework_slug="digital-outcomes-and-specialists-3",
+                    declaration={"foo": "bar"},
+                ).response(),
+                SupplierFrameworkStub(framework_slug="g-cloud-11", declaration={"foo": "bar"}).response(),
             ]
         }
 
@@ -174,9 +177,10 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
     ):
         self.user_role = role
         self.data_api_client.get_supplier_frameworks.return_value["frameworkInterest"].extend((
-            SupplierFrameworkStub(framework_slug="g-cloud-standstill-1").response(),
-            SupplierFrameworkStub(framework_slug="g-cloud-pending-1").response(),
-            SupplierFrameworkStub(framework_slug="g-cloud-open-1").response(),
+            SupplierFrameworkStub(framework_slug="g-cloud-standstill-1", declaration={"foo": "bar"}).response(),
+            SupplierFrameworkStub(framework_slug="g-cloud-pending-1", declaration={"foo": "bar"}).response(),
+            SupplierFrameworkStub(framework_slug="g-cloud-open-1", declaration={"foo": "bar"}).response(),
+            SupplierFrameworkStub(framework_slug="g-cloud-expired-1").response(),
         ))
 
         self.data_api_client.find_frameworks.return_value = {'frameworks': [
@@ -203,6 +207,10 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
             FrameworkStub(
                 status="open",
                 slug="g-cloud-open-1"
+            ).response(),
+            FrameworkStub(
+                status="expired",
+                slug="g-cloud-expired-1"
             ).response(),
             FrameworkStub(
                 id=0,

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1698,12 +1698,14 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         self.data_api_client.get_framework.assert_called_once_with('g-cloud-7')
         self.data_api_client.get_supplier_framework_info.assert_called_once_with(1234, 'g-cloud-7')
 
+    @pytest.mark.parametrize("framework_status", ("live", "pending", "standstill", "expired",))
     @pytest.mark.parametrize("on_framework,expected_application_status", (
         (True, "Pass"),
         (False, "Fail"),
         (None, "Pending"),
     ))
-    def test_should_show_declaration(self, on_framework, expected_application_status):
+    def test_should_show_declaration(self, on_framework, expected_application_status, framework_status):
+        self.data_api_client.get_framework.return_value["frameworks"]["status"] = framework_status
         self.data_api_client.get_supplier_framework_info.return_value["frameworkInterest"]["onFramework"] = \
             on_framework
 
@@ -1730,12 +1732,14 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
             t2=expected_application_status,
         )
 
+    @pytest.mark.parametrize("framework_status", ("live", "pending", "standstill", "expired",))
     @pytest.mark.parametrize("on_framework,expected_application_status", (
         (True, "Pass"),
         (False, "Fail"),
         (None, "Pending"),
     ))
-    def test_should_show_dos_declaration(self, on_framework, expected_application_status):
+    def test_should_show_dos_declaration(self, on_framework, expected_application_status, framework_status):
+        self.data_api_client.get_framework.return_value["frameworks"]["status"] = framework_status
         self.data_api_client.get_supplier_framework_info.return_value["frameworkInterest"]["onFramework"] = \
             on_framework
 
@@ -1767,6 +1771,15 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
 
         response = self.client.get('/admin/suppliers/1234/edit/declarations/digital-outcomes-and-specialists')
         assert response.status_code == 403
+
+    def test_should_404_if_framework_is_deprecated(self):
+        self.data_api_client.get_framework.return_value['frameworks']['status'] = FrameworkStub(
+            slug="g-cloud-4",
+            status="expired",
+        )
+
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-4')
+        assert response.status_code == 404
 
 
 class TestEditingASupplierDeclaration(LoggedInApplicationTest):


### PR DESCRIPTION
This started out as https://trello.com/c/R9x4f7te but as you can see from that ticket this morphed a bit.

What we're now doing is enabling the "view declaration" view for `expired` frameworks. This was previously prevented (which is what was causing the 403 mentioned in the ticket).

This also makes sure `supplierFramework`s which don't have a declaration don't even show in the table on the `supplier_details` page, as there's nothing useful that can be done with such `supplierFramework`s from here.