### PR TITLE
Add link to admin-only DOS opportunities CSV

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -6,7 +6,7 @@ main = Blueprint('main', __name__)
 public = Blueprint('public', __name__)  # Admin login not required
 
 from .views import (
-    agreements, communications, direct_award, search, service_updates,
+    agreements, communications, outcomes, search, service_updates,
     services, suppliers, stats, users, buyers, admin_manager
 )
 from app.main import errors

--- a/app/main/views/outcomes.py
+++ b/app/main/views/outcomes.py
@@ -1,6 +1,10 @@
 from datetime import datetime
-from dmutils import csv_generator
-from flask import Response
+
+from flask import Response, abort, current_app, redirect
+
+from dmutils import csv_generator, s3
+from dmutils.documents import get_signed_url
+
 from .. import main
 from ..auth import role_required
 from ... import data_api_client
@@ -70,3 +74,34 @@ def download_direct_award_outcomes():
             "Content-Type": "text/csv; header=present"
         }
     )
+
+
+@main.route("/digital-outcomes-and-specialists/outcomes", methods=["GET"])
+@role_required("admin-ccs-category", "admin-framework-manager", "admin-ccs-sourcing")
+def download_dos_outcomes():
+    # get the slug for the latest DOS framework iteration
+    framework_slug = (
+        sorted(
+            filter(
+                lambda fw: (
+                    fw["family"] == "digital-outcomes-and-specialists"
+                    and fw["status"] == "live"
+                ),
+                data_api_client.find_frameworks()["frameworks"]
+            ),
+            key=lambda fw: fw["frameworkLiveAtUTC"],
+            reverse=True,
+        )[0]["slug"]
+    )
+
+    reports_bucket = s3.S3(current_app.config["DM_REPORTS_BUCKET"])
+    url = get_signed_url(
+        reports_bucket,
+        f"{framework_slug}/reports/opportunity-data.csv",
+        current_app.config["DM_ASSETS_URL"]
+    )
+
+    if not url:
+        abort(404)
+
+    return redirect(url)

--- a/app/main/views/outcomes.py
+++ b/app/main/views/outcomes.py
@@ -8,7 +8,7 @@ from ... import data_api_client
 
 @main.route('/direct-award/outcomes', methods=['GET'])
 @role_required('admin-ccs-category', 'admin-framework-manager', 'admin-ccs-sourcing')
-def download_outcomes():
+def download_direct_award_outcomes():
     download_filename = "direct-award-outcomes-{}.csv".format(datetime.utcnow().strftime('%Y-%m-%d-at-%H-%M-%S'))
     projects = data_api_client.find_direct_award_projects(having_outcome=True, with_users=True).get('projects', [])
     headers = [

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -133,7 +133,7 @@
         <h2 class="govuk-heading-l">Outcomes</h2>
         <ul class="govuk-list">
           <li>
-            <a class="govuk-link" href="{{ url_for('.download_outcomes') }}">
+            <a class="govuk-link" href="{{ url_for('.download_direct_award_outcomes') }}">
               Download Direct Award outcomes
             </a>
           </li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -137,6 +137,12 @@
               Download Direct Award outcomes
             </a>
           </li>
+
+          <li>
+            <a class="govuk-link" href="{{ url_for('.download_dos_outcomes') }}">
+              Download Digital Outcomes and Specialists outcomes
+            </a>
+          </li>
         </ul>
 
         {# FRAMEWORKS AND APPLICATIONS #}

--- a/tests/app/main/views/test_outcomes.py
+++ b/tests/app/main/views/test_outcomes.py
@@ -7,7 +7,7 @@ import csv
 class TestDirectAwardView(LoggedInApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
-        self.data_api_client_patch = mock.patch('app.main.views.direct_award.data_api_client', autospec=True)
+        self.data_api_client_patch = mock.patch('app.main.views.outcomes.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
 
     def teardown_method(self, method):

--- a/tests/app/main/views/test_outcomes.py
+++ b/tests/app/main/views/test_outcomes.py
@@ -1,7 +1,11 @@
-from ...helpers import LoggedInApplicationTest
-import pytest
-import mock
 import csv
+
+import mock
+import pytest
+
+from dmtestutils.api_model_stubs import FrameworkStub
+
+from ...helpers import LoggedInApplicationTest
 
 
 class TestDirectAwardView(LoggedInApplicationTest):
@@ -145,3 +149,91 @@ class TestDirectAwardView(LoggedInApplicationTest):
             '1234.00', '123321', '2002-12-12', '2020-12-12',
             '123', 'A Buyer', 'buyer@example.com'
         ]
+
+
+class TestDOSView(LoggedInApplicationTest):
+
+    url = "/admin/digital-outcomes-and-specialists/outcomes"
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.outcomes.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+        self.data_api_client.find_frameworks.return_value = {"frameworks": [
+            FrameworkStub(
+                slug="digital-outcomes-and-specialists-4", status="live"
+            ).response()
+        ]}
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
+    @pytest.fixture(autouse=True)
+    def s3(self):
+        with mock.patch("app.main.views.outcomes.s3") as s3:
+            bucket = s3.S3()
+            bucket.get_signed_url.side_effect = \
+                lambda path: f"https://s3.example.com/{path}?signature=deadbeef"
+            yield s3
+
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 403),
+        ("admin-manager", 403),
+        ("admin-ccs-category", 302),
+        ("admin-ccs-sourcing", 302),
+        ("admin-framework-manager", 302),
+    ])
+    def test_download_permissions(self, role, expected_code):
+        self.user_role = role
+        response = self.client.get(self.url)
+        actual_code = response.status_code
+        assert actual_code == expected_code, "Unexpected response {} for role {}".format(actual_code, role)
+
+    def test_redirects_to_assets_domain(self):
+        self.user_role = "admin-ccs-category"
+
+        response = self.client.get(self.url)
+        assert response.status_code == 302
+        assert response.location \
+            == "https://assets.test.digitalmarketplace.service.gov.uk" \
+            "/digital-outcomes-and-specialists-4/reports/opportunity-data.csv" \
+            "?signature=deadbeef"
+
+    @pytest.mark.parametrize("latest_dos_framework", (
+        "digital-outcomes-and-specialists-4",
+        "digital-outcomes-and-specialists-5",
+    ))
+    def test_csv_is_for_latest_live_dos_framework(self, latest_dos_framework, s3):
+        self.user_role = "admin-ccs-category"
+
+        self.data_api_client.find_frameworks.return_value = {"frameworks": [
+            FrameworkStub(
+                framework_live_at="2016-03-03 12:00:00",
+                slug="digital-outcomes-and-specialists",
+                status="expired"
+            ).response(),
+            FrameworkStub(
+                framework_live_at="2018-10-01 10:58:09.43134",
+                slug="digital-outcomes-and-specialists-3",
+                status="live"
+            ).response(),
+            FrameworkStub(
+                framework_live_at="2019-12-18 15:13:24.53636",
+                slug=latest_dos_framework,
+                status="live"
+            ).response(),
+            FrameworkStub(
+                framework_live_at="2020-12-18 15:13:24.53636",
+                slug="g-cloud-12",
+                status="live"
+            ).response(),
+        ]}
+
+        response = self.client.get(self.url)
+
+        assert s3.S3().get_signed_url.call_args == mock.call(
+            f"{latest_dos_framework}/reports/opportunity-data.csv"
+        )
+        assert latest_dos_framework in response.location


### PR DESCRIPTION
Ticket: https://trello.com/c/s5IrVY70/2122-ccsrequest-queries-relating-to-the-digital-marketplace-for-dos-team

Currently CCS admins have to cross-reference buyer user details with an opportunity by hand, which is time-consuming for them.

This commit adds a link to the admin-only DOS opportunities CSV, which is uploaded to the reports bucket by the export-dos-opportunities script since alphagov/digitalmarketplace-scripts#594.

<img width="571" alt="Screenshot 2020-12-22 at 11 11 36" src="https://user-images.githubusercontent.com/503614/102882581-78cc8180-4446-11eb-92e1-dd0a397fd29b.png">