### PR TITLE
Update Docker base image from 5.0.0 to 6.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:5.0.0
+FROM digitalmarketplace/base-frontend:6.0.0


### PR DESCRIPTION
digitalmarketplace/base-frontend:6.0.0 uses npm for building instead of yarn.

This should help fix the admin frontend release pipeline.

Trello ticket: https://trello.com/c/RrpjQDJi