### PR TITLE
Disable FlaskLogin flash messages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -106,6 +106,7 @@ def create_app(config_name):
     # the external NotImplemented routes in the dm-utils external blueprint).
     application.register_blueprint(external_blueprint)
 
+    login_manager.login_message = None  # don't flash message to user
     login_manager.login_view = '/user/login'
     main_blueprint.config = application.config.copy()
 


### PR DESCRIPTION
Ticket: https://trello.com/c/sxhsW20p/88-replace-flash-messages-with-alert-component-in-briefs-frontend

We don't want to use the default flash message for when a user needs an account to access a page, so this PR disables the message flashing in FlaskLogin.

Note that this app previously did not have the message category set to `must_login`, so it does show flash messages on production if you try to access `/admin` and are not logged in, unlike the other apps. However looking at the git log I couldn't see any evidence of this being a deliberate design decision, so I've taken the opinion that we should change it to be consistent with our other apps.