### PR TITLE
content loader: use new `inplace_allowed` options in .filter() and .summary() methods where appropriate

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -89,12 +89,15 @@ def view_service(service_id):
             removed_at = most_recent_audit_events['auditEvents'][0]['createdAt']
 
     service_data['priceString'] = format_service_price(service_data)
-    content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
+    sections = content_loader.get_manifest(
+        service_data['frameworkSlug'],
+        'edit_service_as_admin',
+    ).filter(service_data, inplace_allowed=True).summary(service_data, inplace_allowed=True)
 
     return render_template(
         "view_service.html",
         framework=framework,
-        sections=content.summary(service_data),
+        sections=sections,
         service_data=service_data,
         service_id=service_id,
         removed_by=removed_by,
@@ -160,7 +163,10 @@ def edit_service(service_id, section_id, question_slug=None):
 
     get_framework_or_404(data_api_client, service_data['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
-    content = content_loader.get_manifest(service_data['frameworkSlug'], 'edit_service_as_admin').filter(service_data)
+    content = content_loader.get_manifest(
+        service_data['frameworkSlug'],
+        'edit_service_as_admin',
+    ).filter(service_data, inplace_allowed=True)
 
     section = content.get_section(section_id)
 
@@ -192,7 +198,10 @@ def update_service(service_id, section_id, question_slug=None):
     # TODO remove `expired` from below. It's a temporary fix to allow access to DOS2 as it's expired.
     get_framework_or_404(data_api_client, service['frameworkSlug'], allowed_statuses=['live', 'expired'])
 
-    content = content_loader.get_manifest(service['frameworkSlug'], 'edit_service_as_admin').filter(service)
+    content = content_loader.get_manifest(
+        service['frameworkSlug'],
+        'edit_service_as_admin',
+    ).filter(service, inplace_allowed=True)
     section = content.get_section(section_id)
     if question_slug is not None:
         # Overwrite section with single question section for 'question per page' editing.
@@ -301,7 +310,7 @@ def service_updates(service_id):
         extra_context["sections"] = sections = content_loader.get_manifest(
             service['frameworkSlug'],
             'edit_service_as_admin',
-        ).filter(service).sections
+        ).filter(service, inplace_allowed=True).sections
 
         extra_context["diffs"] = OrderedDict(
             (question_id, table_html,)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -333,7 +333,10 @@ def view_supplier_declaration(supplier_id, framework_slug):
             raise
         sf = {}
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter(sf.get("declaration", {}))
+    content = content_loader.get_manifest(
+        framework_slug,
+        'declaration',
+    ).filter(sf.get("declaration", {}), inplace_allowed=True)
     declaration_sections = content.sections
     question_content = OrderedDict(
         (question.id, question)
@@ -631,7 +634,7 @@ def edit_supplier_declaration_section(supplier_id, framework_slug, section_id):
             raise
         declaration = {}
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration)
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration, inplace_allowed=True)
     section = content.get_section(section_id)
     if section is None:
         abort(404)
@@ -662,7 +665,7 @@ def update_supplier_declaration_section(supplier_id, framework_slug, section_id)
             raise
         declaration = {}
 
-    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration)
+    content = content_loader.get_manifest(framework_slug, 'declaration').filter(declaration, inplace_allowed=True)
     section = content.get_section(section_id)
     if section is None:
         abort(404)
@@ -877,7 +880,7 @@ def _draft_services_annotated_unanswered_counts(framework_slug, draft_services):
         {
             **draft_service,
             "unansweredRequiredCount": count_unanswered_questions(
-                manifest.filter(draft_service).summary(draft_service)
+                manifest.filter(draft_service, inplace_allowed=True).summary(draft_service, inplace_allowed=True)
             )[0],
         } for draft_service in draft_services
     )

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,6 +10,6 @@ lxml==4.4.1
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.2.0#egg=digitalmarketplace-content-loader==7.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ lxml==4.4.1
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.2.0#egg=digitalmarketplace-content-loader==7.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha
 


### PR DESCRIPTION
Basically the same as https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1151

https://trello.com/c/ooTuJDCw

Significant performance gains here. Partly from the content loader bump as it contains some opaque optimizations, but mostly stemming from these additions. These are all in places where it can be seen that the original object reference is discarded afterwards, so it can be considered safe.