### PR TITLE
Prevent admins accidentally introducting whitespace

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -146,7 +146,7 @@ def edit_supplier_name(supplier_id):
 @role_required('admin', 'admin-ccs-category', 'admin-ccs-data-controller')
 def update_supplier_name(supplier_id):
     supplier = data_api_client.get_supplier(supplier_id)
-    new_supplier_name = request.form.get('new_supplier_name', '')
+    new_supplier_name = request.form.get('new_supplier_name', '').strip()
 
     data_api_client.update_supplier(
         supplier['suppliers']['id'], {'name': new_supplier_name}, current_user.email_address

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1397,12 +1397,13 @@ class TestUpdatingSupplierDetails(LoggedInApplicationTest):
         super().teardown_method(method)
 
     @pytest.mark.parametrize("allowed_role", ["admin", "admin-ccs-category", "admin-ccs-data-controller"])
-    def test_admin_and_ccs_category_roles_can_update_supplier_name(self, allowed_role):
+    @pytest.mark.parametrize('company_name', [' Something New', ' Something New ', 'Something New'])
+    def test_admin_and_ccs_category_roles_can_update_supplier_name(self, allowed_role, company_name):
         self.user_role = allowed_role
         self.data_api_client.get_supplier.return_value = {"suppliers": {"id": 1234, "name": "Something Old"}}
         response = self.client.post(
             '/admin/suppliers/1234/edit/name',
-            data={'new_supplier_name': 'Something New'}
+            data={'new_supplier_name': company_name}
         )
         assert response.status_code == 302
         assert response.location == 'http://localhost/admin/suppliers/1234'


### PR DESCRIPTION
We've found five examples of admins accidentally introducing whitespace to company names. When a leading whitespace is added to a company's name, they're moved to the numerical section of the A-Z. This is not optimal for being found! I've now implemented a small tweak to make sure any accidental spaces are stripped out prior to being sent to the API.

I've also added a test. [Ticket](https://trello.com/c/rJR7w9nB/216-supplier-a-z-is-treating-leading-spaces-as-numeric)