### PR TITLE
Bump lxml to 4.5.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 Flask==1.0.4
 Flask-Login==0.5.0
 Flask-WTF==0.14.3
-lxml==4.5.0
+lxml==4.5.1
 itsdangerous==1.1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
 jinja2==2.10.3            # via digitalmarketplace-content-loader, flask, govuk-frontend-jinja
 jmespath==0.9.4           # via boto3, botocore
-lxml==4.5.0               # via -r requirements.in
+lxml==4.5.1               # via -r requirements.in
 mailchimp3==3.0.6         # via digitalmarketplace-utils
 markdown==2.6.11          # via digitalmarketplace-content-loader
 markupsafe==1.1.1         # via jinja2


### PR DESCRIPTION
https://trello.com/c/9SGled2F/1725-resolve-dependabot-prs

The [original dependabot PR](https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/653) decided to remove a bunch of dependencies when it tried bumping this, so I've done it manually for now. We have a separate card to investigate the dependabot issue.