### PR TITLE
Fix link and text styles for temporary message style banners

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -53,6 +53,7 @@ $govuk-global-styles: true;
 
 // Overrides
 @import "overrides/_notification-banner";
+@import "overrides/_temporary-messages";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_temporary-messages.scss
+++ b/app/assets/scss/overrides/_temporary-messages.scss
@@ -1,0 +1,31 @@
+// TODO: Remove when temporary message banners have been replaced
+
+// Ensure that text within banners contrasts with blue background
+.banner-temporary-message-without-action {
+  p.banner-message,
+  p.banner-message {
+    color: $white;
+
+    a, a:visited {
+      color: $white;
+    }
+
+    a:hover, a:active {
+      color: $light-blue-50;
+    }
+  }
+}
+
+.temporary-message {
+  p.temporary-message-message {
+    color: $white;
+
+    a, a:visited {
+      color: $white;
+    }
+
+    a:hover, a:active {
+      color: $light-blue-50;
+    }
+  }
+}


### PR DESCRIPTION
Ticket https://trello.com/c/nT73XTf3/

Admins are unable to see the link to publish a removed service due to a bug in the styles of links in temporary message banners.

Fix copied from https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/release-1037/app/assets/scss/overrides/_temporary-messages.scss

### Before

![image](https://user-images.githubusercontent.com/503614/82572415-2f4c4900-9b7c-11ea-924b-e6625d0febf2.png)

### After

![image](https://user-images.githubusercontent.com/503614/82572805-d0d39a80-9b7c-11ea-893e-0483673a3d2d.png)
