### PR TITLE
toggle_supplier_services view: don't wait_for_index in update_service_status() call

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -46,6 +46,7 @@ UPLOAD_COUNTERSIGNED_AGREEMENT_MESSAGE = "Countersigned agreement file was uploa
 COUNTERSIGNED_AGREEMENT_NOT_PDF_MESSAGE = "Countersigned agreement file is not a PDF"
 SUPPLIER_SERVICES_REMOVED_MESSAGE = "You suspended all {framework_name} services for ‘{supplier_name}’."
 SUPPLIER_SERVICES_UNSUSPENDED_MESSAGE = "You unsuspended all {framework_name} services for ‘{supplier_name}’."
+SUPPLIER_SERVICES_DELAYED_INDEX_MESSAGE = "Search results may take a few minutes to be updated."
 SUPPLIER_USER_MESSAGES = {
     'user_invited': 'User invited',
     'user_moved': 'User moved to this supplier',
@@ -846,11 +847,21 @@ def toggle_supplier_services(supplier_id):
         abort(400, 'No {} services on framework'.format(toggle_action['old_status']))
 
     for service in services:
-        data_api_client.update_service_status(service['id'], toggle_action['new_status'], current_user.email_address)
+        data_api_client.update_service_status(
+            service['id'],
+            toggle_action['new_status'],
+            current_user.email_address,
+            wait_for_index=False,
+        )
 
-    flash(toggle_action['flash_message'].format(
-        supplier_name=services[0]['supplierName'],
-        framework_name=services[0]['frameworkName'])
+    flash(
+        " ".join((
+            toggle_action['flash_message'].format(
+                supplier_name=services[0]['supplierName'],
+                framework_name=services[0]['frameworkName']
+            ),
+            SUPPLIER_SERVICES_DELAYED_INDEX_MESSAGE,
+        ))
     )
     return redirect(url_for('.find_supplier_services', supplier_id=supplier_id))
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,5 +11,5 @@ itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,15 +12,15 @@ itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.223
-botocore==1.12.223
-certifi==2019.6.16
+boto3==1.9.228
+botocore==1.12.228
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 Click==7.0

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1226,9 +1226,9 @@ class TestToggleSupplierServicesView(LoggedInApplicationTest):
             )
         ]
         assert self.data_api_client.update_service_status.call_args_list == [
-            mock.call('5687123785023488', result_status, 'test@example.com'),
-            mock.call('5687123785023489', result_status, 'test@example.com'),
-            mock.call('5687123785023490', result_status, 'test@example.com'),
+            mock.call('5687123785023488', result_status, 'test@example.com', wait_for_index=False),
+            mock.call('5687123785023489', result_status, 'test@example.com', wait_for_index=False),
+            mock.call('5687123785023490', result_status, 'test@example.com', wait_for_index=False),
         ]
 
     @pytest.mark.parametrize('action, message_action', [
@@ -1241,7 +1241,10 @@ class TestToggleSupplierServicesView(LoggedInApplicationTest):
 
         assert response.status_code == 302
 
-        expected_flash_message = "You {} all G-Cloud 8 services for ‘PROACTIS Group Ltd’.".format(message_action)
+        expected_flash_message = (
+            "You {} all G-Cloud 8 services for ‘PROACTIS Group Ltd’. Search results may take a few minutes "
+            "to be updated."
+        ).format(message_action)
         with self.client.session_transaction() as session:
             assert session['_flashes'][0][1] == expected_flash_message
 


### PR DESCRIPTION
This final piece of https://trello.com/c/LABe8BKA is simple enough, depending on https://github.com/alphagov/digitalmarketplace-apiclient/pull/223 and https://github.com/alphagov/digitalmarketplace-api/pull/968