### PR TITLE
set DM_REDIS_SERVICE_NAME to None

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ class Config(object):
     DM_COMMUNICATIONS_BUCKET = None
     DM_REPORTS_BUCKET = None
     DM_ASSETS_URL = None
+    DM_REDIS_SERVICE_NAME = None
 
     STATIC_URL_PATH = '/admin/static'
     ASSET_PATH = STATIC_URL_PATH + '/'


### PR DESCRIPTION
https://trello.com/c/0XO8CHaP/381-05-stand-up-the-paas-infrastructure-for-the-preview-environment

We need to set this to `None` to stop it getting stripped out of the app config when set in an environment variable

Co-authored-by: Benjamin Gill <benjamin.gill@digital.cabinet-office.gov.uk>