### PR TITLE
Replace user research banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,6 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/report-a-problem.js
 //= require ../../../node_modules/govuk-frontend/all.js
 //= require _scroll-through-statistics.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,7 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/report-a-problem.js
+; // Hack needed because show-hide-content.js does not have a closing ";"
 //= require ../../../node_modules/govuk-frontend/all.js
 //= require _scroll-through-statistics.js
 //= require _selection-buttons.js

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -20,7 +20,6 @@ $path: "/admin/static/images/";
 @import "toolkit/_document.scss";
 @import "toolkit/_footer";
 @import "toolkit/_notification-banners";
-@import "toolkit/_phase-banner";
 @import "toolkit/_previous-next-navigation";
 @import "toolkit/_proposition-header";
 @import "toolkit/_secondary-action-link";
@@ -36,7 +35,6 @@ $path: "/admin/static/images/";
 @import "toolkit/forms/_word-counter";
 @import "toolkit/forms/_option-select";
 @import "toolkit/forms/_keyword-search";
-@import "toolkit/_user-research-consent-banner.scss";
 
 // GOV.UK Design System (compatible with old toolkit/elements)
 $govuk-assets-path: '/admin/static/';

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -3,12 +3,35 @@
 {# Import GOV.UK Frontend components for globale usage#}
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "components/tabs/macro.njk" import govukTabs %}
+
+{# This can be removed once we start using govuk-frontend template #}
+{# The reason calling this block here is to change the header title so that it does not
+   include the phase tag #}
+{% block inside_header %}
+  <div class="header-title">
+    <a href="/">Digital Marketplace</a>
+  </div>
+{% endblock %}
+
+{# This can be removed once we start using govuk-frontend template #}
+{# The reason for calling this is to ensure we do not output the user research signup banner #}
+{% block after_header %}
+{% endblock %}
 
 {# override content block to add a beforeContent block like the one in govuk-frontend template #}
 {% block content %}
   {% block top_header %}{% endblock %}
   <div id="wrapper">
+    {# This is only a temporary place for the phase banner until we start using govuk-frontend template #}
+    {{ govukPhaseBanner({
+      "tag": {
+        "text": "beta"
+      },
+      "html": 'Help us improve the Digital Marketplace - <a class="govuk-link" href="https://www.digitalmarketplace.service.gov.uk/help">send your feedback</a>'
+    }) }}
+
     {% block beforeContent %}{% endblock %}
     <main id="content" role="main">
       {% include "toolkit/flash_messages.html" %}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -29,7 +29,7 @@
       "tag": {
         "text": "beta"
       },
-      "html": 'Help us improve the Digital Marketplace - <a class="govuk-link" href="https://www.digitalmarketplace.service.gov.uk/help">send your feedback</a>'
+      "html": 'Help us improve the Digital Marketplace - <a class="govuk-link" href="'  + url_for('external.help') + '">send your feedback</a>'
     }) }}
 
     {% block beforeContent %}{% endblock %}


### PR DESCRIPTION
[Introduces GOV.UK Frontend phase banner component](https://design-system.service.gov.uk/components/phase-banner)

While we were trying to migrate from govuk_template to govuk-frontend
template. An issue was identified with having the user research sign up
banner positioned between the top black header and the colour. It would mean that we could not use GOV.UK Frontend header component
and we would still have to maintain the user research banner and it also
relied on govuk_templates cookie implementation which we would also need
to either copy or remove completely. As this was the only component using
GOVUK.cookie method it would be good to remove it.

This change also brings our designs closer inline with GOV.UK Design System and their recommendation:

> Your banner must be directly under the black GOV.UK header and colour bar.

### Before
![image](https://user-images.githubusercontent.com/3441519/65248448-17529000-daea-11e9-9c01-66d8e7182050.png)

### After
![image (2)](https://user-images.githubusercontent.com/3441519/65707793-25be2000-e085-11e9-997f-8cb0ee58244c.png)

---

Trello: https://trello.com/c/8oD7F688/309-replace-user-research-consent-banner-with-phase-banner-in-the-admin-frontend