### PR TITLE
Reorganise README for consistency with FE apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,110 @@
-# Digital Marketplace admin frontend
+# Digital Marketplace Admin Frontend
 
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-admin-frontend/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-admin-frontend?branch=master)
-[![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-admin-frontend/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-admin-frontend/requirements/?branch=master)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
-
-Frontend administration application for the digital marketplace.
+Frontend application for the Digital Marketplace.
 
 - Python app, based on the [Flask framework](http://flask.pocoo.org/)
 
+This app contains journeys for different admin user roles:
+
+- CCS Support: managing users
+- CCS Category: managing supplier services and buyers
+- CCS Sourcing: reviewing/countersigning framework applications
+- CCS Framework Manager: managing framework documents
+- CCS Admin Manager: managing admin users
+- CCS Data Controller: managing supplier company details
+
 ## Quickstart
 
-Install dependencies, build assets and run the app
+It's recommended to use the [DM Runner](https://github.com/alphagov/digitalmarketplace-runner)
+tool, which will install and run the app as part of the full suite of apps.
+
+If you want to run the app as a stand-alone process, clone the repo then run:
+
 ```
 make run-all
 ```
 
-## Full setup
+This command will install dependencies and start the app.
 
-Create a virtual environment
+By default, the app will be served at [http://127.0.0.1:5004/admin](http://127.0.0.1:5004/admin).
+
+
+### API dependencies
+
+(If you are using DM Runner you can skip this section.)
+
+The Brief Responses Frontend app requires access to the API app. The location and access token for
+this service are set with environment variables in `config.py`.
+
+For development, you can either point the environment variables to use the
+preview environment's `API` box, or use a local API instance if you have one running:
+
 ```
-python3 -m venv ./venv
+export DM_DATA_API_URL=http://localhost:5000
+export DM_DATA_API_AUTH_TOKEN=<auth_token_accepted_by_api>
 ```
 
-### Activate the virtual environment
+Where `DM_DATA_API_AUTH_TOKEN` is a token accepted by the Data API instance pointed to by `DM_API_URL`.
+
+Note: The login is handled in the [User Frontend app](https://github.com/alphagov/digitalmarketplace-user-frontend),
+so this needs to be running as well, to login as an admin.
+
+### Configuring AWS access
+
+The Admin Frontend app uses [boto](https://github.com/boto/boto) as a Python interface for our AWS S3 buckets.
+
+You will need to have AWS access keys set up on your local machine (which `boto` will automatically detect), otherwise
+some pages in the app will give an error message.
+
+Full instructions on how to do this can be found in the
+[Developer Manual](https://alphagov.github.io/digitalmarketplace-manual/infrastructure/aws-accounts.html#programmatic-access).
+
+If you're experiencing problems connecting, make sure to `unset` any `env` variables used by boto (e.g. `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+`AWS_SECURITY_TOKEN` and `AWS_PROFILE`) as they may be overriding the values in your credentials file.
+
+
+## Testing
+
+Run the full test suite:
+
 ```
-source ./venv/bin/activate
+make test
 ```
 
-### Upgrade dependencies
+To only run the Python or Javascript tests:
 
-Install new Python dependencies with pip
+```
+make test-python
+make test-javascript
+```
 
-```make requirements-dev```
+To run the `flake8` linter:
 
-### Compile the front-end code
+```
+make test-flake8
+```
+
+### Updating Python dependencies
+
+`requirements.txt` file is generated from the `requirements.in` in order to pin
+versions of all nested dependencies. If `requirements.in` has been changed (or
+we want to update the unpinned nested dependencies) `requirements.txt` should be
+regenerated with
+
+```
+make freeze-requirements
+```
+
+`requirements.txt` should be committed alongside `requirements.in` changes.
+
+## Frontend assets
+
+Front-end code (both development and production) is compiled using [Node](http://nodejs.org/) and [Gulp](http://gulpjs.com/).
+
+### Requirements
 
 You need Node (try to install the version we use in production -
  see the [base docker image](https://github.com/alphagov/digitalmarketplace-docker-base/blob/master/base.docker)).
@@ -45,55 +115,39 @@ To check the version you're running, type:
 node --version
 ```
 
-
-### Run the tests
-
-```
-make test
-```
-
-
-### Run the development server
-
-To run the Admin Frontend App for local development use the `run-all` target.
-This will install requirements, build assets and run the app.
-
-```
-make run-all
-```
-
-To just run the application use the `run-app` target.
-
-Use the app at [http://127.0.0.1:5004/admin/](http://127.0.0.1:5004/admin/)
-
-When running the admin frontend locally it listens on port 5004 by default.
-This can be changed by setting the `DM_ADMIN_PORT` environment variable, e.g.
-to set the port number to 9004:
-
-```
-export DM_ADMIN_PORT=9004
-```
-
-### Updating application dependencies
-
-`requirements.txt` file is generated from the `requirements-app.txt` in order to pin
-versions of all nested dependencies. If `requirements-app.txt` has been changed (or
-we want to update the unpinned nested dependencies) `requirements.txt` should be
-regenerated with
-
-```
-make freeze-requirements
-```
-
-`requirements.txt` should be committed alongside `requirements-app.txt` changes.
-
-## Frontend tasks
+### Frontend tasks
 
 [npm](https://docs.npmjs.com/cli/run-script) is used for all frontend build tasks. The commands available are:
 
 - `npm run frontend-build:development` (compile the frontend files for development)
 - `npm run frontend-build:production` (compile the frontend files for production)
-- `npm run frontend-build:watch` (watch all frontend files & rebuild when anything changes)
+- `npm run frontend-build:watch` (watch all frontend+framework files & rebuild when anything changes)
+
+### Updating NPM dependencies
+
+Update the relevant version numbers in `package.json`, then run
+
+```
+npm install
+```
+
+Commit the changes to `package.json` and `package-lock.json`.
+
+You can also run `npm audit fix` to make minor updates to `package-lock.json`.
+
+## Contributing
+
+This repository is maintained by the Digital Marketplace team at the [Government Digital Service](https://github.com/alphagov).
+
+If you have a suggestion for improvement, please raise an issue on this repo.
+
+### Reporting Vulnerabilities
+
+If you have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a
+responsible manner.
+
+Please follow the [GDS vulnerability reporting steps](https://github.com/alphagov/.github/blob/master/SECURITY.md),
+giving details of any issue you find. Appropriate credit will be given to those reporting confirmed issues.
 
 ## Licence
 


### PR DESCRIPTION
https://trello.com/c/Du4aEv02/468-update-readmes-for-our-repos

Aligns with the newly-reorganised Buyer FE README (see alphagov/digitalmarketplace-buyer-frontend#1012).

Contains an extra section about boto config, which is needed for this app.