### PR TITLE
Fix url quotes in templates

### DIFF
--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -22,7 +22,7 @@
 
 {% block main_content %}
   {% if remove_countersigned_agreement_confirm %}
-      <form method="post" action="{{ url_for(".remove_countersigned_agreement_file", supplier_id=supplier.id, framework_slug=framework.slug) }}">
+      <form method="post" action="{{ url_for('.remove_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <div class="banner-destructive-with-action">
         <p class="govuk-body banner-message">

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -44,13 +44,13 @@
         <h2>Choose a status</h2>
           <ul class="govuk-list">
             <li>
-              {% if status %}<a class="govuk-link" href="{{ url_for(".list_agreements", framework_slug=framework.slug) }}">{% endif %}
+              {% if status %}<a class="govuk-link" href="{{ url_for('.list_agreements', framework_slug=framework.slug) }}">{% endif %}
                 All
               {% if status %}</a>{% endif %}
             </li>
         {% for status_key, status_label in status_labels.items() %}
             <li>
-              {% if status_key != status %}<a class="govuk-link" href="{{ url_for(".list_agreements", framework_slug=framework.slug, status=status_key) }}">{% endif %}
+              {% if status_key != status %}<a class="govuk-link" href="{{ url_for('.list_agreements', framework_slug=framework.slug, status=status_key) }}">{% endif %}
                 {{ status_label }}
               {% if status_key != status %}</a>{% endif %}
             </li>


### PR DESCRIPTION
Fixes double quotes in `url_for` (see https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/577/commits/4e6753fe1ecb5d5c26cf08d9483d0f7ccd4e7b65).

Given we have zero functional test coverage for these views, I'd rather be on the safe side.