### PR TITLE
Replacing toolkit/page-headings with govuk frontend headings

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -21,7 +21,6 @@ $path: "/admin/static/images/";
 @import "toolkit/_footer";
 @import "toolkit/_grids";
 @import "toolkit/_notification-banners";
-@import "toolkit/_page-headings";
 @import "toolkit/_phase-banner";
 @import "toolkit/_previous-next-navigation";
 @import "toolkit/_proposition-header";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -58,6 +58,7 @@ $govuk-compatibility-govukelements: true;
 
 // Overrides
 @import "overrides/_notifications_banner";
+@import "overrides/_page_headings";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_page_headings.scss
+++ b/app/assets/scss/overrides/_page_headings.scss
@@ -1,0 +1,11 @@
+// FIXME: Temporary, remove once we are using govuk-frontend grids
+//
+// This is needed to push down the page content but more specifically page
+// headings.
+//
+// Previously CSS would adjust top and bottom margins/padding. We should try
+// spacing by pushing content down and not worrying about what is above it.
+
+#content {
+  @include govuk-responsive-margin(7, "top");
+}

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -27,9 +27,7 @@
     {% endwith %}
   {% endfor %}
 
-  {% with heading = "Add a buyer email domain" %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Add a buyer email domain</h1>
 
   <form method="post">
     <div class="grid-row">

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -23,14 +23,9 @@
 {% endblock %}
 
 {% block main_content %}
-  {%
-    with
-    smaller = true,
-    heading = service['serviceName'],
-    context = service['supplierName']
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <span class="govuk-caption-l">{{ service['supplierName'] }}</span>
+  <h1 class="govuk-heading-l">{{ service['serviceName'] }}</h1>
+
   {%
     with
       url = url_for("external.direct_award_service_page", framework_family=service['frameworkFamily'], service_id=service["id"]),

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -23,9 +23,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with heading = "Confirm communications deletion" %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Confirm communications deletion</h1>
 
   <form method="POST" action="">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -21,11 +21,7 @@
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {%
-        with heading = "Download supplier lists for {}".format(framework['name'])
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">Download supplier lists for {{ framework['name'] }}</h1>
 
       <div class="explanation-list">
           <p class="lede">These lists contain details of all suppliers who:</p>

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -28,9 +28,7 @@
     {% endwith %}
   {% endfor %}
 
-  {% with heading = admin_user.emailAddress %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">{{ admin_user.emailAddress }}</h1>
 
   <form method="post">
     <div class="grid-row">

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -28,13 +28,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {%
-    with
-    heading = section.name,
-    smaller = True
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-l">{{ section.name }}</h1>
 
   {% include 'toolkit/forms/validation.html' %}
 

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -23,9 +23,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with heading = "Change supplier name" %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Change supplier name</h1>
   <form method="post">
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -17,9 +17,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {% with heading = "You don’t have permission to perform this action" %}
-    {% include 'toolkit/page-heading.html' %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">You don’t have permission to perform this action</h1>
   <p>
     Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need to access this content.
   </p>

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -29,11 +29,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {%
-    with heading = page_title
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,11 +5,7 @@
 {% block main_content %}
 <div class="grid-row">
   <div class="column-two-thirds">
-  {%
-    with heading = "Admin"
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+    <h1 class="govuk-heading-xl">Admin</h1>
   </div>
 </div>
 <div class="grid-row">

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -28,12 +28,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-        heading = page_name,
-        smaller=True
-      %}
-      {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-l">{{ page_title }}</h1>
 
       <form method="POST" action="{{ url_for('.invite_admin_user') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -20,10 +20,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with heading = "Manage {} communications".format(framework.name) %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Manage {{framework.name}} communications</h1>
 
   <form method="post" enctype="multipart/form-data">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -31,11 +31,7 @@
 {% endblock %}
 
 {% block main_content %}
-  {%
-    with heading = page_title
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
   {% set supplierNameHtml %}
     <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -23,12 +23,8 @@
 {% endblock %}
 
 {% block main_content %}
-    {%
-      with
-      heading = "Check edits to services"
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+    <h1 class="govuk-heading-xl">Check edits to services</h1>
+
     <div class="grid-row">
         <div class="column-one-whole">
         <p class="search-summary">

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -20,12 +20,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {%
-    with heading = supplier.name
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">{{ supplier.name }}</h1>
 
   {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-data-controller') %}
   <p><a href="{{ url_for('.edit_supplier_name', supplier_id=supplier_id) }}">Edit supplier name</a></p>

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -25,19 +25,8 @@
 {% endblock %}
 
 {% block main_content %}
-
-  <div class="grid-row">
-    <div class="service-title">
-      {%
-        with
-        context = supplier.name,
-        heading = section.name,
-        smaller = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
-  </div>
+  <span class="govuk-caption-l">{{ supplier.name }}</span>
+  <h1 class="govuk-heading-l">{{ section.name }}</h1>
 
   <form method="post" enctype="multipart/form-data">
     <div class="grid-row">

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -25,9 +25,7 @@
 {% block main_content %}
 <div class="grid-row">
 <div class="column-two-thirds">
-  {% with heading = "Change the DUNS number for ‘{}’".format(supplier.name) %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Change the DUNS number for ‘{{supplier.name}}’</h1>
 
   <p>You need to contact <a href="mailto:cloud_digital@crowncommercial.gov.uk ">cloud_digital@crowncommercial.gov.uk </a> to change a supplier DUNS number.</p>
   <br /><a href="{{ url_for('.supplier_details', supplier_id=supplier.id) }}">Return to ‘{{ supplier.name }}’ company details</a></p>

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -28,11 +28,8 @@
 {% endblock %}
 
 {% block main_content %}
-
   {% include 'toolkit/forms/validation.html' %}
-  {% with heading = "Update registered company address for ‘{}’".format(supplier.name) %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Update registered company address for ‘{{supplier.name}}’</h1>
   <form method="post">
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -24,9 +24,7 @@
 
 {% block main_content %}
   {% include 'toolkit/forms/validation.html' %}
-  {% with heading = "Update registered company number for ‘{}’".format(supplier.name) %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Update registered company number for ‘{{supplier.name}}’</h1>
   <form method="post">
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -24,9 +24,7 @@
 
 {% block main_content %}
   {% include 'toolkit/forms/validation.html' %}
-  {% with heading = "Update registered company name for ‘{}’".format(supplier.name) %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Update registered company name for ‘{{supplier.name}}’</h1>
   <form method="post">
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -35,18 +35,8 @@
       </div>
   {% endif %}
 
-  <div class="grid-row">
-    <div class="service-title">
-      {%
-        with
-        context = supplier.name,
-        heading = "Upload a " + framework.name + " countersigned agreement",
-        smaller = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
-  </div>
+  <span class="govuk-caption-l">{{ supplier.name }}</span>
+  <h1 class="govuk-heading-l">Upload a {{ framework.name }} countersigned agreement</h1>
 
   {% set field_headings = [
     "Countersigned agreement",

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -25,18 +25,9 @@
 {% endblock %}
 
 {% block main_content %}
-  <div class="grid-row">
-    <div class="service-title">
-      {%
-        with
-        context = supplier.name,
-        heading = framework.name + " declaration",
-        smaller = True
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
-  </div>
+  <span class="govuk-caption-l">{{ supplier.name }}</span>
+  <h1 class="govuk-heading-l">{{ framework.name }} declaration</h1>
+
   {% call summary.mapping_table(
     caption="Application status",
     field_headings_visible=False

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -23,17 +23,7 @@
 {% endblock %}
 
 {% block main_content %}
-<div class='grid-row'>
-  <div class="column-one-whole">
-    {%
-        with
-        heading = company_details.registered_name,
-        smaller = True
-    %}
-    {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-  </div>
-</div>
+<h1 class="govuk-heading-l">{{ company_details.registered_name }}</h1>
 <div class='grid-row'>
   <div class="column-one-third">
       <h2>Registered address</h2>

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -19,15 +19,10 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {%
-    with heading = "Download lists of potential user research participants"
-  %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-    <p class="lede">
+  <h1 class="govuk-heading-xl">Download lists of potential user research participants</h1>
+  <p class="lede govuk-!-margin-bottom-6">
     Lists are generated daily. Check you've got the most recent version of the list before you contact users.
-</p><br>
+  </p>
 
   {%
     with

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -19,10 +19,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with heading = "Manage users" %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Manage users</h1>
 
 <div class="page-section">
   {% set role_descriptors = {

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -21,10 +21,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with heading = "Uploaded {} framework agreements".format(framework.name) %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Uploaded {{framework.name}} framework agreements</h1>
 
   {% set field_headings = [
     "Supplier name",

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -21,10 +21,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with smaller = True, heading = "{} framework agreements".format(framework.name) %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-l">{{framework.name}} framework agreements</h1>
 
   {% if current_user.has_role('admin-ccs-sourcing') %}
   {# ### Don't show instructions for read-only users ### #}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -19,11 +19,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with heading = "Find a buyer" %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
-
+  <h1 class="govuk-heading-xl">Find a buyer</h1>
 
   <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">
     {%

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -90,14 +90,8 @@
 
 
   {% if service_data %}
-    {%
-      with
-      context = service_data['supplierName'],
-      heading = service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'],
-      smaller = True
-    %}
-      {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+    <span class="govuk-caption-l">{{ service['supplierName'] }}</span>
+    <h1 class="govuk-heading-l">{{ service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] }}</h1>
 
     {# links #}
     <ul class="list-no-bullet">

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -27,13 +27,8 @@
   <div class="framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
     <div class="grid-row">
       <div class="column-two-thirds">
-        {%
-          with
-          context = framework.name,
-          heading = "Statistics"
-        %}
-          {% include "toolkit/page-heading.html" %}
-        {% endwith %}
+        <span class="govuk-caption-xl">{{ framework.name }}</span>
+        <h1 class="govuk-heading-xl">Statistics</h1>
 
         {% if not big_screen_mode %}
           <a href="?big_screen_mode=yes">Big screen view</a>

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -55,13 +55,7 @@
     {% endif %}
   {% endblock %}
 
-  <div class="grid-row">
-    <div class="column-one-whole">
-      {% with heading = "Services" %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
-    </div>
-  </div>
+  <h1 class="govuk-heading-xl">Services</h1>
 
   {% if not frameworks_services %}
     {% call(item) summary.list_table(

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -25,10 +25,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with heading = supplier.name %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">{{ supplier.name }}</h1>
 
   <div class='page-section'>
     {% call(item) summary.list_table(

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -19,10 +19,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with heading = "Suppliers" %}
-    {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Suppliers</h1>
 
   <div class="page-section">
       {% include "_view_suppliers_edit_list.html" %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -21,10 +21,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-  {% with heading = "Find a user" %}
-  {% include "toolkit/page-heading.html" %}
-  {% endwith %}
+  <h1 class="govuk-heading-xl">Find a user</h1>
 
   <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
     {%

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -36,7 +36,7 @@ class TestBuyersView(LoggedInApplicationTest):
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
         heading = document.xpath(
-            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+            '//h1/text()')[0].strip()
 
         assert response.status_code == 200
         assert "There are no opportunities with ID" not in page_html

--- a/tests/app/main/views/test_search.py
+++ b/tests/app/main/views/test_search.py
@@ -18,7 +18,7 @@ class TestSearchSuppliersAndServices(LoggedInApplicationTest):
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
         header = document.xpath(
-            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+            '///h1/text()')[0].strip()
 
         assert response.status_code == 200
         assert header == expected_header

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1896,9 +1896,8 @@ class TestServiceUpdates(LoggedInApplicationTest):
             } for args, kwargs in self.data_api_client.find_audit_events.call_args_list
         )
 
-        assert doc.xpath("normalize-space(string(//header//*[@class='context']))") == "Barrington's"
-        assert doc.xpath("normalize-space(string(//header//h1))") == "Lemonflavoured soap"
-
+        assert doc.cssselect('.govuk-caption-l')[0].text == "Barrington's"
+        assert doc.cssselect('.govuk-heading-l')[0].text == "Lemonflavoured soap"
         assert tuple(
             a.attrib["href"] for a in doc.xpath("//a[normalize-space(string())=$t]", t="View service")
         ) == ("/g-cloud/services/151",)

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -40,7 +40,7 @@ class TestUsersView(LoggedInApplicationTest):
         page_html = response.get_data(as_text=True)
         document = html.fromstring(page_html)
         heading = document.xpath(
-            '//header[@class="page-heading page-heading-without-breadcrumb"]//h1/text()')[0].strip()
+            '//h1/text()')[0].strip()
 
         assert response.status_code == 200
         assert "Sorry, we couldn't find an account with that email address" not in page_html


### PR DESCRIPTION
This replaces toolkit/page-headings with govuk frontend page titles.

Generally, the headings were `h1` with a css class of `govuk-heading-xl`.
These were the mappings I used while replacing

Generally, use `govuk-heading-xl` class
If "smaller : true" when calling toolkit/page-heading, is 'h1` with
`govuk-heading-l`.
If "Context" used when calling toolkit/page-heading, add span above the
`h1` and use govuk-caption-xl or govuk-caption-l depending on the heading
used.

while replacing the headings I noticed that there is an inconsistency with
the markup where sometimes the headings are placed inside a grid and others
aren't. I also found a difference between heading titles font sizes, it
would be good to use a consistent size. I will try address these when
the grid system is replaced.


Trello card: https://trello.com/c/jjTqegdr