### PR TITLE
cookie settings link at homepage and test for it

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -200,9 +200,14 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Account settings</h2>
-    <p class="govuk-body">
-      <a class="govuk-link" href="{{ url_for('external.change_password') }}">Change your password</a>
-    </p>
+    <ul class="govuk-list">
+      <li>
+        <a class="govuk-link" href="{{ url_for('external.change_password') }}">Change your password</a>
+      </li>
+      <li>
+        <a class="govuk-link" href="{{ url_for('external.cookie_settings') }}">Change your cookie settings</a>
+      </li>
+    </ul>
   </div>
 </div>
 {% endblock %}

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -16,12 +16,15 @@ class TestIndex(LoggedInApplicationTest):
         "admin-manager",
         "admin-ccs-data-controller",
     ])
-    def test_change_password_link_is_shown_to_all_admin_users(self, role):
+    def test_account_action_links_are_shown_to_all_admin_users(self, role):
         self.user_role = role
         response = self.client.get('/admin')
         assert response.status_code == 200
         document = html.fromstring(response.get_data(as_text=True))
-        assert bool(document.xpath('.//a[@href="/user/change-password"]')), "Role {} cannot see the link".format(role)
+        assert bool(document.xpath('.//a[@href="/user/change-password"]')), \
+            "Role {} cannot see the change password link".format(role)
+        assert bool(document.xpath('.//a[@href="/user/cookie-settings"]')), \
+            "Role {} cannot see the cookie settings link".format(role)
 
     @pytest.mark.parametrize("role, link_should_be_visible", [
         ("admin", True),


### PR DESCRIPTION
trello: https://trello.com/c/X1LuXpy4/313-add-link-to-cookie-settings-page-on-user-dashboards-1