### PR TITLE
Update cookie banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,9 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 ; // Hack needed because show-hide-content.js does not have a closing ";"
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk-frontend/all.js
+//= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/digitalmarketplace-govuk-frontend.js
 //= require _selection-buttons.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/module-loader.js
 
 GOVUKFrontend.initAll()
+DMGOVUKFrontend.initAll()

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -8,6 +8,7 @@
 {% from "govuk-frontend/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {# Import DM Components #}
+{% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
 
 {% set assetPath = '/admin/static' %}
@@ -20,6 +21,12 @@
 {% endblock %}
 
 {% block header %}
+  {% block cookieBanner %}
+    {{ dmCookieBanner({
+      'cookieSettingsUrl': url_for('external.cookie_settings'),
+      'cookieInfoUrl': url_for('external.cookies'),
+    }) }}
+  {% endblock %}
   {{ dmHeader({
     "isAdmin": "true",
     "role": current_user.role | default(None)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1125,9 +1125,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.3.1.tgz",
-      "integrity": "sha512-nw/f5oDTE7L2KboC8ujqw5hyI0B5fkAEh5a6kKnesO4kQl8JOV8rviYfgOcVUzf0MdcwwT9fBUOO2bMPcd13WQ=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.0.tgz",
+      "integrity": "sha512-JuThzUkpgeIRDFfdLnljqZcuz1Ywkzk5lsKdlsrRe20Dg0j8rEuvWhfPJU5rBtcnnyBfoLdILeOXKt55to2lsg=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.3.1",
+    "digitalmarketplace-govuk-frontend": "^0.6.0",
     "govuk-country-and-territory-autocomplete": "0.5.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,7 +9,7 @@ lxml==4.5.0
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lxml==4.5.0
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.3.0#egg=digitalmarketplace-content-loader==7.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.4.0-alpha#egg=govuk-frontend-jinja==0.4.0-alpha

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -486,3 +486,12 @@ class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):
         assert link_is_visible is link_should_be_visible, (
             "Role {} {} see the link".format(role, "cannot" if link_should_be_visible else "can")
         )
+
+
+class TestCookieBanner(LoggedInApplicationTest):
+    def test_should_use_local_cookie_page_on_cookie_message(self):
+        res = self.client.get('/admin')
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+        cookie_banner = document.xpath('//div[@id="dm-cookie-banner"]')
+        assert cookie_banner[0].xpath('//h2//text()')[0].strip() == "Can we store analytics cookies on your device?"


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-3-cookie-settings-page-incl-analytics-roll-out

Introduces the new opt-in cookie banner. Note that this will use the main analytics account - previously the Admin analytics had a separate tracking ID. This code shouldn't be released this until it's confirmed that we can use the main account.

See equivalent for Buyer FE alphagov/digitalmarketplace-buyer-frontend#986

- pulls in CookieBanner component from DM GOVUK Frontend
- pulls in utils fix for the new external /user/cookie-settings route
- adds banner to base page template
- adds a cookie banner unit test (in line with other FE apps)