### PR TITLE
Sourcing admins cannot view draft services for open frameworks

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -892,6 +892,16 @@ def find_supplier_draft_services(supplier_id):
     supplier = data_api_client.get_supplier(supplier_id)["suppliers"]
     frameworks = data_api_client.find_frameworks()['frameworks']
 
+    if current_user.has_role('admin-ccs-sourcing'):
+        visible_framework_statuses = ["pending", "standstill", "live", "expired"]
+    elif current_user.has_role('admin-framework-manager'):
+        visible_framework_statuses = ["open", "pending", "standstill", "live", "expired"]
+    else:
+        # No other roles can access this page yet, but we might want to add them later
+        visible_framework_statuses = []
+
+    frameworks = filter(lambda fw: fw['status'] in visible_framework_statuses, frameworks)
+
     frameworks_draft_services = {
         framework_slug: draft_services
         for framework_slug, draft_services in (

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -900,7 +900,7 @@ def find_supplier_draft_services(supplier_id):
         # No other roles can access this page yet, but we might want to add them later
         visible_framework_statuses = []
 
-    frameworks = filter(lambda fw: fw['status'] in visible_framework_statuses, frameworks)
+    frameworks = (fw for fw in frameworks if fw['status'] in visible_framework_statuses)
 
     frameworks_draft_services = {
         framework_slug: draft_services

--- a/package-lock.json
+++ b/package-lock.json
@@ -1113,8 +1113,8 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#960bc2709719ee31e77a5bbe4503de6a846d23ae",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#69e06e809b51958b108d1223c2a5d6894dcb43e2",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.6.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1113,8 +1113,8 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
     "digitalmarketplace-frameworks": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#69e06e809b51958b108d1223c2a5d6894dcb43e2",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.6.0"
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#e02ef939c571a0a85a693eae0d72175e6283f1b5",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.7.0"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.6.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.7.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.6.5",
     "govuk-country-and-territory-autocomplete": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.0.10",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.6.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.6.5",
     "govuk-country-and-territory-autocomplete": "0.5.1",

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1484,15 +1484,23 @@ class TestSupplierDraftServicesView(LoggedInApplicationTest):
         response = self.client.get("/admin/suppliers/1234/draft-services")
         assert response.status_code == expected_code
 
+    @pytest.mark.parametrize("post_application_framework_status", [
+        "pending", "standstill", "live", "expired"
+    ])
     @pytest.mark.parametrize("role, visible_open_frameworks", [
         ("admin-framework-manager", 1),
         ("admin-ccs-sourcing", 0),
     ])
-    def test_open_frameworks_only_visible_to_framework_manager_admins(self, role, visible_open_frameworks):
+    def test_open_frameworks_only_visible_to_framework_manager_admins(
+        self, role, visible_open_frameworks, post_application_framework_status
+    ):
         self.data_api_client.find_frameworks.return_value = {
             "frameworks": [
                 FrameworkStub(slug="g-cloud-8", status="open").response(),
-                FrameworkStub(slug="digital-outcomes-and-specialists-2", status="pending").response(),
+                FrameworkStub(
+                    slug="digital-outcomes-and-specialists-2",
+                    status=post_application_framework_status
+                ).response(),
             ],
         }
         self.user_role = role


### PR DESCRIPTION
https://trello.com/c/utjmakOq/346-1-ensure-draft-services-view-not-visible-to-sourcing-admins-until-applications-close

To ensure legal compliance, we want to prevent CCS Sourcing admins from viewing suppliers' draft services until applications have closed. GDS framework managers can however view draft services, to help debug/answer any platform queries during applications.

I've also pulled in the latest G12 framework content, ready for QAing on Preview.