### PR TITLE
Reinstate cross-domain tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1125,9 +1125,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.5.tgz",
-      "integrity": "sha512-lc1rpQhML7hzVy2wdVudEIrZ/OCo4Sl5LRC2lcjKdolK9AR9Oaev6xWSNpd7LgCqmvRafYOHhFl2aV70C2cW7g=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.8.1.tgz",
+      "integrity": "sha512-JUWLXyY3UNgvJU4rS8V4Qj6i8PBSHrtnC7Z5KLk1ayqQxw5pzP2lbT3+pj16CoaKY6bfKaLl9Um0kpd9gwljFA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.7.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.6.5",
+    "digitalmarketplace-govuk-frontend": "^0.8.1",
     "govuk-country-and-territory-autocomplete": "0.5.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
https://trello.com/c/hRRSka2u/5-re-enable-cross-domain-tracking-3

- Pulls in new version of DM GOV.UK Frontend containing updated analytics

The old analytics tests weren't previously included in the Admin FE.