### PR TITLE
Show pass/fail status of declaration answers to Sourcing admins

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -332,13 +332,18 @@ def view_supplier_declaration(supplier_id, framework_slug):
 
     content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf.get("declaration", {}))
     declaration_sections = content.sections
-    question_numbers = OrderedDict(
-        (question.id, question.number,)
+    question_content = OrderedDict(
+        (question.id, question)
         for question in sorted(
             chain.from_iterable(section.questions for section in declaration_sections),
             key=lambda question: question.number
         )
     )
+    # Enhance question_content with any nested questions
+    for question in chain.from_iterable(section.questions for section in declaration_sections):
+        if question.type == 'multiquestion':
+            for q in question.questions:
+                question_content[q.id] = q
 
     return render_template(
         "suppliers/view_declaration.html",
@@ -347,7 +352,7 @@ def view_supplier_declaration(supplier_id, framework_slug):
         supplier_framework=sf,
         declaration=sf.get("declaration", {}),
         content=content,
-        question_number_dict=question_numbers
+        question_content=question_content
     )
 
 

--- a/app/templates/suppliers/_declaration_pass_fail.html
+++ b/app/templates/suppliers/_declaration_pass_fail.html
@@ -1,0 +1,19 @@
+{% import "toolkit/summary-table.html" as summary %}
+{% with
+    pass_values = q_content.get('assessment', {}).get('passIfIn', []),
+    discretionary = q_content.get('assessment', {}).get('discretionary')
+%}
+    {% if pass_values %}
+        {% with pass_fail = 'Pass' if (q.value in pass_values) else ('Discretionary' if discretionary else 'Fail') %}
+          {% if multiquestion %}
+            <p>{{ pass_fail }}</p>
+          {% else %}
+            {{ summary.text(pass_fail)}}
+          {% endif %}
+        {% endwith %}
+    {% else %}
+        {% if not multiquestion %}
+          {{ summary.text('Not applicable') }}
+        {% endif %}
+    {% endif %}
+{% endwith %}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -59,13 +59,30 @@
       field_headings=[
         'Question number',
         'Declaration question',
-        'Declaration answer'
+        'Declaration answer',
+        'Pass/Fail'
       ]
     ) %}
       {% call summary.row() %}
-        {{ summary.text(question_number_dict[item.id]) }}
+        {{ summary.text(question_content[item.id].number) }}
         {{ summary.field_name(item.question) }}
         {{ summary[item.type](item.value) }}
+
+        {% if item.type == 'multiquestion' %}
+            {% call summary.field() %}
+            <div class="multiquestion">
+            {% for question in item.questions %}
+                {% with q=question, q_content=question_content[question.id], multiquestion=True %}
+                    <p>{% include "suppliers/_declaration_pass_fail.html" %}</p>
+                {% endwith %}
+            {% endfor %}
+            </div>
+            {% endcall %}
+        {% else %}
+            {% with q=item, q_content=question_content[item.id], multiquestion=False %}
+                {% include "suppliers/_declaration_pass_fail.html" %}
+            {% endwith %}
+        {% endif %}
       {% endcall %}
     {% endcall %}
   {% endfor %}

--- a/tests/app/fixtures/frameworks.json
+++ b/tests/app/fixtures/frameworks.json
@@ -426,6 +426,49 @@
       "slug": "g-cloud-9",
       "status": "open",
       "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": true,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 11,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 9,
+          "name": "Cloud hosting",
+          "oneServiceLimit": false,
+          "slug": "cloud-hosting",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 10,
+          "name": "Cloud software",
+          "oneServiceLimit": false,
+          "slug": "cloud-software",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 11,
+          "name": "Cloud support",
+          "oneServiceLimit": false,
+          "slug": "cloud-support",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 11",
+      "slug": "g-cloud-11",
+      "status": "open",
+      "variations": {}
     }
   ]
 }

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1716,13 +1716,17 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         assert response.status_code == 200
 
         first_answer_row = document.cssselect('h2 + * + .summary-item-body')[0]
-        # This row should have a number, a question, and an answer
-        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[0].text_content().strip() == "1"
-        assert first_answer_row.cssselect(
-            '.summary-item-row td.summary-item-field-first'
-        )[0].text_content().strip() == \
+        # The first row should have a number, a question, an answer and a pass/fail
+        question_number_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[0]
+        question_text_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field-first')[0]
+        supplier_answer_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[1]
+        pass_fail_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[2]
+
+        assert question_number_column.text_content().strip() == "1"
+        assert question_text_column.text_content().strip() == \
             "Do you accept the terms of participation as described in Attachment 4 of the supplier pack (ZIP, 4.3MB)?"
-        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[1].text_content().strip() == "Yes"
+        assert supplier_answer_column.text_content().strip() == "Yes"
+        assert pass_fail_column.text_content().strip() == "Not applicable"
 
         # Application status at the top of the page
         assert document.xpath(
@@ -1750,14 +1754,18 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         assert response.status_code == 200
 
         first_answer_row = document.cssselect('h2 + * + .summary-item-body')[0]
-        # This row should have a number, a question, and an answer
-        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[0].text_content().strip() == "1"
-        assert first_answer_row.cssselect(
-            '.summary-item-row td.summary-item-field-first'
-        )[0].text_content().strip() == \
+        # The first row should have a number, a question, an answer and a pass/fail
+        question_number_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[0]
+        question_text_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field-first')[0]
+        supplier_answer_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[1]
+        pass_fail_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[2]
+
+        assert question_number_column.text_content().strip() == "1"
+        assert question_text_column.text_content().strip() == \
             "Do you agree to comply with the terms of the Digital Outcomes and Specialists " \
             "Invitation to Tender (ZIP, 3.2MB)?"
-        assert first_answer_row.cssselect('.summary-item-row td.summary-item-field')[1].text_content().strip() == "Yes"
+        assert supplier_answer_column.text_content().strip() == "Yes"
+        assert pass_fail_column.text_content().strip() == "Not applicable"
 
         assert document.xpath(
             "//*[contains(@class, 'summary-item-row')]"

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -20,6 +20,66 @@ from dmtestutils.fixtures import valid_pdf_bytes
 from ...helpers import LoggedInApplicationTest, Response
 
 
+G11_DECLARATION = {
+    "servicesHaveOrSupportCloudHostingCloudSoftware": "Yes",
+    "servicesHaveOrSupportCloudSupport": "No",
+    "servicesDoNotInclude": True,
+    "subcontracting": [
+        "as a prime contractor, using third parties (subcontractors) to provide some services"
+    ],
+    "10WorkingDays": True,
+    "GAAR": False,
+    "MI": True,
+    "accurateInformation": True,
+    "accuratelyDescribed": True,
+    "bankrupt": False,
+    "canProvideFromDayOne": True,
+    "confidentialInformation": False,
+    "conflictOfInterest": False,
+    "conspiracy": False,
+    "contactEmailContractNotice": "anne@example.com",
+    "contactNameContractNotice": "Anne Ltd",
+    "corruptionBribery": False,
+    "distortedCompetition": False,
+    "distortingCompetition": False,
+    "employersInsurance": "Yes – your organisation has, or will have in place, employer’s liability insurance "
+                          "of at least £5 million and you will provide certification before the framework is "
+                          "awarded.",
+    "environmentalSocialLabourLaw": False,
+    "environmentallyFriendly": True,
+    "equalityAndDiversity": True,
+    "fraudAndTheft": False,
+    "fullAccountability": True,
+    "graveProfessionalMisconduct": False,
+    "helpBuyersComplyTechnologyCodesOfPractice": True,
+    "influencedContractingAuthority": False,
+    "informationChanges": True,
+    "misleadingInformation": False,
+    "offerServicesYourselves": True,
+    "organisedCrime": False,
+    "primaryContact": "Anne Example",
+    "primaryContactEmail": "anne@example.com",
+    "proofOfClaims": True,
+    "publishContracts": True,
+    "readUnderstoodGuidance": True,
+    "seriousMisrepresentation": False,
+    "termsAndConditions": True,
+    "termsOfParticipation": True,
+    "terrorism": False,
+    "understandHowToAskQuestions": True,
+    "understandTool": True,
+    "unfairCompetition": True,
+    "unspentTaxConvictions": False,
+    "witheldSupportingDocuments": False,
+    "modernSlaveryReportingRequirements": True,
+    "modernSlaveryStatement": "/path/to.pdf",
+    "modernSlaveryTurnover": True,
+    # Discretionary fail
+    "taxEvasion": True,
+    "mitigatingFactors": "Forgot to file tax return, oops",
+}
+
+
 class TestSupplierDetailsView(LoggedInApplicationTest):
 
     def setup_method(self, method):
@@ -1649,14 +1709,14 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         supplier_response = self.load_example_listing('supplier_response')
         self.data_api_client.get_supplier.return_value = supplier_response
 
-        framework_response = self.load_example_listing('framework_response')
+        framework_response = FrameworkStub(slug="g-cloud-11", status="pending").single_result_response()
         self.data_api_client.get_framework.return_value = framework_response
 
         sf_stub = SupplierFrameworkStub(
             framework_slug=framework_response["frameworks"]["slug"],
             supplier_id=supplier_response["suppliers"]["id"],
             on_framework=True,
-            declaration=self.load_example_listing('declaration_response')["declaration"]
+            declaration=G11_DECLARATION.copy()
         )
         self.data_api_client.get_supplier_framework_info.return_value = sf_stub.single_result_response()
 
@@ -1667,14 +1727,14 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
     def test_should_not_be_visible_to_admin_users(self):
         self.user_role = 'admin'
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-11')
 
         assert response.status_code == 403
 
     def test_should_404_if_supplier_does_not_exist(self):
         self.data_api_client.get_supplier.side_effect = APIError(Response(404))
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-11')
 
         assert response.status_code == 404
         self.data_api_client.get_supplier.assert_called_once_with(1234)
@@ -1683,50 +1743,61 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
     def test_should_404_if_framework_does_not_exist(self):
         self.data_api_client.get_framework.side_effect = APIError(Response(404))
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-11')
 
         assert response.status_code == 404
         self.data_api_client.get_supplier.assert_called_with(1234)
-        self.data_api_client.get_framework.assert_called_with('g-cloud-7')
+        self.data_api_client.get_framework.assert_called_with('g-cloud-11')
 
     def test_should_not_404_if_declaration_does_not_exist(self):
         self.data_api_client.get_supplier_framework_info.side_effect = APIError(Response(404))
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-11')
 
         assert response.status_code == 200
         self.data_api_client.get_supplier.assert_called_once_with(1234)
-        self.data_api_client.get_framework.assert_called_once_with('g-cloud-7')
-        self.data_api_client.get_supplier_framework_info.assert_called_once_with(1234, 'g-cloud-7')
+        self.data_api_client.get_framework.assert_called_once_with('g-cloud-11')
+        self.data_api_client.get_supplier_framework_info.assert_called_once_with(1234, 'g-cloud-11')
 
+    @pytest.mark.parametrize("row_number, expected_text", [
+        (0, ('1', "If you're submitting cloud hosting (lot 1) or cloud software (lot 2) services", "Yes", "Pass")),
+        (1, ('2', "If you're submitting a cloud support (lot 3) service", "No", "Fail")),
+        (16, ('17', "in breach of tax payments or social security contributions", "Yes", "Discretionary")),
+        (46, (
+            '47',
+            "Please confirm whether you will provide G-Cloud",
+            "as a prime contractor, using third parties (subcontractors) to provide some services",
+            "Not applicable"
+        )),
+    ])
     @pytest.mark.parametrize("framework_status", ("live", "pending", "standstill", "expired",))
     @pytest.mark.parametrize("on_framework,expected_application_status", (
         (True, "Pass"),
         (False, "Fail"),
         (None, "Pending"),
     ))
-    def test_should_show_declaration(self, on_framework, expected_application_status, framework_status):
+    def test_should_show_declaration(
+            self, on_framework, expected_application_status, framework_status, row_number, expected_text):
         self.data_api_client.get_framework.return_value["frameworks"]["status"] = framework_status
         self.data_api_client.get_supplier_framework_info.return_value["frameworkInterest"]["onFramework"] = \
             on_framework
 
-        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-7')
+        response = self.client.get('/admin/suppliers/1234/edit/declarations/g-cloud-11')
         document = html.fromstring(response.get_data(as_text=True))
 
         assert response.status_code == 200
+        answer_row = document.cssselect('h2 + * + .summary-item-body tr.summary-item-row')[row_number]
 
-        first_answer_row = document.cssselect('h2 + * + .summary-item-body')[0]
-        # The first row should have a number, a question, an answer and a pass/fail
-        question_number_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[0]
-        question_text_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field-first')[0]
-        supplier_answer_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[1]
-        pass_fail_column = first_answer_row.cssselect('.summary-item-row td.summary-item-field')[2]
+        # The row should have a number, a question, an answer and a pass/fail
+        question_number_column = answer_row.cssselect('td.summary-item-field')[0]
+        question_text_column = answer_row.cssselect('td.summary-item-field-first')[0]
+        supplier_answer_column = answer_row.cssselect('td.summary-item-field')[1]
+        pass_fail_column = answer_row.cssselect('td.summary-item-field')[2]
 
-        assert question_number_column.text_content().strip() == "1"
-        assert question_text_column.text_content().strip() == \
-            "Do you accept the terms of participation as described in Attachment 4 of the supplier pack (ZIP, 4.3MB)?"
-        assert supplier_answer_column.text_content().strip() == "Yes"
-        assert pass_fail_column.text_content().strip() == "Not applicable"
+        assert question_number_column.text_content().strip() == expected_text[0]
+        assert expected_text[1] in question_text_column.text_content().strip()
+        assert supplier_answer_column.text_content().strip() == expected_text[2]
+        assert pass_fail_column.text_content().strip() == expected_text[3]
 
         # Application status at the top of the page
         assert document.xpath(


### PR DESCRIPTION
https://trello.com/c/3AIJtJTX/224-highlight-wrong-answers-in-the-admin-declaration-view

![declaration-pass-fail](https://user-images.githubusercontent.com/3492540/63578605-bf774680-c588-11e9-983a-713b43ba8d9e.png)

Adds a column showing 'Pass', 'Fail', 'Discretionary' or 'Not Applicable' for each declaration answer. 'Not Applicable' means the answer is not assessed (for example, a supplier can't 'fail' on their contact email address).

Annoyingly the columns don't line up between sections. This is a known issue with this pattern anyway. However the Sourcing team users are not too worried about layout..

The Modern Slavery section contains a single 'multiquestion' type question with several nested questions - only one of these is assessed, so I haven't been particularly strict on how multiple results would be displayed here. Suggestions on a less messy Jinja approach very welcome.