### PR TITLE
Add Python 3.7 and 3.8 checks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 before_install:
   - nvm install
 install:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,7 +9,7 @@ lxml==4.4.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ python-dotenv==0.10.3  # used to load .flaskenv
 requests-mock==1.6.0
 watchdog==0.9.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.1.0#egg=digitalmarketplace-test-utils==2.1.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,16 +10,16 @@ lxml==4.4.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
 
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.16
-botocore==1.13.16
+boto3==1.10.23
+botocore==1.13.23
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -201,12 +201,12 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
         self.data_api_client = self.data_api_client_patch.start()
         self.data_api_client.get_supplier_frameworks.return_value = {
             "frameworkInterest": [
-                SupplierFrameworkStub(framework_slug="g-cloud-10", declaration={"foo": "bar"}).response(),
+                SupplierFrameworkStub(framework_slug="g-cloud-10", with_declaration=True).response(),
                 SupplierFrameworkStub(
                     framework_slug="digital-outcomes-and-specialists-3",
-                    declaration={"foo": "bar"},
+                    with_declaration=True,
                 ).response(),
-                SupplierFrameworkStub(framework_slug="g-cloud-11", declaration={"foo": "bar"}).response(),
+                SupplierFrameworkStub(framework_slug="g-cloud-11", with_declaration=True).response(),
             ]
         }
 
@@ -237,9 +237,9 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
     ):
         self.user_role = role
         self.data_api_client.get_supplier_frameworks.return_value["frameworkInterest"].extend((
-            SupplierFrameworkStub(framework_slug="g-cloud-standstill-1", declaration={"foo": "bar"}).response(),
-            SupplierFrameworkStub(framework_slug="g-cloud-pending-1", declaration={"foo": "bar"}).response(),
-            SupplierFrameworkStub(framework_slug="g-cloud-open-1", declaration={"foo": "bar"}).response(),
+            SupplierFrameworkStub(framework_slug="g-cloud-standstill-1", with_declaration=True).response(),
+            SupplierFrameworkStub(framework_slug="g-cloud-pending-1", with_declaration=True).response(),
+            SupplierFrameworkStub(framework_slug="g-cloud-open-1", with_declaration=True).response(),
             SupplierFrameworkStub(framework_slug="g-cloud-expired-1").response(),
         ))
 
@@ -1450,7 +1450,7 @@ class TestUpdatingSupplierDetails(LoggedInApplicationTest):
             FrameworkStub(frameworkLiveAtUTC="b", status="live", slug="g-cloud-11").response(),
         ]}
         # TODO: fix test utils bug to reset declaration on init
-        supplier_framework = SupplierFrameworkStub(framework_slug="g-cloud-11", declaration={}).response()
+        supplier_framework = SupplierFrameworkStub(framework_slug="g-cloud-11").response()
         self.data_api_client.get_supplier_frameworks.return_value = {
             "frameworkInterest": [supplier_framework]
         }
@@ -1718,10 +1718,10 @@ class TestViewingASupplierDeclaration(LoggedInApplicationTest):
         sf_stub = SupplierFrameworkStub(
             framework_slug=framework_response["frameworks"]["slug"],
             supplier_id=supplier_response["suppliers"]["id"],
-            on_framework=True,
-            declaration=G11_DECLARATION.copy()
-        )
-        self.data_api_client.get_supplier_framework_info.return_value = sf_stub.single_result_response()
+            on_framework=True
+        ).single_result_response()
+        sf_stub['frameworkInterest']['declaration'] = G11_DECLARATION.copy()
+        self.data_api_client.get_supplier_framework_info.return_value = sf_stub
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- Bumps content loader, utils, test utils and API client
- Adds 3.7 and 3.8 to Travis config 