### PR TITLE
Admin view for e-signature framework agreements (for G12 onwards)

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -36,6 +36,7 @@ from ..helpers.supplier_details import (
     get_company_details_from_supplier,
     DEPRECATED_FRAMEWORK_SLUGS,
 )
+from .agreements import OLD_COUNTERSIGNING_FLOW_FRAMEWORKS
 from ... import data_api_client, content_loader
 
 
@@ -376,32 +377,49 @@ def view_signed_agreement(supplier_id, framework_slug):
     if not supplier_framework.get('agreementReturned'):
         abort(404)
 
+    lot_names = []
     if framework["status"] in ("live", "expired"):
         # If the framework is live or expired we don't need to filter drafts, we only care about successful services
         service_iterator = data_api_client.find_services_iter(supplier_id=supplier_id, framework=framework_slug)
-        lot_slugs_names = [(service["lotSlug"], service["lotName"]) for service in service_iterator]
+        for service in service_iterator:
+            if service['lotName'] not in lot_names:
+                lot_names.append(service['lotName'])
     else:
         # If the framework has not yet become live we need to filter out unsuccessful services
         service_iterator = data_api_client.find_draft_services_iter(supplier_id=supplier_id, framework=framework_slug)
-        lot_slugs_names = [
-            (service["lotSlug"], service["lotName"]) for service in service_iterator if service["status"] == "submitted"
-        ]
+        for service in service_iterator:
+            if service["status"] == "submitted" and service['lotName'] not in lot_names:
+                lot_names.append(service['lotName'])
 
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
-    path = supplier_framework['agreementPath']
-    url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
+
+    if framework_slug in OLD_COUNTERSIGNING_FLOW_FRAMEWORKS:
+        is_e_signature_flow = False
+        # Fetch path to supplier's signature page
+        path = supplier_framework['agreementPath']
+        template = "suppliers/view_signed_agreement.html"
+    else:
+        is_e_signature_flow = True
+        # Fetch path to combined countersigned agreement, if available
+        path = supplier_framework.get('countersignedPath', "")
+        template = "suppliers/view_esignature_agreement.html"
+
+    url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL']) if path else ""
+    agreement_ext = get_extension(path) if path else ""
+
     if not url:
         current_app.logger.info(f'No agreement file found for {path}')
     return render_template(
-        "suppliers/view_signed_agreement.html",
+        template,
         company_details=get_company_details_from_supplier(supplier),
         supplier=supplier,
         framework=framework,
         supplier_framework=supplier_framework,
-        lot_slugs_names=OrderedDict(sorted(lot_slugs_names)),
+        lot_names=list(sorted(lot_names)),
         agreement_url=url,
-        agreement_ext=get_extension(path),
+        agreement_ext=agreement_ext,
         next_status=next_status,
+        is_e_signature_flow=is_e_signature_flow
     )
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -401,7 +401,7 @@ def view_signed_agreement(supplier_id, framework_slug):
     else:
         is_e_signature_flow = True
         # Fetch path to combined countersigned agreement, if available
-        path = supplier_framework.get('countersignedPath', "")
+        path = supplier_framework.get('countersignedPath')
         template = "suppliers/view_esignature_agreement.html"
 
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL']) if path else ""

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -151,15 +151,9 @@
             <ul class="govuk-list">
               {% if framework.status in ["live", "standstill"] or
                   (framework.family == 'digital-outcomes-and-specialists' and framework.status == 'expired') %}
-                {% set agreement_link_text = {
-                  'admin-ccs-category': 'View agreements',
-                  'admin-ccs-sourcing': 'Countersign agreements',
-                  'admin-framework-manager': 'View agreements',
-                  }
-              %}
                 <li>
                   <a class="govuk-link" href="{{ url_for('.list_agreements', framework_slug=framework['slug'], status='signed') }}">
-                    {{ agreement_link_text[current_user.role] }}
+                    View supplier framework agreements
                   </a>
                 </li>
               {% endif %}

--- a/app/templates/suppliers/view_esignature_agreement.html
+++ b/app/templates/suppliers/view_esignature_agreement.html
@@ -34,7 +34,7 @@
         {% call(item)
               summary.list_table(
                 [
-                  {"name": "Appointment is to", "value": ", ".join(lot_names) },
+                  {"name": "Appointment is to", "value": lot_names|join(", ") },
                   {"name": "Signer name", "value": supplier_framework.agreementDetails.signerName },
                   {"name": "Signer role", "value": supplier_framework.agreementDetails.signerRole },
                   {"name": "Signer user", "value": supplier_framework.agreementDetails.uploaderUserEmail  },

--- a/app/templates/suppliers/view_esignature_agreement.html
+++ b/app/templates/suppliers/view_esignature_agreement.html
@@ -1,0 +1,64 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block pageTitle %}
+  {{ framework.name }} agreement for {{ supplier_framework.declaration.nameOfOrganisation }} – Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumbs %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": "{} agreements".format(framework.name),
+        "href": url_for('.list_agreements', framework_slug=framework.slug)
+      },
+      {
+        "text": "Framework agreement"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <h1 class="govuk-heading-l">{{ company_details.registered_name }}</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <p><a href="{{ url_for('.supplier_details', supplier_id=supplier.id) }}">View company details</a></p>
+
+       <h2 class="govuk-heading-m">Signature details</h2>
+        {% call(item)
+              summary.list_table(
+                [
+                  {"name": "Appointment is to", "value": ", ".join(lot_names) },
+                  {"name": "Signer name", "value": supplier_framework.agreementDetails.signerName },
+                  {"name": "Signer role", "value": supplier_framework.agreementDetails.signerRole },
+                  {"name": "Signer user", "value": supplier_framework.agreementDetails.uploaderUserEmail  },
+                  {"name": "Signing date", "value": supplier_framework.agreementReturnedAt|datetimeformat  }
+                ],
+                caption=caption,
+              )
+          %}
+          {% call summary.row() %}
+            {{ summary.field_name(item.name, wide=True) }}
+            {{ summary.text(item.value or "None") }}
+          {% endcall %}
+        {% endcall %}
+
+        <h2 class="govuk-heading-m">Countersignature status</h2>
+      {% if agreement_url %}
+        <p class="govuk-body">
+            <a href="{{ agreement_url }}">View countersigned framework agreement</a>
+        </p>
+        <p class="govuk-body">Automatically countersigned on {{ supplier_framework.countersignedAt|datetimeformat }}</p>
+      {% else %}
+        <p class="govuk-body">Waiting for automatic countersigning</p>
+      {% endif %}
+
+  </div>
+  </div>
+{% endblock %}

--- a/app/templates/suppliers/view_signed_agreement.html
+++ b/app/templates/suppliers/view_signed_agreement.html
@@ -51,7 +51,7 @@
 
       <h2>Appointment is to</h2>
       <ul class="govuk-list">
-        {% for lot_slug, lot_name in lot_slugs_names.items() %}
+        {% for lot_name in lot_names %}
           <li>{{ lot_name }}</li>
         {% endfor %}
       </ul>

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -27,17 +27,23 @@
   {# ### Don't show instructions for read-only users ### #}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">
-          {% if is_e_signature_flow %}
-            {{framework.name}} agreements are electronically signed, and do not need manual countersigning.
-          {% else %}
-            Review the information for each agreement, accept it, and continue to the next one.
-          {% endif %}
-        </p>
-        <p class="govuk-body">
-          If there’s a problem with an agreement, contact the person who uploaded it and come back to it later. Ask
+        {% if is_e_signature_flow %}
+          <p class="govuk-body">
+            {{ framework.name }} agreements are electronically signed, and do not need manual countersigning.
+          </p>
+          <p class="govuk-body">
+          If there’s a problem with the agreement, contact the person who signed it. Ask
           suppliers to resubmit from the link in the email they received after they were accepted on to the framework.
-        </p>
+          </p>
+        {% else %}
+          <p class="govuk-body">
+            Review the information for each agreement, accept it, and continue to the next one.
+          </p>
+          <p class="govuk-body">
+            If there’s a problem with an agreement, contact the person who uploaded it and come back to it later. Ask
+            suppliers to resubmit from the link in the email they received after they were accepted on to the framework.
+          </p>
+        {% endif %}
       </div>
     </div>
   {% endif %}

--- a/app/templates/view_agreements_list.html
+++ b/app/templates/view_agreements_list.html
@@ -28,7 +28,11 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
-          Review the information for each agreement, accept it, and continue to the next one.
+          {% if is_e_signature_flow %}
+            {{framework.name}} agreements are electronically signed, and do not need manual countersigning.
+          {% else %}
+            Review the information for each agreement, accept it, and continue to the next one.
+          {% endif %}
         </p>
         <p class="govuk-body">
           If there’s a problem with an agreement, contact the person who uploaded it and come back to it later. Ask

--- a/tests/app/main/views/test_index_page.py
+++ b/tests/app/main/views/test_index_page.py
@@ -346,9 +346,9 @@ class TestFrameworkActionsOnIndexPage(LoggedInApplicationTest):
 
     @pytest.mark.parametrize("role, link_should_be_visible, expected_link_text", [
         ("admin", False, None),
-        ("admin-ccs-category", True, "View agreements"),
-        ("admin-ccs-sourcing", True, "Countersign agreements"),
-        ("admin-framework-manager", True, "View agreements"),
+        ("admin-ccs-category", True, "View supplier framework agreements"),
+        ("admin-ccs-sourcing", True, "View supplier framework agreements"),
+        ("admin-framework-manager", True, "View supplier framework agreements"),
         ("admin-manager", False, None),
         ("admin-ccs-data-controller", False, None),
     ])


### PR DESCRIPTION
https://trello.com/c/psi3gVdH/157-2-admins-can-view-the-new-pdf-for-g12

- Simplify index page content to reduce confusion about whether an agreement needs a countersigning 'action' to happen
- Change agreement list page to make it clear that no countersigning action is required (and to contact suppliers if there is a problem)
- New template for showing signer details for G12+ frameworks, with link to countersigned PDF if present

Signed, but not countersigned:
![admin-esig-not-countersigned](https://user-images.githubusercontent.com/3492540/92016182-e181d800-ed49-11ea-9ac0-1d77f9cde331.png)

Signed and countersigned (link to PDF file generated by Jenkins):
![admin-esig-countersigned](https://user-images.githubusercontent.com/3492540/92016397-33c2f900-ed4a-11ea-850d-fd92c2c1265f.png)

Agreement list page for an e-signature framework (eg G12):
![admin-esig-agreement-list](https://user-images.githubusercontent.com/3492540/92363322-39716380-f0e9-11ea-9456-105be4b225cc.png)

