### PR TITLE
Replaces grid-* and column-* classes

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -19,7 +19,6 @@ $path: "/admin/static/images/";
 @import "toolkit/_contact-details.scss";
 @import "toolkit/_document.scss";
 @import "toolkit/_footer";
-@import "toolkit/_grids";
 @import "toolkit/_notification-banners";
 @import "toolkit/_phase-banner";
 @import "toolkit/_previous-next-navigation";

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -30,7 +30,7 @@
   <h1 class="govuk-heading-xl">Add a buyer email domain</h1>
 
   <form method="post">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         <p>

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -31,7 +31,7 @@
 
   <form method="post">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         <p>
           <a href="https://www.gov.uk/government/publications/public-sector-organisations-eligible-to-use-cloudstore">

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -34,7 +34,7 @@
     {% include "toolkit/secondary-action-link.html" %}
   {% endwith %}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds page-section">
+      <div class="govuk-grid-column-two-thirds page-section">
         <p>
           {% if latest_update_events %}
             {% if min_number_of_users_who_made_edits > 1 %}
@@ -66,7 +66,7 @@
       <div class="diff">
         {% if diffs %}
           <div class="govuk-grid-row page-column-headings">
-            <div class="column-one-half">
+            <div class="govuk-grid-column-one-half">
               <h3>
                 Previously approved version
               </h3>
@@ -74,7 +74,7 @@
                 Changed on {{ oldest_update_events[-1].createdAt|datetimeformat }}
               </p>
             </div>
-            <div class="column-one-half">
+            <div class="govuk-grid-column-one-half">
               <h3>
                 Current version
               </h3>
@@ -90,7 +90,7 @@
     {% endif %}
 
     <div class="govuk-grid-row">
-      <div class="column-one-whole">
+      <div class="govuk-grid-column-full">
         <h4>Contact supplier:</h4>
         <p><a href="mailto:{{ supplier["contactInformation"][0]["email"] }}">
           {{ supplier["contactInformation"][0]["email"] }}

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -33,7 +33,7 @@
   %}
     {% include "toolkit/secondary-action-link.html" %}
   {% endwith %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds page-section">
         <p>
           {% if latest_update_events %}
@@ -65,7 +65,7 @@
     {% if latest_update_events %}
       <div class="diff">
         {% if diffs %}
-          <div class="grid-row page-column-headings">
+          <div class="govuk-grid-row page-column-headings">
             <div class="column-one-half">
               <h3>
                 Previously approved version
@@ -89,7 +89,7 @@
       </div><!-- end of .diff -->
     {% endif %}
 
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-one-whole">
         <h4>Contact supplier:</h4>
         <p><a href="mailto:{{ supplier["contactInformation"][0]["email"] }}">

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -27,7 +27,7 @@
 
   <form method="POST" action="">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <div class="question">
           Are you sure you want to delete the {{ framework.name }} {{ comm_type }} file ‘{{ filepath }}’?

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -28,7 +28,7 @@
   <form method="POST" action="">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <div class="question">
           Are you sure you want to delete the {{ framework.name }} {{ comm_type }} file ‘{{ filepath }}’?
         </div>

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -20,7 +20,7 @@
 
 {% block main_content %}
   <div class="govuk-grid-row">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Download supplier lists for {{ framework['name'] }}</h1>
 
       <div class="explanation-list">

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -19,7 +19,7 @@
 {% endblock %}
 
 {% block main_content %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds">
       <h1 class="govuk-heading-xl">Download supplier lists for {{ framework['name'] }}</h1>
 

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -31,7 +31,7 @@
   <h1 class="govuk-heading-xl">{{ admin_user.emailAddress }}</h1>
 
   <form method="post">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
 

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -32,7 +32,7 @@
 
   <form method="post">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
 
         {{ edit_admin_user_form.edit_admin_name }}

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -33,7 +33,7 @@
   {% include 'toolkit/forms/validation.html' %}
 
   <form method="post" enctype="multipart/form-data">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {% for question in section.questions %}

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -34,7 +34,7 @@
 
   <form method="post" enctype="multipart/form-data">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {% for question in section.questions %}
           {% if errors and errors[question.id] or question.type == 'multiquestion' %}

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -25,7 +25,7 @@
 {% block main_content %}
   <h1 class="govuk-heading-xl">Change supplier name</h1>
   <form method="post">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {%

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -26,7 +26,7 @@
   <h1 class="govuk-heading-xl">Change supplier name</h1>
   <form method="post">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {%
           with

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -32,7 +32,7 @@
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
   <div class="govuk-grid-row">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
 
       <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">
         {%

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -31,7 +31,7 @@
 {% block main_content %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds">
 
       <form action="{{ url_for('.find_suppliers') }}" method="get" class="question">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,12 +3,12 @@
 {% block page_title %}Digital Marketplace admin{% endblock %}
 
 {% block main_content %}
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="govuk-heading-xl">Admin</h1>
   </div>
 </div>
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <div class="dmspeak">
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,12 +4,12 @@
 
 {% block main_content %}
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Admin</h1>
   </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <div class="dmspeak">
 
   {% if current_user.has_any_role('admin-ccs-data-controller') %}
@@ -136,7 +136,7 @@
 
     </div>
   </div>
-  <div class="column-one-third dmspeak">
+  <div class="govuk-grid-column-one-third dmspeak">
     <h2 class="heading-xmedium">Account settings</h2>
 
     <p>

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -26,7 +26,7 @@
 
   {% include 'toolkit/forms/validation.html' %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds">
       <h1 class="govuk-heading-l">{{ page_title }}</h1>
 

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -27,7 +27,7 @@
   {% include 'toolkit/forms/validation.html' %}
 
   <div class="govuk-grid-row">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ page_title }}</h1>
 
       <form method="POST" action="{{ url_for('.invite_admin_user') }}">

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -25,7 +25,7 @@
   <form method="post" enctype="multipart/form-data">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <div class="dmspeak"><h2 class="heading-large">Communication</h2></div>
           {% call(item) summary.list_table(
             comm_type_objs.communication,

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -24,7 +24,7 @@
 
   <form method="post" enctype="multipart/form-data">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <div class="dmspeak"><h2 class="heading-large">Communication</h2></div>
           {% call(item) summary.list_table(

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -140,7 +140,7 @@
     }]%}
   {% endif %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-one-whole">
       {{ govukTabs({
         "title": "Search",

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -141,7 +141,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <div class="column-one-whole">
+    <div class="govuk-grid-column-full">
       {{ govukTabs({
         "title": "Search",
         "items": pageTabs

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -25,7 +25,7 @@
 {% block main_content %}
     <h1 class="govuk-heading-xl">Check edits to services</h1>
 
-    <div class="grid-row">
+    <div class="govuk-grid-row">
         <div class="column-one-whole">
         <p class="search-summary">
             <span class="search-summary-count">{{ audit_events|length }}</span> edited {{ pluralize(audit_events|length, "service", "services") }}

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -26,7 +26,7 @@
     <h1 class="govuk-heading-xl">Check edits to services</h1>
 
     <div class="govuk-grid-row">
-        <div class="column-one-whole">
+        <div class="govuk-grid-column-full">
         <p class="search-summary">
             <span class="search-summary-count">{{ audit_events|length }}</span> edited {{ pluralize(audit_events|length, "service", "services") }}
         </p>

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -26,7 +26,7 @@
   <p><a href="{{ url_for('.edit_supplier_name', supplier_id=supplier_id) }}">Edit supplier name</a></p>
   {% endif %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds">
       {{ summary.heading("Company details") }}
       {% if current_user.has_role('admin-ccs-data-controller') %}
@@ -49,7 +49,7 @@
     </div>
   </div>
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-one-whole">
       {{ summary.heading("Frameworks") }}
       {% include "suppliers/_frameworks_table.html" %}
@@ -57,7 +57,7 @@
   </div>
 
   {% if not current_user.has_role('admin-ccs-sourcing') %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-one-whole">
       {{ summary.heading("Users") }}
       <a href="{{ url_for('.find_supplier_users', supplier_id=supplier_id) }}">Users</a>

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -27,7 +27,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       {{ summary.heading("Company details") }}
       {% if current_user.has_role('admin-ccs-data-controller') %}
       <p class="govuk-body">
@@ -50,7 +50,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="column-one-whole">
+    <div class="govuk-grid-column-full">
       {{ summary.heading("Frameworks") }}
       {% include "suppliers/_frameworks_table.html" %}
     </div>
@@ -58,7 +58,7 @@
 
   {% if not current_user.has_role('admin-ccs-sourcing') %}
   <div class="govuk-grid-row">
-    <div class="column-one-whole">
+    <div class="govuk-grid-column-full">
       {{ summary.heading("Users") }}
       <a href="{{ url_for('.find_supplier_users', supplier_id=supplier_id) }}">Users</a>
     </div>

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -29,7 +29,7 @@
   <h1 class="govuk-heading-l">{{ section.name }}</h1>
 
   <form method="post" enctype="multipart/form-data">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {% for question in section.questions %}

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -30,7 +30,7 @@
 
   <form method="post" enctype="multipart/form-data">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {% for question in section.questions %}
           {{ forms[question.type](question, declaration, {}) }}

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -24,7 +24,7 @@
 
 {% block main_content %}
 <div class="govuk-grid-row">
-<div class="column-two-thirds">
+<div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-xl">Change the DUNS number for ‘{{supplier.name}}’</h1>
 
   <p>You need to contact <a href="mailto:cloud_digital@crowncommercial.gov.uk ">cloud_digital@crowncommercial.gov.uk </a> to change a supplier DUNS number.</p>

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block main_content %}
-<div class="grid-row">
+<div class="govuk-grid-row">
 <div class="column-two-thirds">
   <h1 class="govuk-heading-xl">Change the DUNS number for ‘{{supplier.name}}’</h1>
 

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -32,7 +32,7 @@
   <h1 class="govuk-heading-xl">Update registered company address for ‘{{supplier.name}}’</h1>
   <form method="post">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ form.street }}
         {{ form.city }}

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -31,7 +31,7 @@
   {% include 'toolkit/forms/validation.html' %}
   <h1 class="govuk-heading-xl">Update registered company address for ‘{{supplier.name}}’</h1>
   <form method="post">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ form.street }}

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -27,7 +27,7 @@
   <h1 class="govuk-heading-xl">Update registered company number for ‘{{supplier.name}}’</h1>
   <form method="post">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ form.companies_house_number }}
         {{ form.other_company_registration_number }}

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -26,7 +26,7 @@
   {% include 'toolkit/forms/validation.html' %}
   <h1 class="govuk-heading-xl">Update registered company number for ‘{{supplier.name}}’</h1>
   <form method="post">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ form.companies_house_number }}

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -26,7 +26,7 @@
   {% include 'toolkit/forms/validation.html' %}
   <h1 class="govuk-heading-xl">Update registered company name for ‘{{supplier.name}}’</h1>
   <form method="post">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ form.registered_company_name }}

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -27,7 +27,7 @@
   <h1 class="govuk-heading-xl">Update registered company name for ‘{{supplier.name}}’</h1>
   <form method="post">
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {{ form.registered_company_name }}
 

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -25,7 +25,7 @@
 {% block main_content %}
 <h1 class="govuk-heading-l">{{ company_details.registered_name }}</h1>
 <div class='grid-row'>
-  <div class="column-one-third">
+  <div class="govuk-grid-column-one-third">
       <h2>Registered address</h2>
       <ul class="govuk-list">
           <li>{{ company_details.address.street_address_line_1 }}</li>
@@ -119,7 +119,7 @@
       </p>
   </div>
 
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
       {% if agreement_url %}
           {% if agreement_ext == '.pdf' %}
               <embed src="{{ agreement_url }}" class="border-image" height="930" type="application/pdf">

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -25,7 +25,7 @@
 
   {% if current_user.has_role('admin-ccs-sourcing') %}
   {# ### Don't show instructions for read-only users ### #}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds dmspeak">
       <p class="govuk-body">
         Review the information for each agreement, accept it, and continue to the next one.
@@ -38,7 +38,7 @@
   </div>
   {% endif %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-one-third search-page-filters">
       <div class="status-filters">
         <h2>Choose a status</h2>

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -26,7 +26,7 @@
   {% if current_user.has_role('admin-ccs-sourcing') %}
   {# ### Don't show instructions for read-only users ### #}
   <div class="govuk-grid-row">
-    <div class="column-two-thirds dmspeak">
+    <div class="govuk-grid-column-two-thirds dmspeak">
       <p class="govuk-body">
         Review the information for each agreement, accept it, and continue to the next one.
       </p>
@@ -39,7 +39,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <div class="column-one-third search-page-filters">
+    <div class="govuk-grid-column-one-third search-page-filters">
       <div class="status-filters">
         <h2>Choose a status</h2>
           <ul>
@@ -58,7 +58,7 @@
           </ul>
       </div>
     </div>
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       {% include "_view_agreements_summary.html" %}
       {% include "_view_agreements_results.html" %}
     </div>

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -26,7 +26,7 @@
 
   <div class="framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-xl">{{ framework.name }}</span>
         <h1 class="govuk-heading-xl">Statistics</h1>
 

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -25,7 +25,7 @@
 {% block main_content %}
 
   <div class="framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <span class="govuk-caption-xl">{{ framework.name }}</span>
         <h1 class="govuk-heading-xl">Statistics</h1>

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -117,7 +117,7 @@
   {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
   <div class='page-section'>
     <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-two-thirds">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {{ invite_form.email_address }}
@@ -131,7 +131,7 @@
 
   <div class='page-section'>
     <form action="{{ url_for('.move_user_to_new_supplier', supplier_id=supplier.id) }}" method="post">
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-two-thirds">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {{ move_user_form.user_to_move_email_address }}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -118,7 +118,7 @@
   <div class='page-section'>
     <form action="{{ url_for('.invite_user', supplier_id=supplier.id) }}" method="post">
       <div class="govuk-grid-row">
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {{ invite_form.email_address }}
           {{ govukButton({
@@ -132,7 +132,7 @@
   <div class='page-section'>
     <form action="{{ url_for('.move_user_to_new_supplier', supplier_id=supplier.id) }}" method="post">
       <div class="govuk-grid-row">
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {{ move_user_form.user_to_move_email_address }}
           {{ govukButton({


### PR DESCRIPTION
There should be no more references to `grid-row` or the various `column-*`. 

This reduces the size of application.css from 348KB [45.5KB compressed]
to 344KB [45.1KB compressed]

Trello: https://trello.com/c/E5Ogi8hD