### PR TITLE
Cross domain tracking

### DIFF
--- a/app/assets/javascripts/analytics/_init.js
+++ b/app/assets/javascripts/analytics/_init.js
@@ -1,12 +1,10 @@
-//= require ../../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
-//= include ../../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js
-
-; // JavaScript in the govuk_frontend_toolkit doesn't have trailing semicolons
-
 // Custom Admin FE analytics
 //= include _register.js
 
 // DM Frontend Toolkit analytics
+//= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_pii.js
+//= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_googleAnalyticsUniversalTracker.js
+//= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_govukAnalytics.js
 //= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_events.js
 //= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_pageViews.js
 //= include ../../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_virtualPageViews.js

--- a/app/assets/javascripts/analytics/_register.js
+++ b/app/assets/javascripts/analytics/_register.js
@@ -14,6 +14,8 @@
         universalId: universalId,
         cookieDomain: cookieDomain
       });
+      // Add GOV.UK cross domain tracking - see https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/480
+      GOVUK.analytics.addLinkedTrackerDomain('UA-145652997-1', 'govuk_shared', ['www.gov.uk'])
     },
 
     // wrapper around access to window.location

--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,8 +1146,8 @@
       "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10"
     },
     "digitalmarketplace-frontend-toolkit": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87fd99dddd47ab620db6fb83637f8c8bd10540c4",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.3.0",
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b0287c4eb54721b126fb56050705cde5bd940efc",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
       "requires": {
         "del": "^4.1.0",
         "govuk-elements-sass": "3.0.3",
@@ -2292,7 +2292,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2310,11 +2311,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2327,15 +2330,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2438,7 +2444,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2448,6 +2455,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2460,17 +2468,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2487,6 +2498,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2559,7 +2571,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2569,6 +2582,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2644,7 +2658,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2674,6 +2689,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2691,6 +2707,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2729,11 +2746,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3094,7 +3113,7 @@
         "glob": "^4.0.6",
         "gulp-util": "^3.0.0",
         "handlebars": "^2.0.0",
-        "jasmine": "github:dflynn15/jasmine-npm#5f74e4336b247e67bbc509a8f82f3c4fa6b52964",
+        "jasmine": "github:dflynn15/jasmine-npm",
         "lodash": "^4.3.0",
         "through2": "^0.6.1"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "colors": "1.1.2",
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.3.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
     "govuk-country-and-territory-autocomplete": "0.5.1",
     "govuk-elements-sass": "3.0.3",
     "govuk-frontend": "^2.4.0",


### PR DESCRIPTION
https://trello.com/c/XzgBSxIQ/1125-fwd-important-cross-domain-tracking-for-govuk-and-digital-market-place-service

- Pulls in FE toolkit changes for cross domain tracking
- Adds the new cross domain tracking ID to the custom `_register.js` file (Admin FE has its own separate tracking ID for our Digital Marketplace analytics, so the custom `_register.js` is used instead of the  FE toolkit file)

See equivalent Buyer FE pull request for more detail alphagov/digitalmarketplace-buyer-frontend#931