### PR TITLE
replace main_content block with mainContent

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -35,7 +35,10 @@
       {% include "toolkit/flash_messages.html" %}
     {% endblock %}
     <main id="content" role="main">
+      {# TODO: Remove this block when we start removing govuk_template but be sure #}
+      {#       To keep the inner block mainContent otherwise no content will be rendered #}
       {% block main_content %}
+        {% block mainContent %}{% endblock %}
       {% endblock %}
     </main>
   </div>

--- a/app/templates/add_buyer_email_domain.html
+++ b/app/templates/add_buyer_email_domain.html
@@ -16,7 +16,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% for error in email_domain_form.new_buyer_domain.errors %}
     {%
       with

--- a/app/templates/compare_revisions.html
+++ b/app/templates/compare_revisions.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <span class="govuk-caption-l">{{ service['supplierName'] }}</span>
   <h1 class="govuk-heading-l">{{ service['serviceName'] }}</h1>
 

--- a/app/templates/confirm_communications_deletion.html
+++ b/app/templates/confirm_communications_deletion.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Confirm communications deletion</h1>
 
   <form method="POST" action="">

--- a/app/templates/download_framework_users.html
+++ b/app/templates/download_framework_users.html
@@ -18,7 +18,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Download supplier lists for {{ framework['name'] }}</h1>

--- a/app/templates/edit_admin_user.html
+++ b/app/templates/edit_admin_user.html
@@ -17,7 +17,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% for error in edit_admin_user_form.edit_admin_name.errors %}
     {%
       with

--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-l">{{ section.name }}</h1>
 
   {% include 'toolkit/forms/validation.html' %}

--- a/app/templates/edit_supplier_name.html
+++ b/app/templates/edit_supplier_name.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Change supplier name</h1>
   <form method="post">
     <div class="govuk-grid-row">

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -16,7 +16,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">You don’t have permission to perform this action</h1>
   <p class="govuk-body">
     Email <a class="govuk-link" href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need to access this content.

--- a/app/templates/find_suppliers_and_services.html
+++ b/app/templates/find_suppliers_and_services.html
@@ -28,7 +28,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
   <div class="govuk-grid-row">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block page_title %}Digital Marketplace admin{% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Admin</h1>

--- a/app/templates/invite_admin_user.html
+++ b/app/templates/invite_admin_user.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% include 'toolkit/forms/validation.html' %}
 

--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -19,7 +19,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Manage {{framework.name}} communications</h1>
 
   <form method="post" enctype="multipart/form-data">

--- a/app/templates/search/search.html
+++ b/app/templates/search/search.html
@@ -30,7 +30,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">{{ page_title }}</h1>
 
   {% set supplierNameHtml %}

--- a/app/templates/service_updates_unapproved.html
+++ b/app/templates/service_updates_unapproved.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
     <h1 class="govuk-heading-xl">Check edits to services</h1>
 
     <div class="govuk-grid-row">

--- a/app/templates/supplier_details.html
+++ b/app/templates/supplier_details.html
@@ -19,7 +19,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">{{ supplier.name }}</h1>
 
   {% if current_user.has_any_role('admin', 'admin-ccs-category', 'admin-ccs-data-controller') %}

--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -24,7 +24,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <span class="govuk-caption-l">{{ supplier.name }}</span>
   <h1 class="govuk-heading-l">{{ section.name }}</h1>
 

--- a/app/templates/suppliers/edit_duns_number.html
+++ b/app/templates/suppliers/edit_duns_number.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-xl">Change the DUNS number for ‘{{supplier.name}}’</h1>

--- a/app/templates/suppliers/edit_registered_address.html
+++ b/app/templates/suppliers/edit_registered_address.html
@@ -27,7 +27,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
   <h1 class="govuk-heading-xl">Update registered company address for ‘{{supplier.name}}’</h1>
   <form method="post">

--- a/app/templates/suppliers/edit_registered_company_number.html
+++ b/app/templates/suppliers/edit_registered_company_number.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
   <h1 class="govuk-heading-xl">Update registered company number for ‘{{supplier.name}}’</h1>
   <form method="post">

--- a/app/templates/suppliers/edit_registered_name.html
+++ b/app/templates/suppliers/edit_registered_name.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
   <h1 class="govuk-heading-xl">Update registered company name for ‘{{supplier.name}}’</h1>
   <form method="post">

--- a/app/templates/suppliers/upload_countersigned_agreement.html
+++ b/app/templates/suppliers/upload_countersigned_agreement.html
@@ -20,7 +20,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% if remove_countersigned_agreement_confirm %}
       <form method="post" action="{{ url_for('.remove_countersigned_agreement_file', supplier_id=supplier.id, framework_slug=framework.slug) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/suppliers/view_declaration.html
+++ b/app/templates/suppliers/view_declaration.html
@@ -24,7 +24,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <span class="govuk-caption-l">{{ supplier.name }}</span>
   <h1 class="govuk-heading-l">{{ framework.name }} declaration</h1>
 

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 <h1 class="govuk-heading-l">{{ company_details.registered_name }}</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">

--- a/app/templates/user_research_participants.html
+++ b/app/templates/user_research_participants.html
@@ -18,7 +18,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Download lists of potential user research participants</h1>
   <p class="govuk-body">
     Lists are generated daily. Check you've got the most recent version of the list before you contact users.

--- a/app/templates/view_admin_users.html
+++ b/app/templates/view_admin_users.html
@@ -18,7 +18,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Manage users</h1>
 
 <div class="page-section">

--- a/app/templates/view_agreements.html
+++ b/app/templates/view_agreements.html
@@ -20,7 +20,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Uploaded {{framework.name}} framework agreements</h1>
 
   {% set field_headings = [

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -20,7 +20,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-l">{{framework.name}} framework agreements</h1>
 
   {% if current_user.has_role('admin-ccs-sourcing') %}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -18,7 +18,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Find a buyer</h1>
 
   <form action="{{ url_for('.find_buyer_by_brief_id') }}" method="get" class="question">

--- a/app/templates/view_service.html
+++ b/app/templates/view_service.html
@@ -26,7 +26,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% block before_heading %}
 

--- a/app/templates/view_statistics.html
+++ b/app/templates/view_statistics.html
@@ -22,7 +22,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   <div class="framework-statistics" {% if big_screen_mode %}id="framework-statistics-big-screen"{% endif %}>
     <div class="govuk-grid-row">

--- a/app/templates/view_supplier_services.html
+++ b/app/templates/view_supplier_services.html
@@ -24,7 +24,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% block before_heading %}
     {% if remove_services_for_framework or publish_services_for_framework %}
 

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -24,7 +24,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">{{ supplier.name }}</h1>
 
   <div class="page-section">

--- a/app/templates/view_suppliers.html
+++ b/app/templates/view_suppliers.html
@@ -18,7 +18,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Suppliers</h1>
 
   <div class="page-section">

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -20,7 +20,7 @@
   }) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   <h1 class="govuk-heading-xl">Find a user</h1>
 
   <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">


### PR DESCRIPTION
As part of migrating us off govuk_template and on to govuk frontend template
we need to be mindful about what blocks govuk frontend uses. govuk frontend
template uses content block so instead of adding this commit to that work it
can be done as a separate commit and then once we come to replace govuk_template
we can just remove the `main_content` block of code and leave mainContent block in `_base_page`.
We will need to output flash messaging inside the content block so we cannot just use govuk-frontend template's `content` block to render our page.

Ticket: https://trello.com/c/lHSmp2Ym