### PR TITLE
Using GOV.UK Frontend buttons

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -17,7 +17,6 @@ $path: "/admin/static/images/";
 // Digital Marketplace Front-end toolkit styles
 @import "toolkit/_breadcrumb";
 @import "toolkit/_browse-list";
-@import "toolkit/_buttons";
 @import "toolkit/_contact-details.scss";
 @import "toolkit/_document.scss";
 @import "toolkit/_footer";
@@ -58,6 +57,9 @@ $govuk-compatibility-govukelements: true;
 @import "_diff.scss";
 @import "views/statistics";
 @import "views/list_agreements";
+
+// Overrides
+@import "overrides/_notifications_banner";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_notifications_banner.scss
+++ b/app/assets/scss/overrides/_notifications_banner.scss
@@ -1,0 +1,7 @@
+// Currently needed to force more margin between notification banner's
+// content and action buttons
+
+.app-banner-action {
+  @include govuk-responsive-margin(1, "top");
+  @include govuk-responsive-margin(0, "bottom");
+}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,5 +1,8 @@
 {% extends "toolkit/layouts/_base_page.html" %}
 
+{# Import GOV.UK Frontend components for globale usage#}
+{% from "components/button/macro.njk" import govukButton %}
+
 {% block footer_top %}
 {% endblock %}
 {% block footer_support_links %}

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -54,13 +54,9 @@
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}
 
-        {%
-          with
-          type = "save",
-          label = "Add"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+        {{ govukButton({
+          "text": "Add"
+        }) }}
       </div>
     </div>
   </form>

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -67,50 +67,50 @@
     </div>
 
     {% if latest_update_events %}
-    <div class="diff">
-    {% if diffs %}
-      <div class="grid-row page-column-headings">
-        <div class="column-one-half">
-          <h3>
-            Previously approved version
-          </h3>
-          <p>
-            Changed on {{ oldest_update_events[-1].createdAt|datetimeformat }}
-          </p>
-        </div>
-        <div class="column-one-half">
-          <h3>
-            Current version
-          </h3>
-        </div>
-      </div>
-    {% endif %}
-    {% for diff_table in diffs.values() %}
-      {{ diff_table }}
-    {% else %}
-      <p>All changes were reversed.</p>
-    {% endfor %}
-    </div><!-- end of .diff -->
+      <div class="diff">
+        {% if diffs %}
+          <div class="grid-row page-column-headings">
+            <div class="column-one-half">
+              <h3>
+                Previously approved version
+              </h3>
+              <p>
+                Changed on {{ oldest_update_events[-1].createdAt|datetimeformat }}
+              </p>
+            </div>
+            <div class="column-one-half">
+              <h3>
+                Current version
+              </h3>
+            </div>
+          </div>
+        {% endif %}
+        {% for diff_table in diffs.values() %}
+          {{ diff_table }}
+        {% else %}
+          <p>All changes were reversed.</p>
+        {% endfor %}
+      </div><!-- end of .diff -->
     {% endif %}
 
     <div class="grid-row">
       <div class="column-one-whole">
         <h4>Contact supplier:</h4>
         <p><a href="mailto:{{ supplier["contactInformation"][0]["email"] }}">
-            {{ supplier["contactInformation"][0]["email"] }}
-         </a></p>
+          {{ supplier["contactInformation"][0]["email"] }}
+          </a></p>
       </div>
     </div>
 
     {% if current_user.has_any_role('admin-ccs-category') and latest_update_events%}
-        <form action="{{ url_for('.submit_service_update_approval', service_id=service.id, audit_id=latest_update_events[0].id)}}" method="post">
-            <div style="display:none;">
-              <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-            </div>
-
-            <input type="submit" class="button-save"  value="Approve {{ pluralize((all_update_events or (oldest_update_events+latest_update_events))|length, "edit", "edits") }}" />
-        </form>
+      <form action="{{ url_for('.submit_service_update_approval', service_id=service.id, audit_id=latest_update_events[0].id)}}" method="post">
+        <div style="display:none;">
+          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+        </div>
+        {{ govukButton({
+          "text": "Approve " + pluralize((all_update_events or (oldest_update_events+latest_update_events))|length, "edit", "edits")
+        }) }}
+      </form>
     {% endif %}
-
   </div>
 {% endblock %}

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -104,9 +104,7 @@
 
     {% if current_user.has_any_role('admin-ccs-category') and latest_update_events%}
       <form action="{{ url_for('.submit_service_update_approval', service_id=service.id, audit_id=latest_update_events[0].id)}}" method="post">
-        <div style="display:none;">
-          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-        </div>
+        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ govukButton({
           "text": "Approve " + pluralize((all_update_events or (oldest_update_events+latest_update_events))|length, "edit", "edits")
         }) }}

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -33,14 +33,11 @@
         <div class="question">
           Are you sure you want to delete the {{ framework.name }} {{ comm_type }} file ‘{{ filepath }}’?
         </div>
-        {%
-          with
-          label="Delete file",
-          type="destructive",
-          name="confirm"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+        {{ govukButton({
+          "classes": "govuk-button--warning",
+          "name": "confirm",
+          "text": "Delete file"
+        }) }}
       </div>
     </div>
   </form>

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -43,13 +43,9 @@
         {{ edit_admin_user_form.edit_admin_permissions }}
         {{ edit_admin_user_form.edit_admin_status }}
 
-        {%
-          with
-          type = "save",
-          label = "Update user"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+        {{ govukButton({
+          "text": "Update user"
+        }) }}
       </div>
     </div>
   </form>

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -38,7 +38,7 @@
   <form method="post" enctype="multipart/form-data">
     <div class="grid-row">
       <div class="column-two-thirds">
-        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {% for question in section.questions %}
           {% if errors and errors[question.id] or question.type == 'multiquestion' %}
             {{ forms[question.type](question, service_data, errors) }}

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -56,13 +56,10 @@
             </div>
           {% endif %}
         {% endfor %}
-        {%
-          with
-          type = "save",
-          label = "Save and return to summary"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+
+        {{ govukButton({
+          "text": "Save and return to summary"
+        }) }}
         <p>
           <a href="{{ url_for('.view_service', service_id=service_data.id) }}">Return without saving</a>
         </p>

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -40,13 +40,10 @@
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}
-        {%
-          with
-          type = "save",
-          label = "Save"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+
+        {{ govukButton({
+          "text": "Save"
+        }) }}
       </div>
     </div>
   </form>

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -46,14 +46,11 @@
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}
-        {%
-          with
-          type = "save",
-          name = "find_supplier_by_name_search",
-          label = "Search"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+
+        {{ govukButton({
+          "name": "find_supplier_by_name_search",
+          "text": "Search"
+        }) }}
       </form>
 
       <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
@@ -65,14 +62,11 @@
         %}
           {% include "toolkit/forms/textbox.html" %}
         {% endwith %}
-        {%
-          with
-          type = "save",
-          name = "find_supplier_by_duns_number_search",
-          label = "Search"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+
+        {{ govukButton({
+          "name": "find_supplier_by_duns_number_search",
+          "text": "Search"
+        }) }}
       </form>
 
       {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
@@ -85,15 +79,12 @@
           %}
             {% include "toolkit/forms/textbox.html" %}
           {% endwith %}
-          {%
-            with
-            type = "save",
-            name = "find_service_by_id_search",
-            label = "Search"
-          %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
-      </form>
+
+          {{ govukButton({
+            "name": "find_service_by_id_search",
+            "text": "Search"
+          }) }}
+        </form>
       {% endif %}
     </div>
   </div>

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -34,14 +34,9 @@
         {{ form.email_address }}
         {{ form.role }}
         {% block save_button %}
-          {%
-            with
-            label="Invite user",
-            name="submit",
-            type="save"
-          %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
+          {{ govukButton({
+            "text": "Invite user"
+          }) }}
         {% endblock %}
       </form>
     </div>

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -27,78 +27,74 @@
     <div class="grid-row">
       <div class="column-two-thirds">
         <div class="dmspeak"><h2 class="heading-large">Communication</h2></div>
-        {% call(item) summary.list_table(
-          comm_type_objs.communication,
-          caption="Communications present",
-          empty_message="No communications files",
-          field_headings=[
-            "Last modified",
-            "File"
-          ],
-          field_headings_visible=False
-        ) %}
-          {% call summary.row() %}
-          {{ summary.field_name(item.last_modified|dateformat) }}
-          {% call summary.field() %}
-            <a href="{{ url_for('.download_communication', comm_type="communication", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
-              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
-              {{ item.filename }}
-            </a>
+          {% call(item) summary.list_table(
+            comm_type_objs.communication,
+            caption="Communications present",
+            empty_message="No communications files",
+            field_headings=[
+              "Last modified",
+              "File"
+            ],
+            field_headings_visible=False
+          ) %}
+            {% call summary.row() %}
+            {{ summary.field_name(item.last_modified|dateformat) }}
+            {% call summary.field() %}
+              <a href="{{ url_for('.download_communication', comm_type="communication", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
+                <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
+                {{ item.filename }}
+              </a>
+            {% endcall %}
+            {{ summary.remove_link(label="Delete", link=url_for('.delete_communication', framework_slug=framework.slug, comm_type="communication", filepath=item.rel_path)) }}
+            {% endcall %}
           {% endcall %}
-          {{ summary.remove_link(label="Delete", link=url_for('.delete_communication', framework_slug=framework.slug, comm_type="communication", filepath=item.rel_path)) }}
-          {% endcall %}
-        {% endcall %}
-        {% with
-          question="Upload communication",
-          hint="This must be an open document format (pdf, pda, odt, ods, odp) or CSV",
-          name="communication",
-          error=communication_error
-        %}
-          {% include "toolkit/forms/upload.html" %}
-        {% endwith %}
+          {% with
+            question="Upload communication",
+            hint="This must be an open document format (pdf, pda, odt, ods, odp) or CSV",
+            name="communication",
+            error=communication_error
+          %}
+            {% include "toolkit/forms/upload.html" %}
+          {% endwith %}
 
-    {% if framework.status in ['open'] %}
-        <div class="dmspeak"><h2 class="heading-large">Clarification answers</h2></div>
-        {% call(item) summary.list_table(
-          comm_type_objs.clarification,
-          caption="Communications present",
-          empty_message="No clarification answers",
-          field_headings=[
-            "Last modified",
-            "File"
-          ],
-          field_headings_visible=False
-        ) %}
-          {% call summary.row() %}
-          {{ summary.field_name(item.last_modified|dateformat) }}
-          {% call summary.field() %}
-            <a href="{{ url_for('.download_communication', comm_type="clarification", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
-              <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
-              {{ item.filename }}
-            </a>
-          {% endcall %}
-          {{ summary.remove_link(label="Delete", link=url_for('.delete_communication', framework_slug=framework.slug, comm_type="clarification", filepath=item.rel_path)) }}
-          {% endcall %}
-        {% endcall %}
-        {% with
-          question="Upload clarification answers",
-          hint="This must be a PDF",
-          name="clarification",
-          error=clarification_error
-        %}
-          {% include "toolkit/forms/upload.html" %}
-        {% endwith %}
-    {% endif %}
-
-        {%
-          with
-          type = "save",
-          label = "Upload files"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+          {% if framework.status in ['open'] %}
+            <div class="dmspeak"><h2 class="heading-large">Clarification answers</h2></div>
+            {% call(item) summary.list_table(
+              comm_type_objs.clarification,
+              caption="Communications present",
+              empty_message="No clarification answers",
+              field_headings=[
+                "Last modified",
+                "File"
+              ],
+              field_headings_visible=False
+            ) %}
+              {% call summary.row() %}
+              {{ summary.field_name(item.last_modified|dateformat) }}
+              {% call summary.field() %}
+                <a href="{{ url_for('.download_communication', comm_type="clarification", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
+                  <span class='document-icon'>{{ item.ext }}<span> document:</span></span>
+                  {{ item.filename }}
+                </a>
+              {% endcall %}
+              {{ summary.remove_link(label="Delete", link=url_for('.delete_communication', framework_slug=framework.slug, comm_type="clarification", filepath=item.rel_path)) }}
+              {% endcall %}
+            {% endcall %}
+            {% with
+              question="Upload clarification answers",
+              hint="This must be a PDF",
+              name="clarification",
+              error=clarification_error
+            %}
+              {% include "toolkit/forms/upload.html" %}
+            {% endwith %}
+          {% endif %}
+          {{ govukButton({
+            "text": "Upload files"
+          }) }}
         </div>
       </div>
+    </div>
   </form>
 
 {% endblock %}

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -70,47 +70,38 @@
           </ul>
 
           <section class="govuk-tabs__panel" id="supplier-name">
-
             <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-                {%
-                  with
-                  question = "Find a supplier by name",
-                  name = "supplier_name",
-                  hint = "Enter any part of the supplier’s registered name or trading name."
-                %}
-                  {% include "toolkit/forms/textbox.html" %}
-                {% endwith %}
-                {%
-                  with
-                  type = "save",
-                  name = "find_supplier_by_name_search",
-                  label = "Search"
-                %}
-                  {% include "toolkit/button.html" %}
-                {% endwith %}
-              </form>
+              {%
+                with
+                question = "Find a supplier by name",
+                name = "supplier_name",
+                hint = "Enter any part of the supplier’s registered name or trading name."
+              %}
+                {% include "toolkit/forms/textbox.html" %}
+              {% endwith %}
 
+              {{ govukButton({
+                "name": "find_supplier_by_name_search",
+                "text": "Search"
+              }) }}
+            </form>
           </section>
           <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="duns-number">
             <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
-                {%
-                  with
-                  question = "Find a supplier by DUNS number",
-                  name = "supplier_duns_number",
-                  hint = "DUNS numbers are usually 9 digits long, for example, 234554321"
-                %}
-                  {% include "toolkit/forms/textbox.html" %}
-                {% endwith %}
-                {%
-                  with
-                  type = "save",
-                  name = "find_supplier_by_duns_number_search",
-                  label = "Search"
-                %}
-                  {% include "toolkit/button.html" %}
-                {% endwith %}
-              </form>
+              {%
+                with
+                question = "Find a supplier by DUNS number",
+                name = "supplier_duns_number",
+                hint = "DUNS numbers are usually 9 digits long, for example, 234554321"
+              %}
+                {% include "toolkit/forms/textbox.html" %}
+              {% endwith %}
 
+              {{ govukButton({
+                "name": "find_supplier_by_duns_number_search",
+                "text": "Search"
+              }) }}
+            </form>
           </section>
           <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="company-registration-number">
             <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
@@ -122,15 +113,12 @@
                 %}
                   {% include "toolkit/forms/textbox.html" %}
                 {% endwith %}
-                {%
-                  with
-                  type = "save",
-                  name = "find_supplier_by_company_registration_number_search",
-                  label = "Search"
-                %}
-                  {% include "toolkit/button.html" %}
-                {% endwith %}
-              </form>
+
+                {{ govukButton({
+                  "name": "find_supplier_by_company_registration_number_search",
+                  "text": "Search"
+                }) }}
+            </form>
           </section>
           {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
           <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="service-id">
@@ -143,14 +131,10 @@
               %}
                 {% include "toolkit/forms/textbox.html" %}
               {% endwith %}
-              {%
-                with
-                type = "save",
-                name = "find_service_by_id_search",
-                label = "Search"
-              %}
-                {% include "toolkit/button.html" %}
-              {% endwith %}
+              {{ govukButton({
+                "name": "find_service_by_id_search",
+                "text": "Search"
+              }) }}
             </form>
           </section>
           {% endif %}

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -47,13 +47,10 @@
         {% for question in section.questions %}
           {{ forms[question.type](question, declaration, {}) }}
         {% endfor %}
-        {%
-          with
-          type = "save",
-          label = "Save and return to summary"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+
+        {{ govukButton({
+          "text": "Save and return to summary"
+        }) }}
         <p>
           <a href="{{ url_for('.view_supplier_declaration', supplier_id=supplier.id, framework_slug=framework.slug) }}">Return without saving</a>
         </p>

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -43,7 +43,7 @@
   <form method="post" enctype="multipart/form-data">
     <div class="grid-row">
       <div class="column-two-thirds">
-        <div style="display:none;"><input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}"></div>
+       <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {% for question in section.questions %}
           {{ forms[question.type](question, declaration, {}) }}
         {% endfor %}

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -43,42 +43,39 @@
         {{ form.postcode }}
         {% if form.country.errors %}
 
-      <div class="validation-wrapper">
-        <style>
-          #location-autocomplete {border: 5px solid #B10E1E;}
-          .autocomplete__hint {border: 5px solid;}
-        </style>
-      {% endif %}
-
-      <div class="question" id="country">
-        <span class="question-heading" id="country-label">Country</span>
-        {{ forms.field_errors(form.country.name, errors=form.country.errors) }}
-        <select name="country" id="location-autocomplete" class="location-autocomplete-fallback">
-        {% if not form.country.data %}
-          <option value="" selected="selected"></option>
+          <div class="validation-wrapper">
+            {# TODO remove inline styles #}
+            <style>
+              #location-autocomplete {border: 5px solid #B10E1E;}
+              .autocomplete__hint {border: 5px solid;}
+            </style>
         {% endif %}
-        {% for country in countries %}
-          <option value="{{country[1]}}"{% if form.country.data == country[1]%} selected="selected"{% endif %}>{{country[0]}}</option>
-        {% endfor %}
-        </select>
-      </div>
-      {% if form.country.errors %}
-      </div>
-      {% endif %}
 
-        {%
-          with
-          type = "save",
-          label = "Save"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+          <div class="question" id="country">
+            <span class="question-heading" id="country-label">Country</span>
+            {{ forms.field_errors(form.country.name, errors=form.country.errors) }}
+            <select name="country" id="location-autocomplete" class="location-autocomplete-fallback">
+            {% if not form.country.data %}
+              <option value="" selected="selected"></option>
+            {% endif %}
+            {% for country in countries %}
+              <option value="{{country[1]}}"{% if form.country.data == country[1]%} selected="selected"{% endif %}>{{country[0]}}</option>
+            {% endfor %}
+            </select>
+          </div>
+        {% if form.country.errors %}
+          </div>
+        {% endif %}
+
+        {{ govukButton({
+          "text": "Save"
+        }) }}
       </div>
     </div>
   </form>
 {% endblock %}
 
 {% block page_scripts %}
-<script type="text/javascript" src="{{ asset_path }}javascripts/location-autocomplete.min.js"></script>
-<script type="text/javascript" src="{{ asset_path }}javascripts/app-location-autocomplete.js"></script>
+  <script type="text/javascript" src="{{ asset_path }}javascripts/location-autocomplete.min.js"></script>
+  <script type="text/javascript" src="{{ asset_path }}javascripts/app-location-autocomplete.js"></script>
 {% endblock %}

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -36,13 +36,9 @@
         {{ form.companies_house_number }}
         {{ form.other_company_registration_number }}
 
-        {%
-          with
-          type = "save",
-          label = "Save"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+        {{ govukButton({
+          "text": "Save"
+        }) }}
       </div>
     </div>
   </form>

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -35,13 +35,9 @@
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ form.registered_company_name }}
 
-        {%
-          with
-          type = "save",
-          label = "Save"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+        {{ govukButton({
+          "text": "Save"
+        }) }}
       </div>
     </div>
   </form>

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -27,7 +27,10 @@
         <p class="banner-message">
           Do you want to remove the countersigned agreement?
         </p>
-        <button class="button-destructive banner-action" type="submit">Yes</button>
+        {{ govukButton({
+          "classes": "govuk-button--warning",
+          "text": "Yes"
+        }) }}
       </div>
   {% endif %}
 
@@ -68,8 +71,8 @@
   {% endcall %}
 
   <form method="post" enctype="multipart/form-data">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-  {%
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    {%
       with
       question = "Please upload a countersigned agreement",
       name = "countersigned_agreement",
@@ -77,13 +80,10 @@
     %}
       {% include "toolkit/forms/upload.html" %}
     {% endwith %}
-    {%
-      with
-      type = "save",
-      label = "Upload file"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
+
+    {{ govukButton({
+      "text": "Upload file"
+    }) }}
   </form>
 
 {% endblock %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -92,38 +92,28 @@
         <form action="{{ url_for('.unapprove_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
-          {%
-            with
-            type = "destructive",
-            label = "Cancel acceptance"
-          %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
+          {{ govukButton({
+            "classes": "govuk-button--warning",
+            "text": "Cancel acceptance"
+          }) }}
         </form>
         {% endif %}
       {% elif current_user.has_role('admin-ccs-sourcing') %}
         <form action="{{ url_for('.approve_agreement_for_countersignature', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
           <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
           <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
-          {%
-            with
-            type = "save",
-            label = "Accept and continue"
-          %}
-            {% include "toolkit/button.html" %}
-          {% endwith %}
+          {{ govukButton({
+            "text": "Accept and continue"
+          }) }}
         </form>
         {% if supplier_framework.agreementStatus != 'on-hold' %}
           <form action="{{ url_for('.put_signed_agreement_on_hold', agreement_id=supplier_framework.agreementId, next_status=next_status) }}" method="post">
             <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
             <input name="nameOfOrganisation" value="{{ supplier_framework.declaration.nameOfOrganisation }}" type="hidden">
-            {%
-              with
-              type = "secondary",
-              label = "Put on hold and continue"
-            %}
-              {% include "toolkit/button.html" %}
-            {% endwith %}
+            {{ govukButton({
+              "classes": "govuk-button--secondary",
+              "text": "Put on hold and continue"
+            }) }}
           </form>
         {% endif %}
       {% endif %}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -32,13 +32,10 @@
     %}
       {% include "toolkit/forms/textbox.html" %}
     {% endwith %}
-    {%
-      with
-      type = "save",
-      label = "Search"
-    %}
-      {% include "toolkit/button.html" %}
-    {% endwith %}
+
+    {{ govukButton({
+      "text": "Search"
+    }) }}
   </form>
 
   {{ summary.heading(brief.title) }}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -38,7 +38,10 @@
               service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName']
             ),
             type = "destructive",
-            action = '<button type="submit" class="button-destructive banner-action">Publish</button>'|safe
+            action = govukButton({
+              "classes": "govuk-button--warning app-banner-action",
+              "text": "Publish"
+            }) | safe
           %}
             {% include "toolkit/notification-banner.html" %}
           {% endwith %}
@@ -55,7 +58,10 @@
             service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName']
           ),
           type = "destructive",
-          action = '<button type="submit" class="button-destructive banner-action">Remove</button>'|safe
+          action = govukButton({
+              "classes": "govuk-button--warning app-banner-action",
+              "text": "Remove"
+            }) | safe
         %}
           {% include "toolkit/notification-banner.html" %}
         {% endwith %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -33,12 +33,20 @@
         {% if remove_services_for_framework %}
           {% set url = url_for('main.toggle_supplier_services', supplier_id=supplier.id, remove=remove_services_for_framework.slug) %}
           {% set message = "Are you sure you want to suspend {} services for ‘{}’?".format(remove_services_for_framework.name, supplier.name) %}
-          {% set action = '<button type="submit" class="button-destructive banner-action">Suspend all services</button>'|safe %}
+          {% set action = govukButton({
+              "classes": "govuk-button--warning app-banner-action",
+              "text": "Suspend all services"
+            }) | safe
+          %}
         {% elif publish_services_for_framework %}
           {% set url = url_for('main.toggle_supplier_services', supplier_id=supplier.id, publish=publish_services_for_framework.slug) %}
           {% set message = "Are you sure you want to unsuspend {} services for ‘{}’?".format(publish_services_for_framework.name, supplier.name) %}
           {% set banner_content = "This won’t change the status for services that ‘{}’ suspended themselves.".format(supplier.name) %}
-          {% set action = '<button type="submit" class="button-destructive banner-action">Unsuspend all services</button>'|safe %}
+          {% set action = govukButton({
+              "classes": "govuk-button--warning app-banner-action",
+              "text": "Unsuspend all services"
+            }) | safe
+          %}
         {% endif %}
         <form action="{{ url }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -32,124 +32,119 @@
   {% endwith %}
 
   <div class='page-section'>
-      {% call(item) summary.list_table(
-          users,
-          caption="Users",
-          empty_message="This supplier has no users on the Digital Marketplace",
-          field_headings=[
-              'Name',
-              'Email address',
-              'Last login',
-              'Pwd changed',
-              'Locked',
-              summary.hidden_field_heading("Change status") if current_user.has_any_role('admin', 'admin-ccs-category') else summary.hidden_field_heading("")
-          ],
-          field_headings_visible=True)
-      %}
+    {% call(item) summary.list_table(
+      users,
+      caption="Users",
+      empty_message="This supplier has no users on the Digital Marketplace",
+      field_headings=[
+          'Name',
+          'Email address',
+          'Last login',
+          'Pwd changed',
+          'Locked',
+          summary.hidden_field_heading("Change status") if current_user.has_any_role('admin', 'admin-ccs-category') else summary.hidden_field_heading("")
+      ],
+      field_headings_visible=True)
+    %}
       {% call summary.row() %}
 
-      {{ summary.field_name(item.name) }}
+        {{ summary.field_name(item.name) }}
 
-      {{ summary.text(item.emailAddress) }}
+        {{ summary.text(item.emailAddress) }}
 
-      {% call summary.field() %}
+        {% call summary.field() %}
           {% if item.loggedInAt %}
-              {{ item.loggedInAt|timeformat }}<br/>
-              {{ item.loggedInAt|dateformat }}
+            {{ item.loggedInAt|timeformat }}<br/>
+            {{ item.loggedInAt|dateformat }}
           {% else %}
-              Never
+            Never
           {% endif %}
-      {% endcall %}
+        {% endcall %}
 
-      {% call summary.field() %}
+        {% call summary.field() %}
           {% if item.passwordChangedAt %}
-              {{ item.passwordChangedAt|timeformat }}<br/>
-              {{ item.passwordChangedAt|dateformat }}
+            {{ item.passwordChangedAt|timeformat }}<br/>
+            {{ item.passwordChangedAt|dateformat }}
           {% else %}
-              Never
+            Never
           {% endif %}
-      {% endcall %}
+        {% endcall %}
 
-      {% call summary.field() %}
-      {% if item.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
-      <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          {%
-              with
-              type = "secondary",
-              label = "Unlock"
-          %}
-          {% include "toolkit/button.html" %}
-          {% endwith %}
-      </form>
-      {% elif item.locked %}
-          Yes
-      {% else %}
-          No
-      {% endif %}
-      {% endcall %}
+        {% call summary.field() %}
+          {% if item.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
+          <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            {{ govukButton({
+              "classes": "govuk-button--secondary",
+              "text": "Unlock"
+            }) }}
+          </form>
+          {% elif item.locked %}
+              Yes
+          {% else %}
+              No
+          {% endif %}
+        {% endcall %}
 
-      {% call summary.field() %}
-      {% if item.active %}
-        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-          <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-              {%
-                  with
-                  type = "destructive",
-                  label = "Deactivate"
-              %}
-              {% include "toolkit/button.html" %}
-              {% endwith %}
-          </form>
-        {% else %}
-          Active
-        {% endif %}
-      {% else %}
-        {% if current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
-          <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-              {%
-                  with
-                  type = "secondary",
-                  label = "Activate"
-              %}
-              {% include "toolkit/button.html" %}
-              {% endwith %}
-          </form>
-        {% else %}
-          Deactivated
-        {% endif %}
-      {% endif %}
+        {% call summary.field() %}
+          {% if item.active %}
+            {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+              <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                {{ govukButton({
+                  "classes": "govuk-button--warning",
+                  "text": "Deactivate"
+                }) }}
+              </form>
+            {% else %}
+              Active
+            {% endif %}
+          {% else %}
+            {% if current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
+              <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                {{ govukButton({
+                  "classes": "govuk-button--secondary",
+                  "text": "Activate"
+                }) }}
+              </form>
+            {% else %}
+              Deactivated
+            {% endif %}
+          {% endif %}
+        {% endcall %}
       {% endcall %}
-      {% endcall %}
-      {% endcall %}
+    {% endcall %}
   </div>
 
 
   {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
   <div class='page-section'>
-      <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
-          <div class="grid-row">
-              <div class="column-two-thirds">
-                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  {{ invite_form.email_address }}
-                 <button class="button-save">Send invitation</button>
-              </div>
-          </div>
-      </form>
+    <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {{ invite_form.email_address }}
+          {{ govukButton({
+            "text": "Send invitation"
+          }) }}
+        </div>
+      </div>
+    </form>
   </div>
 
-    <div class='page-section'>
-        <form action="{{ url_for('.move_user_to_new_supplier', supplier_id=supplier.id) }}" method="post">
-            <div class="grid-row">
-                <div class="column-two-thirds">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                    {{ move_user_form.user_to_move_email_address }}
-                    <button class="button-save">Move user to this supplier</button>
-                </div>
-            </div>
-        </form>
-    </div>
+  <div class='page-section'>
+    <form action="{{ url_for('.move_user_to_new_supplier', supplier_id=supplier.id) }}" method="post">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          {{ move_user_form.user_to_move_email_address }}
+          {{ govukButton({
+            "text": "Move user to this supplier"
+          }) }}
+        </div>
+      </div>
+    </form>
+  </div>
   {% endif %}
 {% endblock %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -25,123 +25,112 @@
   {% endwith %}
 
   <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-  {%
-    with
-    question = "Find a user by email",
-    name = "email_address"
-  %}
-    {% include "toolkit/forms/textbox.html" %}
-  {% endwith %}
+    {%
+      with
+      question = "Find a user by email",
+      name = "email_address"
+    %}
+      {% include "toolkit/forms/textbox.html" %}
+    {% endwith %}
 
-  {{ govukButton({
-    "text": "Search"
-  }) }}
+    {{ govukButton({
+      "text": "Search"
+    }) }}
 
   </form>
 
   {% call(item) summary.list_table(
-          users,
-          caption="Users",
-          empty_message="No users to show",
-          field_headings=[
-              'Name',
-              'Role',
-              'Supplier',
-              'Last login',
-              'Last password change',
-              'Locked',
-              summary.hidden_field_heading("Change status")
-          ],
-          field_headings_visible=True)
-      %}
-      {% call summary.row() %}
+    users,
+    caption="Users",
+    empty_message="No users to show",
+    field_headings=[
+        'Name',
+        'Role',
+        'Supplier',
+        'Last login',
+        'Last password change',
+        'Locked',
+        summary.hidden_field_heading("Change status")
+    ],
+    field_headings_visible=True)
+  %}
+    {% call summary.row() %}
 
       {{ summary.field_name(item.name) }}
 
       {{ summary.text(item.role) }}
 
       {% call summary.field() %}
-          {% if item.role == 'supplier' %}
+        {% if item.role == 'supplier' %}
           <a href="{{ url_for('.find_suppliers', supplier_id=item.supplier.supplierId) }}">{{ item.supplier.name }}</a>
-          {% endif %}
+        {% endif %}
       {% endcall %}
 
       {% call summary.field() %}
-          {% if item.loggedInAt %}
-              {{ item.loggedInAt|timeformat }}<br/>
-              {{ item.loggedInAt|dateformat }}
-          {% else %}
-              Never
-          {% endif %}
+        {% if item.loggedInAt %}
+          {{ item.loggedInAt|timeformat }}<br/>
+          {{ item.loggedInAt|dateformat }}
+        {% else %}
+          Never
+        {% endif %}
       {% endcall %}
 
       {% call summary.field() %}
-          {% if item.passwordChangedAt %}
-              {{ item.passwordChangedAt|timeformat }}<br/>
-              {{ item.passwordChangedAt|dateformat }}
-          {% else %}
-              Never
-          {% endif %}
+        {% if item.passwordChangedAt %}
+          {{ item.passwordChangedAt|timeformat }}<br/>
+          {{ item.passwordChangedAt|dateformat }}
+        {% else %}
+          Never
+        {% endif %}
       {% endcall %}
 
       {% call summary.field() %}
-      {% if item.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
-      <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
-          {%
-              with
-              type = "secondary",
-              label = "Unlock"
-          %}
-          {% include "toolkit/button.html" %}
-          {% endwith %}
-      </form>
-      {% elif item.locked %}
+        {% if item.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
+          <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+            {{ govukButton({
+              "classes": "govuk-button--secondary",
+              "text": "Unlock"
+            }) }}
+          </form>
+        {% elif item.locked %}
           Yes
-      {% else %}
+        {% else %}
           No
-      {% endif %}
+        {% endif %}
       {% endcall %}
 
       {% call summary.field() %}
-          {% if item.active %}
-            {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-              <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
-                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
-                  {%
-                      with
-                      type = "destructive",
-                      label = "Deactivate"
-                  %}
-                  {% include "toolkit/button.html" %}
-                  {% endwith %}
-              </form>
-            {% else %}
-              Active
-            {% endif %}
+        {% if item.active %}
+          {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+            <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+              {{ govukButton({
+                "classes": "govuk-button--warning",
+                "text": "Deactivate"
+              }) }}
+            </form>
           {% else %}
-            {% if current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
-              <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
-                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                  <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
-                  {%
-                      with
-                      type = "secondary",
-                      label = "Activate"
-                  %}
-                  {% include "toolkit/button.html" %}
-                  {% endwith %}
-              </form>
-            {% else %}
-              Deactivated
-            {% endif %}
+            Active
           {% endif %}
+        {% else %}
+          {% if current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
+            <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
+              {{ govukButton({
+                "classes": "govuk-button--secondary",
+                "text": "Activate"
+              }) }}
+            </form>
+          {% else %}
+            Deactivated
+          {% endif %}
+        {% endif %}
       {% endcall %}
 
-      {% endcall %}
-      {% endcall %}
-  </div>
-
+    {% endcall %}
+  {% endcall %}
 {% endblock %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -32,15 +32,6 @@
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
-  {# {%
-    with
-    type = "save",
-    label = "Search"
-  %}
-    {% include "toolkit/button.html" %}
-  {% endwith %} #}
-
-  {% from "components/button/macro.njk" import govukButton %}
 
   {{ govukButton({
     "text": "Search"

--- a/tests/app/main/views/test_admin_manager.py
+++ b/tests/app/main/views/test_admin_manager.py
@@ -381,7 +381,7 @@ class TestAdminManagerEditsAdminUsers(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         assert document.xpath('//h1')[0].text.strip() == "reality.auditor@digital.cabinet-office.gov.uk"
-        assert document.xpath('//input[@class="button-save"]')[0].value.strip() == "Update user"
+        assert document.xpath('//button')[0].text.strip() == "Update user"
 
     def test_edit_admin_user_form_prefills_edit_name_with_user_name(self):
         self.data_api_client.get_user.return_value = self.admin_user_to_edit

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -161,7 +161,7 @@ class TestManageCommunicationsView(_BaseTestCommunicationsView):
 
         # find the form that has our submit button
         form = doc.xpath(
-            "//form[@method='post'][@enctype='multipart/form-data'][.//input[@type='submit'][@value='Upload files']]"
+            "//form[@method='post'][@enctype='multipart/form-data'][.//button[contains(text(),'Upload files')]]"
         )[0]
         # should be a self-posting form
         assert urljoin(
@@ -400,7 +400,7 @@ class TestDeleteCommunicationsConfirmationPage(_BaseTestCommunicationsView):
         # find the form that has our submit button
         form = doc.xpath(
             "//form[@method='POST'][.//input[@name='csrf_token']]"
-            "[.//input[@type='submit'][@name='confirm'][@value='Delete file']]"
+            "[.//button[@name='confirm'][contains(text(), 'Delete file')]]"
         )[0]
         # should be a self-posting form
         assert urljoin(

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1926,7 +1926,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
 
             # in this case we want a strict assertion that *all* of the following are true about the ack_form
             ack_forms = doc.xpath(
-                "//form[.//input[@type='submit' and @value=$ack_text]]",
+                "//form[.//button[contains(text(), $ack_text)]]",
                 ack_text="Approve edit{}".format("" if len(find_audit_events_api_response) == 1 else "s"),
             )
             assert len(ack_forms) == 1

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -582,7 +582,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         response = self.client.get('/admin/suppliers/users?supplier_id=1000')
         assert response.status_code == 200
         document = html.fromstring(response.get_data(as_text=True))
-        deactivate_buttons = document.xpath('.//input[contains(@value, "Deactivate")]')
+        deactivate_buttons = document.xpath('.//button[contains(text(), "Deactivate")]')
         assert len(deactivate_buttons) == (1 if can_edit else 0)
 
     def test_should_404_if_no_supplier_does_not_exist(self):
@@ -630,9 +630,9 @@ class TestSupplierUsersView(LoggedInApplicationTest):
         assert "No" in response.get_data(as_text=True)
 
         document = html.fromstring(response.get_data(as_text=True))
-        assert document.xpath('//input[@value="Deactivate"][@type="submit"][@class="button-destructive"]')
+        assert document.xpath('//button[contains(text(), "Deactivate")][contains(@class, "govuk-button--warning")]')
         assert document.xpath('//form[@action="/admin/suppliers/users/999/deactivate"][@method="post"]')
-        assert document.xpath('//button[@class="button-save"][contains(text(), "Move user to this supplier")]')
+        assert document.xpath('//button[contains(text(), "Move user to this supplier")]')
         assert document.xpath('//form[@action="/admin/suppliers/1234/move-existing-user"][@method="post"]')
 
     def test_should_show_unlock_button_if_user_locked_and_not_personal_data_removed(self):
@@ -646,7 +646,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
         assert document.xpath('//form[@action="/admin/suppliers/users/999/unlock"][@method="post"]')
-        assert document.xpath('//input[@value="Unlock"][@type="submit"][@class="button-secondary"]')
+        assert document.xpath('//button[contains(text(), "Unlock")][contains(@class, "govuk-button--secondary")]')
 
     def test_should_not_show_unlock_button_if_user_not_locked(self):
         users = self.load_example_listing("users_response")
@@ -684,7 +684,7 @@ class TestSupplierUsersView(LoggedInApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
         assert document.xpath('//form[@action="/admin/suppliers/users/999/activate"][@method="post"]')
-        assert document.xpath('//input[@value="Activate"][@type="submit"][@class="button-secondary"]')
+        assert document.xpath('//button[contains(text(), "Activate")][contains(@class, "govuk-button--secondary")]')
 
     def test_should_not_show_activate_button_if_user_personal_data_removed(self):
         users = self.load_example_listing("users_response")
@@ -2830,7 +2830,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
 
         assert "Cancel acceptance" not in data
 
-        accept_input_elems = document.xpath("//form//input[@type='submit'][@value='Accept and continue']")
+        accept_input_elems = document.xpath("//form//button[contains(text(), 'Accept and continue')]")
         assert len(accept_input_elems) == 1
         accept_form_elem = accept_input_elems[0].xpath("ancestor::form")[0]
         assert self._parsed_url_matches(
@@ -2842,7 +2842,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         assert accept_form_elem.xpath("input[@name='csrf_token']")
         assert accept_form_elem.xpath("input[@name='nameOfOrganisation'][@value=$n]", n=self.decl_nameOfOrganization)
 
-        hold_input_elems = document.xpath("//form//input[@type='submit'][@value='Put on hold and continue']")
+        hold_input_elems = document.xpath("//form//button[contains(text(), 'Put on hold and continue')]")
         assert len(hold_input_elems) == 1
         hold_form_elem = hold_input_elems[0].xpath("ancestor::form")[0]
         assert self._parsed_url_matches(
@@ -2881,7 +2881,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
 
         assert "Cancel acceptance" not in data
 
-        accept_input_elems = document.xpath("//form//input[@type='submit'][@value='Accept and continue']")
+        accept_input_elems = document.xpath("//form//button[contains(text(), 'Accept and continue')]")
         assert len(accept_input_elems) == 1
         accept_form_elem = accept_input_elems[0].xpath("ancestor::form")[0]
         assert self._parsed_url_matches(
@@ -2923,7 +2923,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
         assert "Put on hold and continue" not in data
         assert len(document.xpath("//h2[normalize-space(string())='Accepted by']")) == 1
 
-        cancel_input_elems = document.xpath("//form//input[@type='submit'][@value='Cancel acceptance']")
+        cancel_input_elems = document.xpath("//form//button[contains(text(), 'Cancel acceptance')]")
         assert len(cancel_input_elems) == 1
         cancel_form_elem = cancel_input_elems[0].xpath("ancestor::form")[0]
         assert self._parsed_url_matches(

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -119,7 +119,7 @@ class TestUsersView(LoggedInApplicationTest):
         assert locked == 'No'
 
         button = document.xpath(
-            '//input[@class="button-destructive"]')[0].value
+            '//button[contains(@class, "govuk-button--warning")]')[0].text.strip()
         assert button == 'Deactivate'
 
     def test_should_show_supplier_user(self):
@@ -151,7 +151,7 @@ class TestUsersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         unlock_button = document.xpath(
-            '//input[@class="button-secondary"]')[0].attrib['value']
+            '//button[contains(@class, "govuk-button--secondary")]')[0].text.strip()
         unlock_link = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/form')[0]
         return_link = document.xpath(
@@ -177,7 +177,7 @@ class TestUsersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         deactivate_button = document.xpath(
-            '//input[@class="button-destructive"]')[0].attrib['value']
+            '//button[contains(@class, "govuk-button--warning")]')[0].text.strip()
         deactivate_link = document.xpath(
             '//tr[@class="summary-item-row"]//td/span/form')[0]
         return_link = document.xpath(
@@ -204,7 +204,7 @@ class TestUsersView(LoggedInApplicationTest):
         response = self.client.get('/admin/users?email_address=test.user@sme.com')
         document = html.fromstring(response.get_data(as_text=True))
 
-        assert document.xpath('//input[@value="Activate"][@type="submit"]')
+        assert document.xpath('//button[contains(text(), "Activate")]')
 
 
 @mock.patch('app.main.views.users.s3')


### PR DESCRIPTION
## Noticeable differences.
- Search buttons are smaller but we don't think this will be an issue or is important to ensure they are the same size. 

- Previously "buttons" were actually `<input type="submit">` but now they are actually `<button>`. 
`<button>` is newer than `<input type="submit">`, is more semantic, easy to stylize and support HTML inside of it. There should not be any other behaviour changes because `<button>` has a `type="submit"` by default.

Trello ticket: https://trello.com/c/nsfgRLBj/289-replace-toolkit-button-with-govukbutton-in-admin-frontend