### PR TITLE
Using GOV.UK Frontend breadcrumbs

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -15,7 +15,6 @@ $path: "/admin/static/images/";
 @import "shared_scss/_dmspeak.scss";
 
 // Digital Marketplace Front-end toolkit styles
-@import "toolkit/_breadcrumb";
 @import "toolkit/_browse-list";
 @import "toolkit/_contact-details.scss";
 @import "toolkit/_document.scss";

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -8,7 +8,6 @@
 {# override content block to add a beforeContent block like the one in govuk-frontend template #}
 {% block content %}
   {% block top_header %}{% endblock %}
-  {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     {% block beforeContent %}{% endblock %}
     <main id="content" role="main">

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,6 +1,7 @@
 {% extends "toolkit/layouts/_base_page.html" %}
 
 {# Import GOV.UK Frontend components for globale usage#}
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/tabs/macro.njk" import govukTabs %}
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -5,6 +5,20 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/tabs/macro.njk" import govukTabs %}
 
+{# override content block to add a beforeContent block like the one in govuk-frontend template #}
+{% block content %}
+  {% block top_header %}{% endblock %}
+  {% block breadcrumb %}{% endblock %}
+  <div id="wrapper">
+    {% block beforeContent %}{% endblock %}
+    <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
+      {% block main_content %}
+      {% endblock %}
+    </main>
+  </div>
+{% endblock %}
+
 {% block footer_top %}
 {% endblock %}
 {% block footer_support_links %}

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -2,7 +2,7 @@
 
 {% block page_title %}Add buyer email domains – Digital Marketplace admin{% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -14,6 +14,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
   {% for error in email_domain_form.new_buyer_domain.errors %}
     {%
       with

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -2,23 +2,18 @@
 
 {% block page_title %}Add buyer email domains – Digital Marketplace admin{% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": "Add buyer email domains"
+        "text": "Add buyer email domains"
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
-{% block main_content %}
+  }) }}
   {% for error in email_domain_form.new_buyer_domain.errors %}
     {%
       with

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -4,24 +4,20 @@
   {{ service['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-          {
-            "link": url_for('.service_update_audits'),
-            "label": "Check edits to services"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": "Check edits to services",
+        "href": url_for('.service_update_audits')
+      }
+    ]
+  }) }}
+
   {%
     with
     smaller = true,

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -14,6 +14,9 @@
       {
         "text": "Check edits to services",
         "href": url_for('.service_update_audits')
+      },
+      {
+        "text": service['serviceName']
       }
     ]
   }) }}

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -4,7 +4,7 @@
   {{ service['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -17,7 +17,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {%
     with
     smaller = true,

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -14,6 +14,9 @@
       {
         "text": "Manage {} communications".format(framework.name),
         "href": url_for('.manage_communications', framework_slug=framework.slug)
+      },
+      {
+        "text": "Confirm communications deletion"
       }
     ]
   }) }}

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -4,7 +4,7 @@
   Confirm communications deletion - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -17,7 +17,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% with heading = "Confirm communications deletion" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -4,24 +4,20 @@
   Confirm communications deletion - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-          {
-              "link": url_for('.manage_communications', framework_slug=framework.slug),
-              "label": "Manage {} communications".format(framework.name)
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": "Manage {} communications".format(framework.name),
+        "href": url_for('.manage_communications', framework_slug=framework.slug)
+      }
+    ]
+  }) }}
+
   {% with heading = "Confirm communications deletion" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -10,6 +10,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Download supplier lists"
       }
     ]
   }) }}

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -4,7 +4,7 @@
   Download supplier lists for {{ framework.name }} - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -13,6 +13,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
       {%

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -4,20 +4,15 @@
   Download supplier lists for {{ framework.name }} - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
-{% block main_content %}
+  }) }}
   <div class="grid-row">
     <div class="column-two-thirds">
       {%

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -3,23 +3,19 @@
   Edit details of admin user: {{ admin_user.emailAddress }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": "Edit an admin user"
+        "text": "Edit an admin user",
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   {% for error in edit_admin_user_form.edit_admin_name.errors %}
     {%
       with

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -3,7 +3,7 @@
   Edit details of admin user: {{ admin_user.emailAddress }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -15,7 +15,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% for error in edit_admin_user_form.edit_admin_name.errors %}
     {%
       with

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -7,7 +7,7 @@
   Edit {{ section.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -20,7 +20,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {%
     with
     heading = section.name,

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -3,8 +3,10 @@
 
 {% extends "_base_page.html" %}
 
+{% set page_title = "Edit {}".format(section.name) %}
+
 {% block page_title %}
-  Edit {{ section.name }} – Digital Marketplace admin
+  {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 
 {% block beforeContent %}
@@ -17,6 +19,9 @@
       {
         "text": service_data['serviceName'],
         "href": url_for(".view_service", service_id=service_data.id)
+      },
+      {
+        "text": page_title
       }
     ]
   }) }}

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -7,24 +7,20 @@
   Edit {{ section.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "link": url_for(".view_service", service_id=service_data.id),
-        "label": service_data['serviceName']
+        "text": service_data['serviceName'],
+        "href": url_for(".view_service", service_id=service_data.id)
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   {%
     with
     heading = section.name,

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -4,27 +4,23 @@
   Change name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": supplier.name,
-        "link": url_for('.supplier_details', supplier_id=supplier.id)
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
       },
       {
-        "label": "Change supplier name"
+        "text": "Change supplier name"
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   {% with heading = "Change supplier name" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -4,7 +4,7 @@
   Change name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -20,7 +20,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% with heading = "Change supplier name" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -2,20 +2,16 @@
 
 {% block page_title %}Access denied - 403 – Digital Marketplace{% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('main.index'),
-              "label": "Admin home"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('main.index')
+      }
+    ]
+  }) }}
+
   {% with heading = "You don’t have permission to perform this action" %}
     {% include 'toolkit/page-heading.html' %}
   {% endwith %}

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -8,6 +8,9 @@
       {
         "text": "Admin home",
         "href": url_for('main.index')
+      },
+      {
+        "text": "Access denied"
       }
     ]
   }) }}

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -2,7 +2,7 @@
 
 {% block page_title %}Access denied - 403 – Digital Marketplace{% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -11,7 +11,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% with heading = "You don’t have permission to perform this action" %}
     {% include 'toolkit/page-heading.html' %}
   {% endwith %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -14,7 +14,7 @@
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -23,7 +23,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {%
     with heading = page_title
   %}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -20,6 +20,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": page_title
       }
     ]
   }) }}

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -14,20 +14,16 @@
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
+
   {%
     with heading = page_title
   %}

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -1,22 +1,25 @@
 {% extends "_base_page.html" %}
 
 {% import "toolkit/forms/macros/forms.html" as forms %}
-{% set page_name = 'Invite a new admin user' %}
-{% block page_title %}{{ page_name }} – Digital Marketplace admin{% endblock %}
-{% block breadcrumb %}
-  {%
-    with items = [
-      {"link": url_for('.index'), "label": "Admin home"},
-      {"link": url_for('main.manage_admin_users'), "label": "Manage users"},
-      {"label": "Invite a new admin user"}
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
+{% set page_title = 'Invite a new admin user' %}
+{% block page_title %}{{ page_title }} – Digital Marketplace admin{% endblock %}
 
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": "Manage users",
+        "href": url_for('main.manage_admin_users')
+      },
+      {
+        "text": page_title
+      }
+    ]
+  }) }}
 
   {% include 'toolkit/forms/validation.html' %}
 

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -4,7 +4,7 @@
 {% set page_title = 'Invite a new admin user' %}
 {% block page_title %}{{ page_title }} – Digital Marketplace admin{% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -20,6 +20,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% include 'toolkit/forms/validation.html' %}
 

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -5,7 +5,7 @@
   Manage {{ framework.name }} communications - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -14,6 +14,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with heading = "Manage {} communications".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -11,6 +11,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Manage communications"
       }
     ]
   }) }}

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -5,19 +5,16 @@
   Manage {{ framework.name }} communications - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
+
   {% with heading = "Manage {} communications".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -16,20 +16,15 @@
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
   {%
     with heading = page_title
   %}

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -16,7 +16,7 @@
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -25,6 +25,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
   {%
     with heading = page_title
   %}

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -22,6 +22,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": page_title
       }
     ]
   }) }}

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -8,19 +8,16 @@
 
 {% set csrf = csrf_token() %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-{% block main_content %}
+  }) }}
+
     {%
       with
       heading = "Check edits to services"

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -8,7 +8,7 @@
 
 {% set csrf = csrf_token() %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -17,7 +17,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
     {%
       with
       heading = "Check edits to services"

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -14,6 +14,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Check edits to services"
       }
     ]
   }) }}

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -5,23 +5,18 @@
   {{ supplier.name }} - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for(".index"),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": supplier.name
+        "text": supplier.name
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
-{% block main_content %}
+  }) }}
 
   {%
     with heading = supplier.name

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -5,7 +5,7 @@
   {{ supplier.name }} - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -17,6 +17,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {%
     with heading = supplier.name

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -6,7 +6,7 @@
   Change {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -22,6 +22,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   <div class="grid-row">
     <div class="service-title">

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -6,27 +6,23 @@
   Change {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-          {
-              "link": url_for('.supplier_details', supplier_id=supplier.id),
-              "label": supplier.name
-          },
-          {
-              "label": "{} declaration".format(framework.name)
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
+      },
+      {
+        "text": "{} declaration".format(framework.name)
+      }
+    ]
+  }) }}
+
   <div class="grid-row">
     <div class="service-title">
       {%

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -4,7 +4,7 @@
   DUNS number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -20,7 +20,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
 <div class="grid-row">
 <div class="column-two-thirds">
   {% with heading = "Change the DUNS number for ‘{}’".format(supplier.name) %}

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -4,27 +4,23 @@
   DUNS number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": supplier.name,
-        "link": url_for('.supplier_details', supplier_id=supplier.id)
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
       },
       {
-        "label": "DUNS number"
+        "text": "DUNS number"
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
 <div class="grid-row">
 <div class="column-two-thirds">
   {% with heading = "Change the DUNS number for ‘{}’".format(supplier.name) %}

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -9,27 +9,23 @@
   {{ super() }}
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": supplier.name,
-        "link": url_for('.supplier_details', supplier_id=supplier.id)
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
       },
       {
-        "label": "Change registered company address"
+        "text": "Change registered company address"
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company address for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -9,7 +9,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -25,6 +25,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company address for ‘{}’".format(supplier.name) %}

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -4,27 +4,23 @@
   Change registered company number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": supplier.name,
-        "link": url_for('.supplier_details', supplier_id=supplier.id)
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
       },
       {
-        "label": "Change registered company number"
+        "text": "Change registered company number"
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company number for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -4,7 +4,7 @@
   Change registered company number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -20,7 +20,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company number for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -4,27 +4,23 @@
   Change registered company name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": supplier.name,
-        "link": url_for('.supplier_details', supplier_id=supplier.id)
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
       },
       {
-        "label": "Change registered company name"
+        "text": "Change registered company name"
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company name for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -4,7 +4,7 @@
   Change registered company name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -20,7 +20,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% include 'toolkit/forms/validation.html' %}
   {% with heading = "Update registered company name for ‘{}’".format(supplier.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -6,20 +6,16 @@
   Upload {{ framework.name }} countersigned agreement - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
+
   {% if remove_countersigned_agreement_confirm %}
       <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug) }}'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -6,7 +6,7 @@
   Upload {{ framework.name }} countersigned agreement - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -15,7 +15,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% if remove_countersigned_agreement_confirm %}
       <form method="post" action='{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug) }}'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -12,6 +12,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Upload countersigned agreement"
       }
     ]
   }) }}

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -6,7 +6,7 @@
   View {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -22,7 +22,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   <div class="grid-row">
     <div class="service-title">
       {%

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -6,27 +6,23 @@
   View {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-          {
-              "link": url_for('.supplier_details', supplier_id=supplier.id),
-              "label": supplier.name
-          },
-          {
-              "label": "{} declaration".format(framework.name)
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
+      },
+      {
+        "text": "{} declaration".format(framework.name)
+      }
+    ]
+  }) }}
+
   <div class="grid-row">
     <div class="service-title">
       {%

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -14,6 +14,9 @@
       {
         "text": "{} agreements".format(framework.name),
         "href": url_for('.list_agreements', framework_slug=framework.slug)
+      },
+      {
+        "text": "Countersign framework agreements"
       }
     ]
   }) }}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -4,24 +4,20 @@
   Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-    {%
-    with items = [
-        {
-            "link": url_for('.index'),
-            "label": "Admin home"
-        },
-        {
-            "link": url_for('.list_agreements', framework_slug=framework.slug),
-            "label": "%s agreements" | format(framework.name)
-        },
-        ]
-    %}
-        {% include "toolkit/breadcrumb.html" %}
-    {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": "{} agreements".format(framework.name),
+        "href": url_for('.list_agreements', framework_slug=framework.slug)
+      }
+    ]
+  }) }}
+
 <div class='grid-row'>
   <div class="column-one-whole">
     {%

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -4,7 +4,7 @@
   Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -17,7 +17,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
 <div class='grid-row'>
   <div class="column-one-whole">
     {%

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -4,20 +4,16 @@
   Download lists of potential user research participants - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   {%
     with heading = "Download lists of potential user research participants"
   %}

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -10,6 +10,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Download lists of potential user research participants"
       }
     ]
   }) }}

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -4,7 +4,7 @@
   Download lists of potential user research participants - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -13,6 +13,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {%
     with heading = "Download lists of potential user research participants"

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -4,7 +4,7 @@
 
 {% block page_title %}Manage admin users - Digital Marketplace admin{% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -13,6 +13,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with heading = "Manage users" %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -10,6 +10,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Manage admin users"
       }
     ]
   }) }}

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -4,20 +4,16 @@
 
 {% block page_title %}Manage admin users - Digital Marketplace admin{% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
+
   {% with heading = "Manage users" %}
     {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -6,7 +6,7 @@
   Uploaded {{ framework.name }} framework agreements – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -15,6 +15,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with heading = "Uploaded {} framework agreements".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -6,20 +6,15 @@
   Uploaded {{ framework.name }} framework agreements – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
 
   {% with heading = "Uploaded {} framework agreements".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -12,6 +12,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Uploaded framework agreements"
       }
     ]
   }) }}

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -6,7 +6,7 @@
   {{ framework.name }} framework agreements - Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -15,6 +15,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with smaller = True, heading = "{} framework agreements".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -6,20 +6,15 @@
   {{ framework.name }} framework agreements - Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
 
   {% with smaller = True, heading = "{} framework agreements".format(framework.name) %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -12,6 +12,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Framework agreements"
       }
     ]
   }) }}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -10,6 +10,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Buyers"
       }
     ]
   }) }}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -4,7 +4,7 @@
 
 {% block page_title %}Buyers - Digital Marketplace admin{% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -13,6 +13,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with heading = "Find a buyer" %}
   {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -4,20 +4,16 @@
 
 {% block page_title %}Buyers - Digital Marketplace admin{% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
+
   {% with heading = "Find a buyer" %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -6,7 +6,7 @@
   {{ service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] }} – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -19,6 +19,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% block before_heading %}
 

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -6,24 +6,19 @@
   {{ service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] }} – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "link": url_for(".find_supplier_services", supplier_id=service_data['supplierId']),
-        "label": service_data['supplierName']
+        "text": service_data['supplierName'],
+        "href": url_for(".find_supplier_services", supplier_id=service_data['supplierId'])
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
-{% block main_content %}
+  }) }}
 
   {% block before_heading %}
 

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -2,8 +2,10 @@
 
 {% extends "_base_page.html" %}
 
+{% set page_title = service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] %}
+
 {% block page_title %}
-  {{ service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] }} – Digital Marketplace admin
+  {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 
 {% block beforeContent %}
@@ -16,6 +18,9 @@
       {
         "text": service_data['supplierName'],
         "href": url_for(".find_supplier_services", supplier_id=service_data['supplierId'])
+      },
+      {
+        "text": page_title
       }
     ]
   }) }}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -2,8 +2,10 @@
 
 {% extends "_base_page.html" %}
 
+{% set page_title = "{} statistics".format(framework['name']) %}
+
 {% block page_title %}
-  {{ framework.name }} Statistics – Digital Marketplace admin
+  {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 
 {% block beforeContent %}
@@ -12,6 +14,9 @@
       {
         "text": "Admin home",
         "href": url_for('main.index')
+      },
+      {
+        "text": page_title
       }
     ]
   }) }}

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -6,15 +6,18 @@
   {{ framework.name }} Statistics – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
         "text": "Admin home",
-        "href": url_for('.index')
+        "href": url_for('main.index')
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   <div class="framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
     <div class="grid-row">

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -6,20 +6,16 @@
   {{ framework.name }} Statistics – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('main.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+  }) }}
 
-{% block main_content %}
   <div class="framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
     <div class="grid-row">
       <div class="column-two-thirds">
@@ -30,7 +26,7 @@
         %}
           {% include "toolkit/page-heading.html" %}
         {% endwith %}
-        
+
         {% if not big_screen_mode %}
           <a href="?big_screen_mode=yes">Big screen view</a>
         {% endif %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -6,26 +6,22 @@
   {{ supplier.name }} - Services – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-    with items = [
+{% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
       {
-        "link": url_for('.index'),
-        "label": "Admin home"
+        "text": "Admin home",
+        "href": url_for('.index')
       },
       {
-        "label": supplier.name,
-        "link": url_for('.supplier_details', supplier_id=supplier.id)
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
       },
       {
-        "label": "Services"
+        "text": "Services"
       }
     ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-{% block main_content %}
+  }) }}
 
   {% block before_heading %}
     {% if remove_services_for_framework or publish_services_for_framework %}

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -6,7 +6,7 @@
   {{ supplier.name }} - Services – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -22,7 +22,9 @@
       }
     ]
   }) }}
+{% endblock %}
 
+{% block main_content %}
   {% block before_heading %}
     {% if remove_services_for_framework or publish_services_for_framework %}
 

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -6,7 +6,7 @@
   {{ supplier.name }} users – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -22,6 +22,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with heading = supplier.name %}
   {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -6,27 +6,23 @@
   {{ supplier.name }} users – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-          {
-              "label": supplier.name,
-              "link": url_for('.supplier_details', supplier_id=supplier.id)
-          },
-          {
-              "label": "Users"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
+      },
+      {
+        "text": "Users"
+      }
+    ]
+  }) }}
+
   {% with heading = supplier.name %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -10,6 +10,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Suppliers"
       }
     ]
   }) }}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -4,7 +4,7 @@
 
 {% block page_title %}Suppliers - Digital Marketplace admin{% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -13,6 +13,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with heading = "Suppliers" %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -4,20 +4,15 @@
 
 {% block page_title %}Suppliers - Digital Marketplace admin{% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          }
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
 
   {% with heading = "Suppliers" %}
     {% include "toolkit/page-heading.html" %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -12,6 +12,9 @@
       {
         "text": "Admin home",
         "href": url_for('.index')
+      },
+      {
+        "text": "Find a user"
       }
     ]
   }) }}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -6,20 +6,16 @@
     Find a user – Digital Marketplace admin
 {% endblock %}
 
-{% block breadcrumb %}
-  {%
-      with items = [
-          {
-              "link": url_for('.index'),
-              "label": "Admin home"
-          },
-      ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
-
 {% block main_content %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      }
+    ]
+  }) }}
+
   {% with heading = "Find a user" %}
   {% include "toolkit/page-heading.html" %}
   {% endwith %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -6,7 +6,7 @@
     Find a user – Digital Marketplace admin
 {% endblock %}
 
-{% block main_content %}
+{% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
@@ -15,6 +15,9 @@
       }
     ]
   }) }}
+{% endblock %}
+
+{% block main_content %}
 
   {% with heading = "Find a user" %}
   {% include "toolkit/page-heading.html" %}

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -719,7 +719,8 @@ class TestServiceEdit(LoggedInApplicationTest):
             "normalize-space(string(//input[@name='serviceName']/@value))"
         ) == service["serviceName"]
         assert document.xpath(
-            "//nav//a[@href='/admin/services/123'][normalize-space(string())=$t]",
+            "//div[contains(@class, 'govuk-breadcrumbs')]"
+            "//a[@href='/admin/services/123'][normalize-space(string())=$t]",
             t=service["serviceName"],
         )
 
@@ -829,7 +830,8 @@ class TestServiceEdit(LoggedInApplicationTest):
         # ensure a field that data doesn't yet exist for is shown
         assert document.xpath("//input[@name='sfiaRateDocumentURL']")
         assert document.xpath(
-            "//nav//a[@href='/admin/services/321'][normalize-space(string())=$t]",
+            "//div[contains(@class, 'govuk-breadcrumbs')]"
+            "//a[@href='/admin/services/321'][normalize-space(string())=$t]",
             t=service["serviceName"],
         )
 


### PR DESCRIPTION
The biggest thing to look out for as part of code review is that the label
and href match what was previously used on the page.

breadcrumbs block will not be available once we migrate from govuk_template
to govuk-frontend template. We will need to move these inside a beforeContent block but for the moment we will need to place it inside `main` so that breadcrumbs are scoped to the width of the page

See:
- http://design-system.service.gov.uk/styles/layout/#limiting-width-of-content
- http://design-system.service.gov.uk/styles/page-template

Trello card: https://trello.com/c/9KcXEsfF