### PR TITLE
set DM_COOKIE_PROBE_COOKIE_EXPECT_PRESENT, enabling cookie error page

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,8 @@ class Config(object):
 
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour
 
+    DM_COOKIE_PROBE_EXPECT_PRESENT = True
+
     DM_S3_DOCUMENT_BUCKET = None
     DM_DATA_API_URL = None
     DM_DATA_API_AUTH_TOKEN = None


### PR DESCRIPTION
https://trello.com/c/HsZ9mj7o

This should only ever show itself in place of a CSRF token failure, so should be a fairly safe thing to enable.