### PR TITLE
Enumerate declaration questions

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from itertools import groupby
+from itertools import groupby, chain
 from operator import itemgetter
 
 from dateutil.parser import parse as parse_date
@@ -327,6 +327,14 @@ def view_supplier_declaration(supplier_id, framework_slug):
         sf = {}
 
     content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf.get("declaration", {}))
+    declaration_sections = content.sections
+    question_numbers = OrderedDict(
+        (question.id, question.number,)
+        for question in sorted(
+            chain.from_iterable(section.questions for section in declaration_sections),
+            key=lambda question: question.number
+        )
+    )
 
     return render_template(
         "suppliers/view_declaration.html",
@@ -335,6 +343,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
         supplier_framework=sf,
         declaration=sf.get("declaration", {}),
         content=content,
+        question_number_dict=question_numbers
     )
 
 

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -57,11 +57,13 @@
       caption="Declaration",
       empty_message="This supplier not made a declaration",
       field_headings=[
+        'Question number',
         'Declaration question',
         'Declaration answer'
       ]
     ) %}
       {% call summary.row() %}
+        {{ summary.text(question_number_dict[item.id]) }}
         {{ summary.field_name(item.question) }}
         {{ summary[item.type](item.value) }}
       {% endcall %}

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1703,9 +1703,17 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         assert response.status_code == 200
-        assert document.cssselect('h2 + * + .summary-item-body')[0].cssselect(
-            '.summary-item-row td.summary-item-field'
-        )[0].text_content().strip() == "Yes"
+
+        first_answer_row = document.cssselect('h2 + * + .summary-item-body')[0]
+        # This row should have a number, a question, and an answer
+        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[0].text_content().strip() == "1"
+        assert first_answer_row.cssselect(
+            '.summary-item-row td.summary-item-field-first'
+        )[0].text_content().strip() == \
+            "Do you accept the terms of participation as described in Attachment 4 of the supplier pack (ZIP, 4.3MB)?"
+        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[1].text_content().strip() == "Yes"
+
+        # Application status at the top of the page
         assert document.xpath(
             "//*[contains(@class, 'summary-item-row')]"
             "[./*[1][contains(@class, 'summary-item-field')][normalize-space(string())=$t1]]"
@@ -1727,9 +1735,17 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         assert response.status_code == 200
-        assert document.cssselect('h2 + * + .summary-item-body')[0].cssselect(
-            '.summary-item-row td.summary-item-field'
-        )[0].text_content().strip() == "Yes"
+
+        first_answer_row = document.cssselect('h2 + * + .summary-item-body')[0]
+        # This row should have a number, a question, and an answer
+        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[0].text_content().strip() == "1"
+        assert first_answer_row.cssselect(
+            '.summary-item-row td.summary-item-field-first'
+        )[0].text_content().strip() == \
+            "Do you agree to comply with the terms of the Digital Outcomes and Specialists " \
+            "Invitation to Tender (ZIP, 3.2MB)?"
+        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[1].text_content().strip() == "Yes"
+
         assert document.xpath(
             "//*[contains(@class, 'summary-item-row')]"
             "[./*[1][contains(@class, 'summary-item-field')][normalize-space(string())=$t1]]"


### PR DESCRIPTION
https://trello.com/c/xo8bObtV/222-add-question-numbers-to-the-admin-declaration-view

Not the prettiest layout ever in terms of spacing, but it does the job and includes accessibility text for the header row. I didn't want to hack the `summary.table` macros any more than they are already.

The enumeration code is copied from the script that generates the failure/discretionary report (see ticket), so the numbers should match what CCS Admins are looking for. For reference, suppliers only see the question numbers on the Supplier FE when they're filling out the forms, not on the overview page (i.e. once applications have closed, they won't see the question numbers).

![declaration-questions-admin](https://user-images.githubusercontent.com/3492540/63358339-c91f6500-c362-11e9-9046-29dafab7db21.png)
 