### PR TITLE
add find_supplier_draft_services view 

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -884,7 +884,7 @@ def _draft_services_annotated_unanswered_counts(framework_slug, draft_services):
 
 
 @main.route('/suppliers/<int:supplier_id>/draft-services', methods=['GET'])
-@role_required('admin-framework-manager')
+@role_required('admin-framework-manager', 'admin-ccs-sourcing')
 def find_supplier_draft_services(supplier_id):
     supplier = data_api_client.get_supplier(supplier_id)["suppliers"]
     frameworks = data_api_client.find_frameworks()['frameworks']

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -1,10 +1,11 @@
 {% set field_headings = [
   "Supplier Name"
-] if current_user.has_role('admin-ccs-sourcing') else [
-  "Supplier Name",
+] + ([
   summary.hidden_field_heading("Users"),
   summary.hidden_field_heading("Services")
-] %}
+] if not current_user.has_role('admin-ccs-sourcing') else []) + ([
+  summary.hidden_field_heading("Draft services")
+] if current_user.has_role('admin-framework-manager') else []) %}
 
 {% call(item) summary.list_table(
   suppliers,
@@ -19,6 +20,9 @@
     {% if not current_user.has_role('admin-ccs-sourcing') %}
       {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
       {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
+    {% endif %}
+    {% if current_user.has_role('admin-framework-manager') %}
+      {{ summary.edit_link("Draft services", url_for(".find_supplier_draft_services", supplier_id=item.id)) }}
     {% endif %}
   {% endcall %}
 

--- a/app/templates/_view_suppliers_edit_list.html
+++ b/app/templates/_view_suppliers_edit_list.html
@@ -5,7 +5,7 @@
   summary.hidden_field_heading("Services")
 ] if not current_user.has_role('admin-ccs-sourcing') else []) + ([
   summary.hidden_field_heading("Draft services")
-] if current_user.has_role('admin-framework-manager') else []) %}
+] if current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') else []) %}
 
 {% call(item) summary.list_table(
   suppliers,
@@ -21,7 +21,7 @@
       {{ summary.edit_link("Users", url_for(".find_supplier_users", supplier_id=item.id)) }}
       {{ summary.edit_link("Services", url_for(".find_supplier_services", supplier_id=item.id)) }}
     {% endif %}
-    {% if current_user.has_role('admin-framework-manager') %}
+    {% if current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
       {{ summary.edit_link("Draft services", url_for(".find_supplier_draft_services", supplier_id=item.id)) }}
     {% endif %}
   {% endcall %}

--- a/app/templates/suppliers/_frameworks_table.html
+++ b/app/templates/suppliers/_frameworks_table.html
@@ -17,7 +17,7 @@
    {{ summary.edit_link("View services", url_for(".find_supplier_services", supplier_id=supplier_id,) + "#{}_services".format(item.frameworkSlug)) }}
   {% endif %}
 
-  {% if current_user.has_role('admin-framework-manager') %}
+  {% if current_user.has_any_role('admin-framework-manager', 'admin-ccs-sourcing') %}
     {{ summary.edit_link("View draft services", url_for(".find_supplier_draft_services", supplier_id=supplier_id,) + "#{}_draft_services".format(item.frameworkSlug)) }}
   {% endif %}
 

--- a/app/templates/suppliers/_frameworks_table.html
+++ b/app/templates/suppliers/_frameworks_table.html
@@ -17,6 +17,10 @@
    {{ summary.edit_link("View services", url_for(".find_supplier_services", supplier_id=supplier_id,) + "#{}_services".format(item.frameworkSlug)) }}
   {% endif %}
 
+  {% if current_user.has_role('admin-framework-manager') %}
+    {{ summary.edit_link("View draft services", url_for(".find_supplier_draft_services", supplier_id=supplier_id,) + "#{}_draft_services".format(item.frameworkSlug)) }}
+  {% endif %}
+
   {% if item.frameworkSlug in old_interesting_framework_slugs %}
     {{ summary.edit_link("Download agreements", url_for(".download_signed_agreement_file", supplier_id=supplier_id, framework_slug=item.frameworkSlug)) }}
   {% else %}

--- a/app/templates/view_supplier_draft_services.html
+++ b/app/templates/view_supplier_draft_services.html
@@ -1,0 +1,64 @@
+{% import "toolkit/summary-table.html" as summary %}
+
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}
+  {{ supplier.name }} - Draft services – Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumbs %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": supplier.name,
+        "href": url_for('.supplier_details', supplier_id=supplier.id)
+      },
+      {
+        "text": "Draft services"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <h1 class="govuk-heading-xl">Draft services</h1>
+  {% if not frameworks_draft_services %}
+    {% call(item) summary.list_table(
+      empty_message="This supplier has no draft services on the Digital Marketplace."
+    )
+    %}{% endcall %}
+  {% else %}
+    {% for framework in frameworks | sort(attribute='id', reverse=True) %}
+      {% if framework['slug'] in frameworks_draft_services %}
+        {{ summary.heading(framework['name'], id="{}_draft_services".format(framework['slug'])) }}
+
+        {% call(item) summary.list_table(
+          frameworks_draft_services[framework['slug']],
+          caption="Draft services for the {} framework.".format(framework['name']),
+          empty_message="This supplier has no draft services for the {} framework.".format(framework['name']),
+          field_headings=['Draft service name', 'Date created', 'Draft service ID', 'Lot', 'Status', 'Unanswered questions'],
+          field_headings_visible=True
+        ) %}
+          {% call summary.row() %}
+            {% call summary.field(first=True, wide=True) %}
+              {{ item.serviceName or item.lotName }}
+            {% endcall %}
+            {{ summary.text(item.createdAt|dateformat) }}
+            {{ summary.text(item.id) }}
+            {{ summary.text(item.lotName) }}
+            {% call summary.field() %}
+              <span class="service-status-{{ item.status }}">
+                {{ item.status.replace('-', ' ')|title }}
+              </span>
+            {% endcall %}
+            {{ summary.text(item.unansweredRequiredCount|string) }}
+          {% endcall %}
+        {% endcall %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endblock %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,6 +10,6 @@ lxml==4.4.1
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.2.0#egg=digitalmarketplace-content-loader==7.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ lxml==4.4.1
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.2.0#egg=digitalmarketplace-content-loader==7.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -42,6 +42,7 @@ class BaseApplicationTest(object):
         # with a mock, because then the shared instance won't have been configured (done in create_app). Instead,
         # just mock the one function that would make an API call in this case.
         data_api_client.find_frameworks = mock.Mock()
+        # the value set here has an effect on the content that gets initially loaded by the content loader by default
         data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
 
         # if we don't make this tweak, the content loader will get re-built for every test, which is incredibly slow.

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -340,7 +340,7 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
         ("admin-ccs-category", False, True, False),
         ("admin-ccs-data-controller", False, True, False),
         ("admin-framework-manager", False, True, True),
-        ("admin-ccs-sourcing", True, False, False)
+        ("admin-ccs-sourcing", True, False, True)
     ))
     def test_sourcing_admins_see_links(
         self,
@@ -358,7 +358,7 @@ class TestSupplierDetailsViewFrameworkTable(LoggedInApplicationTest):
             FrameworkStub(
                 status="live",
                 slug="digital-outcomes-and-specialists-3"
-            ).response()
+            ).response(),
         ]}
 
         response = self.client.get("/admin/suppliers/1234")
@@ -452,7 +452,7 @@ class TestSuppliersListView(LoggedInApplicationTest):
             ("admin-ccs-category", True, False),
             ("admin-ccs-data-controller", True, False),
             ("admin-framework-manager", True, True),
-            ("admin-ccs-sourcing", False, False)
+            ("admin-ccs-sourcing", False, True)
         ]
     )
     def test_services_and_user_links_shown_to_users_with_right_roles(

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1470,6 +1470,20 @@ class TestSupplierDraftServicesView(LoggedInApplicationTest):
         assert self.data_api_client.find_draft_services_iter.called is False
         assert self.data_api_client.find_frameworks.called is False
 
+    @pytest.mark.parametrize("role, expected_code", [
+        ("admin", 403),
+        ("admin-ccs-category", 403),
+        ("admin-ccs-sourcing", 200),
+        ("admin-ccs-data-controller", 403),
+        ("admin-framework-manager", 200),
+        ("admin-manager", 403),
+    ])
+    def test_permissions(self, role, expected_code):
+        self.user_role = role
+
+        response = self.client.get("/admin/suppliers/1234/draft-services")
+        assert response.status_code == expected_code
+
 
 class TestSupplierInviteUserView(LoggedInApplicationTest):
 


### PR DESCRIPTION
https://trello.com/c/g5P0RxQn

![Spectacle X14222](https://user-images.githubusercontent.com/807447/71900689-3129e880-3156-11ea-9151-0cd6fd2bef6e.png)

Can't think of much I have to say - fairly straightforward. Currently implemented to just show drafts from all framework states to `admin-framework-manager`, nobody else.

![Spectacle X14322](https://user-images.githubusercontent.com/807447/71901123-202da700-3157-11ea-85ba-a927e090718c.png)
![Spectacle h14401](https://user-images.githubusercontent.com/807447/71901176-4ce1be80-3157-11ea-9c4c-3df66d48308b.png)
