### PR TITLE
Stop filtering re-used manifest in-place

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -898,7 +898,7 @@ def _draft_services_annotated_unanswered_counts(framework_slug, draft_services):
         {
             **draft_service,
             "unansweredRequiredCount": count_unanswered_questions(
-                manifest.filter(draft_service, inplace_allowed=True).summary(draft_service, inplace_allowed=True)
+                manifest.filter(draft_service).summary(draft_service)
             )[0],
         } for draft_service in draft_services
     )


### PR DESCRIPTION
Trello: https://trello.com/c/HaEzwoIn/2019-investigate-potential-admin-dashboard-bug

In 58b1af0a33ac560e1798aaa64f5943bddc510d3b, we started filtering this manifest in-place for performance reasons. However, this manifest gets re-used for each draft service. This caused problems for g-cloud because there are some questions that only appear in certain lots. This meant that we would filter these questions out, and then throw a KeyError when trying to get the summary of a later draft for a different lot.

Switch back to not filtering/summarising in place to avoid this problem. This will reduce performance slightly. However, it's the admin app, so it doesn't matter that much.

I've checked the other `inplace`s added in https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/610 and https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1151. As far as I can tell, none of the other instances have this same problem.