### PR TITLE
Add govuk-frontend-jinja extension

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from dmcontent.content_loader import ContentLoader
 from dmutils import init_app, formats
 from dmutils.timing import logged_duration
 from dmutils.user import User
+from govuk_frontend_jinja.flask_ext import init_govuk_frontend
 
 from config import configs
 
@@ -72,6 +73,9 @@ def create_app(config_name):
     application = Flask(__name__,
                         static_folder='static/',
                         static_url_path=configs[config_name].STATIC_URL_PATH)
+
+    # allow using govuk-frontend Nunjucks templates
+    init_govuk_frontend(application)
 
     init_app(
         application,

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -32,13 +32,20 @@
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
-  {%
+  {# {%
     with
     type = "save",
     label = "Search"
   %}
     {% include "toolkit/button.html" %}
-  {% endwith %}
+  {% endwith %} #}
+
+  {% from "components/button/macro.njk" import govukButton %}
+
+  {{ govukButton({
+    "text": "Search"
+  }) }}
+
   </form>
 
   {% call(item) summary.list_table(

--- a/config.py
+++ b/config.py
@@ -58,7 +58,8 @@ class Config(object):
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
         template_folders = [
-            os.path.join(repo_root, 'app/templates')
+            os.path.join(repo_root, 'app/templates'),
+            os.path.join(repo_root, 'node_modules/govuk-frontend'),
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -12,3 +12,4 @@ itsdangerous==0.24  # pyup: <1.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,12 +13,13 @@ itsdangerous==0.24  # pyup: <1.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.216
-botocore==1.12.216
+boto3==1.9.223
+botocore==1.12.223
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
@@ -55,6 +56,6 @@ s3transfer==0.2.1
 six==1.12.0
 unicodecsv==0.14.1
 urllib3==1.25.3
-Werkzeug==0.15.5
+Werkzeug==0.15.6
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
govuk-frontend-jinja converts nunjucks templates to jinja. This will
enable us to use GOV.UK components without re-creating each component
as a template.

There is a separate commit that demos GOV.UK Frontend button component being used.
The way we import components will change once we start rolling out govuk-frontend.

Trello Card: https://trello.com/c/W1SeD6ht