### PR TITLE
Add GOV.UK Frontend images to /static

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -38,7 +38,7 @@ $path: "/admin/static/images/";
 
 // GOV.UK Design System (compatible with old toolkit/elements)
 $govuk-assets-path: '/admin/static/';
-$govuk-images-path: '/admin/static/images/';
+$govuk-images-path: '/admin/static/images/govuk-frontend';
 $govuk-fonts-path: '/admin/static/fonts/';
 $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ const govukTemplateFolder = path.join(repoRoot, 'node_modules', 'govuk_template'
 const govukTemplateAssetsFolder = path.join(govukTemplateFolder, 'assets')
 const govukTemplateLayoutsFolder = path.join(govukTemplateFolder, 'views', 'layouts')
 const govukFrontendFontsFolder = path.join(govukFrontendRoot, 'assets', 'fonts')
+const govukFrontendImageFolder = path.join(govukFrontendRoot, 'assets', 'images')
 
 // JavaScript paths
 const jsSourceFile = path.join(assetsFolder, 'javascripts', 'application.js')
@@ -291,6 +292,15 @@ gulp.task(
   )
 )
 
+gulp.task(
+  'copy:govuk_frontend_assets:images',
+  copyFactory(
+    'images from the GOVUK frontend',
+    govukFrontendImageFolder,
+    staticFolder + '/images/govuk-frontend/'
+  )
+)
+
 gulp.task('set_environment_to_development', function (cb) {
   environment = 'development'
   cb()
@@ -315,6 +325,7 @@ gulp.task(
     'copy:images',
     'copy:govuk_template',
     'copy:govuk_frontend_assets:fonts',
+    'copy:govuk_frontend_assets:images',
     'copy:country_picker:jsons',
     'copy:country_picker:stylesheets',
     'copy:country_picker_package:javascripts',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -340,9 +340,9 @@ gulp.task('build:development', gulp.series(gulp.parallel('set_environment_to_dev
 gulp.task('build:production', gulp.series(gulp.parallel('set_environment_to_production', 'clean'), 'compile'))
 
 gulp.task('watch', gulp.series('build:development', function () {
-  const jsWatcher = gulp.watch([assetsFolder + '/**/*.js'], ['js'])
-  const cssWatcher = gulp.watch([assetsFolder + '/**/*.scss'], ['sass'])
-  const dmWatcher = gulp.watch([npmRoot + '/digitalmarketplace-frameworks/**'], ['copy:frameworks'])
+  const jsWatcher = gulp.watch([assetsFolder + '/**/*.js'], gulp.series('js'))
+  const cssWatcher = gulp.watch([assetsFolder + '/**/*.scss'], gulp.series('sass'))
+  const dmWatcher = gulp.watch([npmRoot + '/digitalmarketplace-frameworks/**'], gulp.series('copy:frameworks'))
   const notice = function (event) {
     console.log('File ' + event.path + ' was ' + event.type + ' running tasks...')
   }


### PR DESCRIPTION
- add GOV.UK Frontend images to static
- fixes gulp watch to use gulp.series (Should have been done as part of #552)