### PR TITLE
Refactor CSS to bring it more inline with GOV.UK Frontend

### DIFF
--- a/app/assets/scss/_c3.scss
+++ b/app/assets/scss/_c3.scss
@@ -2,7 +2,7 @@
 
 /*-- Chart --*/
 .c3 svg {
-  font-size: 14px;
+  @include govuk-font(14);
 }
 
 .c3 path, .c3 line {
@@ -21,8 +21,8 @@
   stroke: #fff; }
 
 .c3-chart-arc text {
-  fill: #fff;
-  font-size: 14px; }
+  @include govuk-font(14);
+  fill: #fff;}
 
 /*-- Axis --*/
 /*-- Grid --*/
@@ -116,14 +116,13 @@
 }
 
 .c3-tooltip th {
-  font-weight: bold;
+  @include govuk-font(14, $weight: bold);
   padding: 5px;
   text-align: left;
-  font-size: 14px;
 }
 
 .c3-tooltip td {
-  font-size: 14px;
+  @include govuk-font(14);
   padding: 5px;
   margin-bottom: 12px;
   border-top: 1px solid $border-colour;
@@ -153,8 +152,8 @@
   stroke: none; }
 
 .c3-chart-arcs .c3-chart-arcs-gauge-unit {
-  fill: #000;
-  font-size: 16px; }
+  @include govuk-font(16);
+  fill: #000;}
 
 .c3-chart-arcs .c3-chart-arcs-gauge-max {
   fill: #777; }

--- a/app/assets/scss/_c3.scss
+++ b/app/assets/scss/_c3.scss
@@ -106,13 +106,13 @@
   border-collapse: collapse;
   border-spacing: 0;
   empty-cells: show;
-  -webkit-box-shadow: 7px 7px 12px -9px rgba($text-colour, 0.1);
-  -moz-box-shadow: 7px 7px 12px -9px rgba($text-colour, 0.1);
-  box-shadow: 7px 7px 12px -9px rgba($text-colour, 0.1);
+  -webkit-box-shadow: 7px 7px 12px -9px rgba($govuk-text-colour, 0.1);
+  -moz-box-shadow: 7px 7px 12px -9px rgba($govuk-text-colour, 0.1);
+  box-shadow: 7px 7px 12px -9px rgba($govuk-text-colour, 0.1);
 }
 
 .c3-tooltip tr {
-  background: rgba($white, 0.9);
+  background: rgba(govuk-colour("white"), 0.9);
 }
 
 .c3-tooltip th {
@@ -125,7 +125,7 @@
   @include govuk-font(14);
   padding: 5px;
   margin-bottom: 12px;
-  border-top: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
 }
 
 .c3-tooltip td > span {

--- a/app/assets/scss/_diff.scss
+++ b/app/assets/scss/_diff.scss
@@ -1,9 +1,9 @@
 .diff {
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
 
   .page-column-headings + table {
       caption {
-          padding-top: $gutter/2;
+          padding-top: govuk-spacing(3);
       }
   }
 
@@ -18,7 +18,7 @@
     caption {
       font-weight: bold;
       text-align: left;
-      padding: $gutter 0 10px;
+      padding: govuk-spacing(6) 0 govuk-spacing(2);
     }
 
     tbody tr {
@@ -31,7 +31,7 @@
       vertical-align: top;
       border-right: none;
       @include media(tablet) {
-        border-right: 5px solid white;
+        border-right: govuk-spacing(1) solid govuk-colour('white');
       }
 
       &.line-non-existent {

--- a/app/assets/scss/_diff.scss
+++ b/app/assets/scss/_diff.scss
@@ -8,9 +8,9 @@
   }
 
   table {
-    @include core-14;
+    @include govuk-font(14);
     @include media(tablet) {
-      @include core-19;
+      @include govuk-font(19);
     }
 
     width: 100%;
@@ -57,7 +57,7 @@
       }
 
       &.line-number {
-        @include core-14($tabular-numbers: true);
+        @include govuk-font($size: 14, $tabular: true);
         text-align: right;
         float: left;
         clear: both;
@@ -66,7 +66,7 @@
         border-right: none;
 
         @include media(tablet) {
-          @include core-19($tabular-numbers: true);
+          @include govuk-font($size: 19, $tabular: true);
           float: none;
         }
       }

--- a/app/assets/scss/_layout.scss
+++ b/app/assets/scss/_layout.scss
@@ -2,7 +2,7 @@
 @import "colours";
 
 #global-header-bar {
-  background: $red;
+  background: govuk-colour('red');
 }
 
 #wrapper {

--- a/app/assets/scss/_layout.scss
+++ b/app/assets/scss/_layout.scss
@@ -7,9 +7,9 @@
 
 #wrapper {
   @extend %site-width-container;
-  padding-bottom: $gutter * 2;
+  padding-bottom: govuk-spacing(9);
 }
 
 .page-section {
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -113,7 +113,7 @@ $govuk-compatibility-govukelements: true;
 }
 
 .location-autocomplete-fallback {
-  @include core-19;
+  @include govuk-font(19);
   width: 100%;
   height: 42px;
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -63,12 +63,12 @@ $govuk-compatibility-govukelements: true;
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit
 .border-image {
   width: 100%;
-  border: 5px solid #dee0e2;
+  border: govuk-spacing(1) solid #dee0e2;
 }
 
 .search-summary-border-bottom {
-  padding: 0 0 $gutter-half;
-  margin: 0 0 $gutter-half;
+  padding: 0 0 govuk-spacing(3);
+  margin: 0 0 govuk-spacing(3);
   border-bottom: 1px solid $govuk-border-colour;
 
   em {
@@ -78,9 +78,8 @@ $govuk-compatibility-govukelements: true;
 }
 
 .search-summary {
-  padding-bottom: 20px;
-  font-size: 24px;
-
+  padding-bottom: govuk-spacing(4);
+  @include govuk-font(24);
 }
 
 .break-email {
@@ -89,11 +88,11 @@ $govuk-compatibility-govukelements: true;
 
 .question + .secondary-action-link {
   margin-top: -36px;
-  margin-bottom: 40px;
+  margin-bottom: govuk-spacing(7);
 }
 
 .summary-item-field-heading, .summary-item-field {
-  padding-left: 10px;
+  padding-left: govuk-spacing(2);
 }
 
 .five-columns-table {

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -24,7 +24,6 @@ $path: "/admin/static/images/";
 @import "toolkit/_phase-banner";
 @import "toolkit/_previous-next-navigation";
 @import "toolkit/_proposition-header";
-@import "toolkit/_report-a-problem.scss";
 @import "toolkit/_secondary-action-link";
 @import "toolkit/_service-id";
 @import "toolkit/forms/_hint";
@@ -62,17 +61,9 @@ $govuk-compatibility-govukelements: true;
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit
-.padding-bottom-small {
-  padding-bottom: 10px;
-}
-
 .border-image {
   width: 100%;
   border: 5px solid #dee0e2;
-}
-
-.lead {
-  margin-bottom: 20px;
 }
 
 .search-summary-border-bottom {

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -69,7 +69,7 @@ $govuk-compatibility-govukelements: true;
 .search-summary-border-bottom {
   padding: 0 0 $gutter-half;
   margin: 0 0 $gutter-half;
-  border-bottom: 1px solid $border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
 
   em {
     font-style: normal;

--- a/app/assets/scss/views/_list_agreements.scss
+++ b/app/assets/scss/views/_list_agreements.scss
@@ -4,11 +4,11 @@
 .search-page-filters {
   .status-filters {
     h2 {
-      @include bold-19;
+      @include govuk-font(19, $weight: bold);
     }
 
     ul {
-      @include core-16;
+      @include govuk-font(16);
       list-style: none;
       padding-left: 0;
       margin: 5px 0 $gutter;

--- a/app/assets/scss/views/_list_agreements.scss
+++ b/app/assets/scss/views/_list_agreements.scss
@@ -11,7 +11,7 @@
       @include govuk-font(16);
       list-style: none;
       padding-left: 0;
-      margin: 5px 0 $gutter;
+      margin: govuk-spacing(1) 0 govuk-spacing(6);
     }
   }
 }

--- a/app/assets/scss/views/_statistics.scss
+++ b/app/assets/scss/views/_statistics.scss
@@ -16,7 +16,7 @@
   }
 
   .summary-item-field {
-    @include bold-80;
+    @include govuk-font(80, $weight: bold);
   }
 
   .summary-item-field-headings-visible {
@@ -30,7 +30,7 @@
 
   .summary-item-field-heading {
 
-    @include core-24;
+    @include govuk-font(24);
 
     .key {
       display: inline-block;

--- a/app/assets/scss/views/_statistics.scss
+++ b/app/assets/scss/views/_statistics.scss
@@ -2,7 +2,7 @@
 
   position: relative;
   background: $link-colour;
-  box-shadow: 0 0 0 100em $link-colour;
+  box-shadow: 0 0 0 100em $govuk-link-colour;
   padding-bottom: 100em;
   z-index: 1000;
 
@@ -20,7 +20,7 @@
   }
 
   .summary-item-field-headings-visible {
-    border-top: 3px solid $link-colour;
+    border-top: 3px solid $govuk-link-colour;
   }
 
   .summary-item-field-first,
@@ -47,7 +47,7 @@
   }
 
   table.summary-item-body {
-    border-bottom: 3px solid $grey-3;
+    border-bottom: 3px solid govuk-colour('grey-3');
   }
 
   table.summary-item-body tbody td {

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -30,14 +30,14 @@
     <div class="column-two-thirds">
       {{ summary.heading("Company details") }}
       {% if current_user.has_role('admin-ccs-data-controller') %}
-      <p class="padding-bottom-small">
+      <p class="govuk-body">
         Change the company details on ‘{{ supplier.name }}’s Digital Marketplace account.
       </p>
-      <p class="padding-bottom-small">
+      <p class="govuk-body">
         These details do not get updated on the supplier’s framework agreement. Contact <a href="mailto:ccsrequests@digitalmarketplace.service.gov.uk">ccsrequests@digitalmarketplace.service.gov.uk</a>
         to update details on the framework agreement.
       </p>
-      <p class="padding-bottom-small">
+      <p class="govuk-body">
         This usually takes 5 days. ‘{{ supplier.name }}’ can’t sign their agreement until it is updated.
       </p>
       {% endif %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -27,14 +27,14 @@
 <div class='grid-row'>
   <div class="column-one-third">
       <h2>Registered address</h2>
-      <ul class="padding-bottom-small">
+      <ul class="govuk-list">
           <li>{{ company_details.address.street_address_line_1 }}</li>
           <li>{{ company_details.address.locality }}</li>
           <li>{{ company_details.address.postcode }}</li>
       </ul>
 
       <h2>Company number</h2>
-      <div class="padding-bottom-small">
+      <div class="govuk-!-padding-bottom-4">
         {% if company_details.registered_with == "companies_house" %}
           {%
           with
@@ -50,19 +50,19 @@
       </div>
 
       <h2>Appointment is to</h2>
-      <ul class="padding-bottom-small">
+      <ul class="govuk-list">
         {% for lot_slug, lot_name in lot_slugs_names.items() %}
           <li>{{ lot_name }}</li>
         {% endfor %}
       </ul>
 
       <h2>Signed by</h2>
-      <p class="padding-bottom-small">
+      <p class="govuk-body">
           {{ supplier_framework.agreementDetails.signerName}}, {{ supplier_framework.agreementDetails.signerRole }}
       </p>
 
       <h2>Uploaded by</h2>
-      <p class="padding-bottom-small">
+      <p class="govuk-body">
           {{ supplier_framework.agreementDetails.uploaderUserName }}
           <br>
           <span class="break-email">
@@ -74,7 +74,7 @@
 
       {% if supplier_framework.agreementStatus in ['approved', 'countersigned'] %}
         <h2>Accepted by</h2>
-        <p class="padding-bottom-small">
+        <p class="govuk-body">
           {{ supplier_framework.countersignedDetails.approvedByUserName }}
           <br>
           {{ supplier_framework.countersignedAt|datetimeformat }}
@@ -108,7 +108,7 @@
           </form>
         {% endif %}
       {% endif %}
-      <p class="padding-bottom-small">
+      <p class="govuk-body">
         {%
           with
           url = url_for(".next_agreement", framework_slug=framework.slug, supplier_id=supplier.id, status=next_status),

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -27,15 +27,13 @@
   {# ### Don't show instructions for read-only users ### #}
   <div class="grid-row">
     <div class="column-two-thirds dmspeak">
-      <div class="lead">
-          <p>
-            Review the information for each agreement, accept it, and continue to the next one.
-          </p>
-          <p>
-            If there’s a problem with an agreement, contact the person who uploaded it and come back to it later. Ask
-            suppliers to resubmit from the link in the email they received after they were accepted on to the framework.
-          </p>
-      </div>
+      <p class="govuk-body">
+        Review the information for each agreement, accept it, and continue to the next one.
+      </p>
+      <p class="govuk-body">
+        If there’s a problem with an agreement, contact the person who uploaded it and come back to it later. Ask
+        suppliers to resubmit from the link in the email they received after they were accepted on to the framework.
+      </p>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
- Removes two unnecessary css modifiers
- Start using govuk-font mix 
- [Start using govuk-frontend colour palette](https://design-system.service.gov.uk/styles/colour/). **(Colour palette did change slightly between v2 and v3 of govuk-frontend so I've had to still use v2 colour palette for the time being)**
- [Start using govuk-frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#spacing-on-custom-components) 