### PR TITLE
Fixes position of download icon

### DIFF
--- a/app/templates/manage_communications.html
+++ b/app/templates/manage_communications.html
@@ -42,7 +42,7 @@
             {% call summary.row() %}
             {{ summary.field_name(item.last_modified|dateformat) }}
             {% call summary.field() %}
-              <a class="govuk-link" href="{{ url_for('.download_communication', comm_type="communication", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
+              <a class="govuk-link document-link-with-icon" href="{{ url_for('.download_communication', comm_type="communication", filepath=item.rel_path, framework_slug=framework.slug) }}">
                 <span class="document-icon">{{ item.ext }}<span> document:</span></span>
                 {{ item.filename }}
               </a>
@@ -76,7 +76,7 @@
               {% call summary.row() %}
               {{ summary.field_name(item.last_modified|dateformat) }}
               {% call summary.field() %}
-                <a class="govuk-link" href="{{ url_for('.download_communication', comm_type="clarification", filepath=item.rel_path, framework_slug=framework.slug) }}" class="document-link-with-icon">
+                <a class="govuk-link document-link-with-icon" href="{{ url_for('.download_communication', comm_type="clarification", filepath=item.rel_path, framework_slug=framework.slug) }}">
                   <span class="document-icon">{{ item.ext }}<span> document:</span></span>
                   {{ item.filename }}
                 </a>


### PR DESCRIPTION
This bug was introduced by commit 0f6022 where I had not seen the class attribute defined towards the end of the line and so we ended up with a link
with two class attributes declarations. I double checked the rest of the changes
in that commit and the changes made in
https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/569

## Before:
![image](https://user-images.githubusercontent.com/3441519/71522397-72034100-28bc-11ea-9a74-6f9ec04c11ba.png)


## After:
![image](https://user-images.githubusercontent.com/3441519/71522380-63b52500-28bc-11ea-833e-9edf30479a18.png)

Ticket:
https://trello.com/c/83IwwPu3
