### PR TITLE
Update digitalmarketplace-govuk-frontend to v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,9 +1231,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.1.0.tgz",
-      "integrity": "sha512-KmPwk1vZmHnDN1nD/sTkjjkbPVcNriaY7ROeamhFMory38HdsFCjqRc4rCcep881riPz9r4bpH17JX43YWrRBA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.2.0.tgz",
+      "integrity": "sha512-sELMElO6SS4MuPYHYEDr0+ZhIg2ZKr2TzWrxm52lcZKuMmgJ2otq3x1aezcZbj7ZXpwdNtoTOrvlTH1xy08bkQ=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
-    "digitalmarketplace-govuk-frontend": "^0.1.0",
+    "digitalmarketplace-govuk-frontend": "^0.2.0",
     "govuk-country-and-territory-autocomplete": "0.5.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
Needed for #560. 

- Adds error templates
- Adds custom meta tags