### PR TITLE
replace page_title block with pageTitle

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -15,6 +15,9 @@
   </div>
 {% endblock %}
 
+{# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
+{% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}
+
 {# This can be removed once we start using govuk-frontend template #}
 {# The reason for calling this is to ensure we do not output the user research signup banner #}
 {% block after_header %}

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Add buyer email domains – Digital Marketplace admin{% endblock %}
+{% block pageTitle %}
+  Add buyer email domains – Digital Marketplace admin
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ govukBreadcrumbs({

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ service['serviceName'] }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Confirm communications deletion - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Download supplier lists for {{ framework.name }} - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -1,5 +1,5 @@
 {% extends "_base_page.html" %}
-{% block page_title %}
+{% block pageTitle %}
   Edit details of admin user: {{ admin_user.emailAddress }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -5,7 +5,7 @@
 
 {% set page_title = "Edit {}".format(section.name) %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Change name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Access denied - 403 – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Access denied - 403 – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ govukBreadcrumbs({

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -10,7 +10,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Digital Marketplace admin{% endblock %}
+{% block pageTitle %}
+  Digital Marketplace admin
+{% endblock %}
 
 {% block mainContent %}
 <div class="govuk-grid-row">

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -2,7 +2,9 @@
 
 {% import "toolkit/forms/macros/forms.html" as forms %}
 {% set page_title = 'Invite a new admin user' %}
-{% block page_title %}{{ page_title }} – Digital Marketplace admin{% endblock %}
+{% block pageTitle %}
+  {{ page_title }} – Digital Marketplace admin
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ govukBreadcrumbs({

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}
+{% block pageTitle %}
   Manage {{ framework.name }} communications - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -12,7 +12,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ page_title }} - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Check edits to services - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ supplier.name }} - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Change {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   DUNS number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/forms/macros/forms.html" as forms %}
 
-{% block page_title %}
+{% block pageTitle %}
   Change registered company address – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 {% block head %}

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Change registered company number – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Change registered company name – {{ supplier.name }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Upload {{ framework.name }} countersigned agreement - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   View {{ framework.name }} declaration - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Countersign {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Download lists of potential user research participants - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -2,7 +2,9 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}Manage admin users - Digital Marketplace admin{% endblock %}
+{% block pageTitle %}
+  Manage admin users - Digital Marketplace admin
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ govukBreadcrumbs({

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Uploaded {{ framework.name }} framework agreements – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ framework.name }} framework agreements - Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -2,7 +2,9 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}Buyers - Digital Marketplace admin{% endblock %}
+{% block pageTitle %}
+  Buyers - Digital Marketplace admin
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ govukBreadcrumbs({

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -4,7 +4,7 @@
 
 {% set page_title = service_data['serviceName'] or service_data['frameworkName'] + ' - ' + service_data['lotName'] %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -4,7 +4,7 @@
 
 {% set page_title = "{} statistics".format(framework['name']) %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ page_title }} – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ supplier.name }} - Services – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {{ supplier.name }} users – Digital Marketplace admin
 {% endblock %}
 

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -2,7 +2,9 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}Suppliers - Digital Marketplace admin{% endblock %}
+{% block pageTitle %}
+  Suppliers - Digital Marketplace admin
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ govukBreadcrumbs({

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -2,7 +2,7 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
     Find a user – Digital Marketplace admin
 {% endblock %}
 


### PR DESCRIPTION
As part of migrating us off govuk_template and on to govuk frontend template
we need to be mindful about what blocks govuk frontend used. govuk frontend
template uses pageTitle so instead of adding this commit to that work it
can be done as a separate commit and then once we come to replace govuk_template
we can just remove the two lines of code in `_base_page` which we added
in this commit.

Ticket: https://trello.com/c/Al713JMc