### PR TITLE
Move govukBreadcrumbs into its own block

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -24,15 +24,16 @@
 {% block content %}
   {% block top_header %}{% endblock %}
   <div id="wrapper">
-    {# This is only a temporary place for the phase banner until we start using govuk-frontend template #}
-    {{ govukPhaseBanner({
-      "tag": {
-        "text": "beta"
-      },
-      "html": 'Help us improve the Digital Marketplace - <a class="govuk-link" href="'  + url_for('external.help') + '">send your feedback</a>'
-    }) }}
+    {% block beforeContent %}
+      {{ govukPhaseBanner({
+        "tag": {
+          "text": "beta"
+        },
+        "html": 'Help us improve the Digital Marketplace - <a class="govuk-link" href="'  + url_for('external.help') + '">send your feedback</a>'
+      }) }}
+      {% block breadcrumbs %}{% endblock %}
+    {% endblock %}
 
-    {% block beforeContent %}{% endblock %}
     <main id="content" role="main">
       {% include "toolkit/flash_messages.html" %}
       {% block main_content %}

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -2,7 +2,7 @@
 
 {% block page_title %}Add buyer email domains – Digital Marketplace admin{% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -4,7 +4,7 @@
   {{ service['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -4,7 +4,7 @@
   Confirm communications deletion - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -4,7 +4,7 @@
   Download supplier lists for {{ framework.name }} - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -3,7 +3,7 @@
   Edit details of admin user: {{ admin_user.emailAddress }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -9,7 +9,7 @@
   {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -4,7 +4,7 @@
   Change name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -2,7 +2,7 @@
 
 {% block page_title %}Access denied - 403 – Digital Marketplace{% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -14,7 +14,7 @@
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -4,7 +4,7 @@
 {% set page_title = 'Invite a new admin user' %}
 {% block page_title %}{{ page_title }} – Digital Marketplace admin{% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -5,7 +5,7 @@
   Manage {{ framework.name }} communications - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -16,7 +16,7 @@
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -8,7 +8,7 @@
 
 {% set csrf = csrf_token() %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -5,7 +5,7 @@
   {{ supplier.name }} - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -6,7 +6,7 @@
   Change {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -4,7 +4,7 @@
   DUNS number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -9,7 +9,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -4,7 +4,7 @@
   Change registered company number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -4,7 +4,7 @@
   Change registered company name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -6,7 +6,7 @@
   Upload {{ framework.name }} countersigned agreement - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -6,7 +6,7 @@
   View {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -4,7 +4,7 @@
   Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -4,7 +4,7 @@
   Download lists of potential user research participants - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -4,7 +4,7 @@
 
 {% block page_title %}Manage admin users - Digital Marketplace admin{% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -6,7 +6,7 @@
   Uploaded {{ framework.name }} framework agreements – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -6,7 +6,7 @@
   {{ framework.name }} framework agreements - Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -4,7 +4,7 @@
 
 {% block page_title %}Buyers - Digital Marketplace admin{% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -8,7 +8,7 @@
   {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -8,7 +8,7 @@
   {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -6,7 +6,7 @@
   {{ supplier.name }} - Services – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -6,7 +6,7 @@
   {{ supplier.name }} users – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -4,7 +4,7 @@
 
 {% block page_title %}Suppliers - Digital Marketplace admin{% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -6,7 +6,7 @@
     Find a user – Digital Marketplace admin
 {% endblock %}
 
-{% block beforeContent %}
+{% block breadcrumbs %}
   {{ govukBreadcrumbs({
     "items": [
       {


### PR DESCRIPTION
This commit is needed as part of prepping for govuk-template as we will
need to use the phase banner and breadcrumbs inside the "beforeContent".

The way I implemented this means we do not have to add `super()` to each pages "beforeContent" block just to inherit the phase banner from base_page template.