### PR TITLE
Allow overriding the development server port using an environment variable

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,4 @@
+FLASK_APP=application:application
+FLASK_ENV=development
+FLASK_RUN_EXTRA_FILES=app/content/frameworks/
+FLASK_RUN_PORT=5004

--- a/.flaskenv
+++ b/.flaskenv
@@ -1,4 +1,7 @@
+DM_API_PORT=5000
+DM_ADMIN_PORT=5004
+
 FLASK_APP=application:application
 FLASK_ENV=development
 FLASK_RUN_EXTRA_FILES=app/content/frameworks/
-FLASK_RUN_PORT=5004
+FLASK_RUN_PORT=${DM_ADMIN_PORT}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run-all: requirements npm-install frontend-build run-app
 
 .PHONY: run-app
 run-app: show-environment virtualenv
-	${VIRTUALENV_ROOT}/bin/python application.py runserver
+	${VIRTUALENV_ROOT}/bin/flask run
 
 .PHONY: virtualenv
 virtualenv:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,15 @@ make run-all
 
 To just run the application use the `run-app` target.
 
-The admin frontend runs on port 5004. Use the app at [http://127.0.0.1:5004/admin/](http://127.0.0.1:5004/admin/)
+Use the app at [http://127.0.0.1:5004/admin/](http://127.0.0.1:5004/admin/)
+
+When running the admin frontend locally it listens on port 5004 by default.
+This can be changed by setting the `DM_ADMIN_PORT` environment variable, e.g.
+to set the port number to 9004:
+
+```
+export DM_ADMIN_PORT=9004
+```
 
 ### Updating application dependencies
 

--- a/config.py
+++ b/config.py
@@ -93,7 +93,7 @@ class Development(Config):
     DM_REPORTS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_ASSETS_URL = "https://{}.s3-eu-west-1.amazonaws.com".format(DM_S3_DOCUMENT_BUCKET)
 
-    DM_DATA_API_URL = "http://localhost:5000"
+    DM_DATA_API_URL = f"http://localhost:{os.getenv('DM_API_PORT', 5000)}"
     DM_DATA_API_AUTH_TOKEN = "myToken"
     SECRET_KEY = "verySecretKey"
     DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ freezegun==0.3.12
 mock==3.0.5
 pytest==4.6.3
 pytest-cov==2.7.1
+python-dotenv==0.10.3  # used to load .flaskenv
 requests-mock==1.6.0
 watchdog==0.9.0
 


### PR DESCRIPTION
2nd line ticket: https://trello.com/c/cwjzIU8U/1212-stop-search-api-from-using-port-5001

See the PR on the search api that adds `DM_SEARCH_API_PORT` for more details: https://github.com/alphagov/digitalmarketplace-search-api/pull/241