### PR TITLE
minimist JS library update

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -258,7 +258,7 @@ gulp.task(
   copyFactory(
     'images from the GOVUK frontend',
     govukFrontendImageFolder,
-    path.join(staticFolder, 'images'),
+    path.join(staticFolder, 'images')
   )
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4222,9 +4222,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",


### PR DESCRIPTION
https://trello.com/c/Gb30qeGd/1556-vulnerability-fix-tracking

Addresses a Snyk alert for this package. Updated using `npm audit fix`.

Standard JS also complained about a trailing comma in the gulpfile, so I've fixed that. 