### PR TITLE
find_supplier_services, toggle_supplier_services views: use find_services_iter

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -837,11 +837,11 @@ def toggle_supplier_services(supplier_id):
     if framework['status'] != 'live':
         abort(400, "Cannot toggle services for framework {}".format(toggle_action['framework_slug']))
 
-    services = data_api_client.find_services(
+    services = tuple(data_api_client.find_services_iter(
         supplier_id=supplier_id,
         framework=toggle_action['framework_slug'],
         status=toggle_action['old_status']
-    )['services']
+    ))
     if not services:
         abort(400, 'No {} services on framework'.format(toggle_action['old_status']))
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -776,14 +776,13 @@ def find_supplier_services(supplier_id):
     frameworks = data_api_client.find_frameworks()['frameworks']
     supplier = data_api_client.get_supplier(supplier_id)["suppliers"]
 
-    services = data_api_client.find_services(
-        supplier_id=supplier_id,
-        framework=','.join(f['slug'] for f in frameworks if f['status'] in ['live', 'expired'])
-    )['services']
     frameworks_services = {
         framework_slug: list(framework_services)
         for framework_slug, framework_services in
-        groupby(sorted(services, key=itemgetter('frameworkSlug')), key=itemgetter('frameworkSlug'))
+        groupby(sorted(data_api_client.find_services_iter(
+            supplier_id=supplier_id,
+            framework=','.join(f['slug'] for f in frameworks if f['status'] in ['live', 'expired'])
+        ), key=itemgetter('frameworkSlug')), key=itemgetter('frameworkSlug'))
     }
 
     remove_services_for_framework, publish_services_for_framework = None, None


### PR DESCRIPTION
In preparation for https://trello.com/c/g5P0RxQn I realized that these existing views were using `find_services` without any paging capability. This would mean that for suppliers with a large number of services, we're not showing or not operating on _all_ services that actually exist.

In the past people have made arguments against use of `find_services_iter` in views because of the unbounded number of responses, but I'd much rather that caused this to fail loudly and to let us know about it than just silently be showing incorrect/incomplete results.