### PR TITLE
Remove use of secondary action link component

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -22,7 +22,6 @@ $path: "/admin/static/images/";
 @import "toolkit/_notification-banners";
 @import "toolkit/_previous-next-navigation";
 @import "toolkit/_proposition-header";
-@import "toolkit/_secondary-action-link";
 @import "toolkit/_service-id";
 @import "toolkit/forms/_hint";
 @import "toolkit/forms/_list-entry";
@@ -81,11 +80,6 @@ $govuk-compatibility-govukelements: true;
 
 .break-email {
   word-break: break-all;
-}
-
-.question + .secondary-action-link {
-  margin-top: -36px;
-  margin-bottom: govuk-spacing(7);
 }
 
 .summary-item-field-heading, .summary-item-field {

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -26,13 +26,11 @@
   <span class="govuk-caption-l">{{ service['supplierName'] }}</span>
   <h1 class="govuk-heading-l">{{ service['serviceName'] }}</h1>
 
-  {%
-    with
-      url = url_for("external.direct_award_service_page", framework_family=service['frameworkFamily'], service_id=service["id"]),
-      text = "View service"
-  %}
-    {% include "toolkit/secondary-action-link.html" %}
-  {% endwith %}
+  <a class="govuk-link govuk-!-margin-bottom-3 govuk-!-display-inline-block"
+     href="{{ url_for('external.direct_award_service_page', framework_family=service['frameworkFamily'], service_id=service['id']) }}">
+    View service
+  </a>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds page-section">
         <p class="govuk-body">

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -108,15 +108,10 @@
           </form>
         {% endif %}
       {% endif %}
-      <p class="govuk-body">
-        {%
-          with
-          url = url_for(".next_agreement", framework_slug=framework.slug, supplier_id=supplier.id, status=next_status),
-          text = "Next agreement"
-        %}
-          {% include "toolkit/secondary-action-link.html" %}
-        {% endwith %}
-      </p>
+      <a class="govuk-link govuk-link--no-visited-state"
+         href="{{ url_for('.next_agreement', framework_slug=framework.slug, supplier_id=supplier.id, status=next_status) }}">
+        Next agreement
+      </a>
   </div>
 
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Using the GOV.UK Design System [spacing override classes] we can add spacing around a link without need for a custom component or even a div.

When adding spacing override classes to inline elements such as anchors, we do need to also add the `govuk-!-display-inline-block` override.

[spacing override classes]: https://design-system.service.gov.uk/styles/spacing/#spacing-override-classes