### PR TITLE
digitalmarketplace-utils dependency: bump to v51.1.0, re-freeze dependencies

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,7 +9,7 @@ lxml==4.4.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.4.0#egg=digitalmarketplace-utils==50.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lxml==4.4.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.4.0#egg=digitalmarketplace-utils==50.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
@@ -18,8 +18,8 @@ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.36
-botocore==1.13.36
+boto3==1.10.41
+botocore==1.13.41
 certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
@@ -43,7 +43,7 @@ mailchimp3==3.0.6
 Markdown==2.6.11
 MarkupSafe==1.1.1
 monotonic==1.5
-notifications-python-client==5.4.0
+notifications-python-client==5.4.1
 odfpy==1.4.0
 prometheus-client==0.2.0
 pycparser==2.19


### PR DESCRIPTION
https://trello.com/c/sYHAwVef

No `get_app_status` changes needed.