### PR TITLE
Applying styles to lists and refactoring lists of links

### DIFF
--- a/app/templates/_view_agreements_results.html
+++ b/app/templates/_view_agreements_results.html
@@ -3,7 +3,7 @@
   <h2 class="search-result-title">
     <a class="govuk-link" href="{{ url_for('.view_signed_agreement', supplier_id=supplier_framework.supplierId, framework_slug=supplier_framework.frameworkSlug, next_status=(status or None)) }}">{{ supplier_framework.supplierName }}</a>
   </h2>
-  <ul class="search-result-important-metadata">
+  <ul class="govuk-list search-result-important-metadata">
     <li class="search-result-metadata-item">
       Submitted: {{ supplier_framework.agreementReturnedAt }}
     </li>

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -24,13 +24,13 @@
       <h1 class="govuk-heading-xl">Download supplier lists for {{ framework['name'] }}</h1>
 
       <div class="explanation-list">
-          <p class="govuk-body">These lists contain details of all suppliers who:</p>
-          <ul class='list-bullet'>
-            <li>started an application</li>
-            <li>are on the framework</li>
-            <li>weren't accepted on the framework</li>
-            <li>have been excluded from the framework</li>
-          </ul>
+        <p class="govuk-body">These lists contain details of all suppliers who:</p>
+        <ul class='govuk-list govuk-list--bullet'>
+          <li>started an application</li>
+          <li>are on the framework</li>
+          <li>weren't accepted on the framework</li>
+          <li>have been excluded from the framework</li>
+        </ul>
       </div>
       <br />
       {%

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -25,7 +25,7 @@
 
       <div class="explanation-list">
         <p class="govuk-body">These lists contain details of all suppliers who:</p>
-        <ul class='govuk-list govuk-list--bullet'>
+        <ul class="govuk-list govuk-list--bullet">
           <li>started an application</li>
           <li>are on the framework</li>
           <li>weren't accepted on the framework</li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,128 +11,148 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="dmspeak">
-
-  {% if current_user.has_any_role('admin-ccs-data-controller') %}
+      {% if current_user.has_any_role('admin-ccs-data-controller') %}
         {# ADMIN CCS DATA CONTROLLER #}
         <h3 class="heading-xmedium">Search for users</h3>
-        <p class="govuk-body">
+        <ul class="govuk-list">
+          <li>
             <a class="govuk-link" href="{{ url_for('.find_user_by_email_address') }}">Find a user by email</a>
-        </p>
+          </li>
+        </ul>
+
         <h3 class="heading-xmedium">Search for suppliers</h3>
-        <p class="govuk-body">
+        <ul class="govuk-list">
+          <li>
             <a class="govuk-link" href="{{ url_for('.search_suppliers_and_services') }}">View and edit suppliers</a>
-        </p>
+          </li>
+        </ul>
+
         <h3 class="heading-xmedium">Download supplier lists</h3>
         {% for framework in frameworks %}
           {% if framework.status in ["pending", "standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
-            <p class="govuk-body">
-              <a class="govuk-link" href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">{{ framework.name }}</a>
-            </p>
+            <ul class="govuk-list">
+              <li>
+                <a class="govuk-link" href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">{{ framework.name }}</a>
+              </li>
+            </ul>
           {% endif %}
         {% endfor %}
 
-  {% elif current_user.has_role('admin-manager') %}
+      {% elif current_user.has_role('admin-manager') %}
         {# ADMIN MANAGER #}
-        <p class="govuk-body">
-          <a class="govuk-link" href="{{ url_for('.manage_admin_users') }}">View and edit admin accounts</a>
-        </p>
-  {% else %}
+        <ul class="govuk-list">
+          <li>
+            <a class="govuk-link" href="{{ url_for('.manage_admin_users') }}">View and edit admin accounts</a>
+          </li>
+        </ul>
+
+      {% else %}
         {# BUYERS, SUPPLIERS AND SERVICES #}
         <h2 class="heading-large">User support</h2>
-            {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-              <a class="govuk-link" href="{{ url_for('.find_user_by_email_address') }}">Find a user by email</a>
-            {% endif %}
+        {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
+        <ul class="govuk-list">
+          <li>
+            <a class="govuk-link" href="{{ url_for('.find_user_by_email_address') }}">Find a user by email</a>
+          </li>
+        </ul>
+      {% endif %}
 
-            <h3 class="heading-xmedium">Suppliers</h3>
+      <h3 class="heading-xmedium">Suppliers</h3>
 
-            {% set find_supplier_and_services_link_text = {
-                'admin': 'Edit supplier accounts or view services',
-                'admin-ccs-category': 'Edit suppliers and services',
-                'admin-ccs-sourcing': 'Edit supplier declarations',
-                'admin-framework-manager': 'View suppliers and services',
-                }
-            %}
-              <p class="govuk-body">
-                <a class="govuk-link" href="{{ url_for('.search_suppliers_and_services') }}">{{ find_supplier_and_services_link_text[current_user.role] }}</a>
-              </p>
+      {% set find_supplier_and_services_link_text = {
+          'admin': 'Edit supplier accounts or view services',
+          'admin-ccs-category': 'Edit suppliers and services',
+          'admin-ccs-sourcing': 'Edit supplier declarations',
+          'admin-framework-manager': 'View suppliers and services',
+          }
+      %}
+      <ul class="govuk-list">
+        <li>
+          <a class="govuk-link" href="{{ url_for('.search_suppliers_and_services') }}">{{ find_supplier_and_services_link_text[current_user.role] }}</a>
+        </li>
 
-            {% if current_user.has_any_role('admin-framework-manager') %}
-              <p class="govuk-body">
-                <a class="govuk-link" href="{{ url_for('.supplier_user_research_participants_by_framework') }}">Download potential user research participants (suppliers)</a>
-              </p>
-            {% elif current_user.has_any_role('admin-ccs-category') %}
-              <p class="govuk-body">
-                <a class="govuk-link" href="{{ url_for('.service_update_audits') }}">Review service changes</a>
-              </p>
-            {% endif %}
-        {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
-            <h3 class="heading-xmedium">Buyers</h3>
-
-            {% if current_user.has_any_role('admin-framework-manager') %}
-                <p class="govuk-body">
-                    <a class="govuk-link" href="{{ url_for('.download_buyers') }}">Download list of all buyers</a>
-                </p>
-                <p class="govuk-body">
-                    <a class="govuk-link" href="{{ url_for('.download_buyers_for_user_research') }}">Download potential user research participants (buyers)</a>
-                </p>
-            {% elif current_user.has_any_role('admin', 'admin-ccs-category') %}
-                <p class="govuk-body">
-                    <a class="govuk-link" href="{{ url_for('.find_buyer_by_brief_id') }}">Find a buyer by opportunity ID</a>
-                </p>
-                <p class="govuk-body">
-                    <a class="govuk-link" href="{{ url_for('.add_buyer_domains') }}">Add a buyer email domain</a>
-                </p>
-            {% endif %}
+        {% if current_user.has_any_role('admin-framework-manager') %}
+          <li>
+            <a class="govuk-link" href="{{ url_for('.supplier_user_research_participants_by_framework') }}">Download potential user research participants (suppliers)</a>
+          </li>
+        {% elif current_user.has_any_role('admin-ccs-category') %}
+          <li>
+            <a class="govuk-link" href="{{ url_for('.service_update_audits') }}">Review service changes</a>
+          </li>
         {% endif %}
+      </ul>
+
+      {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-framework-manager') %}
+        <h3 class="heading-xmedium">Buyers</h3>
+
+        <ul class="govuk-list">
+          {% if current_user.has_any_role('admin-framework-manager') %}
+            <li>
+              <a class="govuk-link" href="{{ url_for('.download_buyers') }}">Download list of all buyers</a>
+            </li>
+            <li>
+              <a class="govuk-link" href="{{ url_for('.download_buyers_for_user_research') }}">Download potential user research participants (buyers)</a>
+            </li>
+          {% elif current_user.has_any_role('admin', 'admin-ccs-category') %}
+            <li>
+              <a class="govuk-link" href="{{ url_for('.find_buyer_by_brief_id') }}">Find a buyer by opportunity ID</a>
+            </li>
+            <li>
+              <a class="govuk-link" href="{{ url_for('.add_buyer_domains') }}">Add a buyer email domain</a>
+            </li>
+          {% endif %}
+        </ul>
+      {% endif %}
 
         {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager', 'admin-ccs-sourcing') %}
-            {# OUTCOMES #}
-            <h2 class="heading-large">Outcomes</h2>
-            <p class="govuk-body">
-                <a class="govuk-link" href="{{ url_for('.download_outcomes') }}">Download Direct Award outcomes</a>
-            </p>
+          {# OUTCOMES #}
+          <h2 class="heading-large">Outcomes</h2>
+          <ul class="govuk-list">
+            <li>
+              <a class="govuk-link" href="{{ url_for('.download_outcomes') }}">Download Direct Award outcomes</a>
+            </li>
+          </ul>
 
-            {# FRAMEWORKS AND APPLICATIONS #}
-            <h2 class="heading-large">Manage applications</h2>
+          {# FRAMEWORKS AND APPLICATIONS #}
+          <h2 class="heading-large">Manage applications</h2>
 
-            {% for framework in frameworks %}
-                {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' or current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
-                    <h3 class="heading-xmedium">{{framework.name}}</h3>
+          {% for framework in frameworks %}
+            {% if framework.status in ["standstill", "live"] or framework.slug == 'digital-outcomes-and-specialists-2' or current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
+              <h3 class="heading-xmedium">{{framework.name}}</h3>
 
-                    {% if framework.status in ["live", "standstill"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
-                      {% set agreement_link_text = {
-                          'admin-ccs-category': 'View agreements',
-                          'admin-ccs-sourcing': 'Countersign agreements',
-                          'admin-framework-manager': 'View agreements',
-                          }
-                      %}
-                        <p class="govuk-body">
-                          <a class="govuk-link" href="{{ url_for('.list_agreements', framework_slug=framework['slug'], status='signed') }}">{{ agreement_link_text[current_user.role] }}</a>
-                        </p>
-                    {% endif %}
+              <ul class="govuk-list">
+              {% if framework.status in ["live", "standstill"] or framework.slug == 'digital-outcomes-and-specialists-2' %}
+                {% set agreement_link_text = {
+                    'admin-ccs-category': 'View agreements',
+                    'admin-ccs-sourcing': 'Countersign agreements',
+                    'admin-framework-manager': 'View agreements',
+                    }
+                %}
+                <li>
+                  <a class="govuk-link" href="{{ url_for('.list_agreements', framework_slug=framework['slug'], status='signed') }}">{{ agreement_link_text[current_user.role] }}</a>
+                </li>
+              {% endif %}
 
-                    {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
-                        <p class="govuk-body">
-                          <a class="govuk-link" href="{{ url_for('public.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
-                        </p>
-                    {% endif %}
-                    {% if current_user.has_any_role('admin-framework-manager') %}
-                        <p class="govuk-body">
-                          <a class="govuk-link" href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Manage communications</a>
-                        </p>
-                    {% endif %}
-                    {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
-                        <p class="govuk-body">
-                          <a class="govuk-link" href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">Contact suppliers</a>
-                        </p>
-                    {% endif %}
-                {% endif %}
-            {% endfor %}
-
+              {% if current_user.has_any_role('admin-ccs-sourcing', 'admin-framework-manager') %}
+                <li>
+                  <a class="govuk-link" href="{{ url_for('public.view_statistics', framework_slug=framework['slug']) }}">View application statistics</a>
+                </li>
+              {% endif %}
+              {% if current_user.has_any_role('admin-framework-manager') %}
+                <li>
+                  <a class="govuk-link" href="{{ url_for('.manage_communications', framework_slug=framework['slug']) }}">Manage communications</a>
+                </li>
+              {% endif %}
+              {% if current_user.has_any_role('admin-ccs-category', 'admin-framework-manager') %}
+                <li>
+                  <a class="govuk-link" href="{{ url_for('.user_list_page_for_framework', framework_slug=framework['slug']) }}">Contact suppliers</a>
+                </li>
+              {% endif %}
+              </ul>
+            {% endif %}
+          {% endfor %}
         {% endif %}
-
-  {% endif %}
-
+      {% endif %}
     </div>
   </div>
   <div class="govuk-grid-column-one-third dmspeak">

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -42,7 +42,7 @@
     <div class="govuk-grid-column-one-third search-page-filters">
       <div class="status-filters">
         <h2>Choose a status</h2>
-          <ul>
+          <ul class="govuk-list">
             <li>
               {% if status %}<a class="govuk-link" href="{{ url_for(".list_agreements", framework_slug=framework.slug) }}">{% endif %}
                 All

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -94,7 +94,7 @@
     <h1 class="govuk-heading-l">{{ service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] }}</h1>
 
     {# links #}
-    <ul class="list-no-bullet">
+    <ul class="govuk-list">
       {% if service_data['frameworkFamily'] == 'g-cloud' %}
         <li><a class="govuk-link" href="{{ url_for('external.direct_award_service_page', framework_family=service_data['frameworkFamily'], service_id=service_id) }}">View service</a></li>
       {% endif %}


### PR DESCRIPTION
- All `<ul>` should use `govuk-list` class (https://design-system.service.gov.uk/styles/typography/#lists)

- Refactored the lists of links on the admin home page
As the links on the home page, are categorized. It feels more semantic
to declare them in an unordered list. This will help screen readers understand
how the links are related. I.e they are not just a group of random links
with no context.

