### PR TITLE
Use e-signature boolean in API response

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -20,18 +20,6 @@ def get_status_labels():
     ))
 
 
-OLD_COUNTERSIGNING_FLOW_FRAMEWORKS = [
-    'digital-outcomes-and-specialists-4',
-    'digital-outcomes-and-specialists-3',
-    'digital-outcomes-and-specialists-2',
-    'digital-outcomes-and-specialists',
-    'g-cloud-11',
-    'g-cloud-10',
-    'g-cloud-9',
-    'g-cloud-8',
-]
-
-
 def _get_supplier_frameworks(framework_slug, status=None):
     return [
         supplier_framework for supplier_framework in data_api_client.find_framework_suppliers(
@@ -62,12 +50,11 @@ def list_agreements(framework_slug):
     # Determine which template to use.
     # G-Cloud 7 and earlier frameworks do not have a frameworkAgreementVersion and use an old countersigning flow
     # G-Cloud 12 and newer frameworks use e-signature flow (countersignatures are automated)
-    is_e_signature_flow = False
+    is_e_signature_flow = framework['isESignatureSupported']
     if framework.get('frameworkAgreementVersion'):
         template = "view_agreements_list.html"
-        if framework['slug'] not in OLD_COUNTERSIGNING_FLOW_FRAMEWORKS:
+        if is_e_signature_flow:
             status_labels['signed'] = "Waiting for automated countersigning"
-            is_e_signature_flow = True
     else:
         template = 'view_agreements.html'
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -36,7 +36,6 @@ from ..helpers.supplier_details import (
     get_company_details_from_supplier,
     DEPRECATED_FRAMEWORK_SLUGS,
 )
-from .agreements import OLD_COUNTERSIGNING_FLOW_FRAMEWORKS
 from ... import data_api_client, content_loader
 
 
@@ -393,13 +392,12 @@ def view_signed_agreement(supplier_id, framework_slug):
 
     agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
 
-    if framework_slug in OLD_COUNTERSIGNING_FLOW_FRAMEWORKS:
-        is_e_signature_flow = False
+    is_e_signature_flow = framework['isESignatureSupported']
+    if not is_e_signature_flow:
         # Fetch path to supplier's signature page
         path = supplier_framework['agreementPath']
         template = "suppliers/view_signed_agreement.html"
     else:
-        is_e_signature_flow = True
         # Fetch path to combined countersigned agreement, if available
         path = supplier_framework.get('countersignedPath')
         template = "suppliers/view_esignature_agreement.html"

--- a/example_responses/framework_response.json
+++ b/example_responses/framework_response.json
@@ -50,6 +50,7 @@
     "slug":"g-cloud-8",
     "framework":"g-cloud",
     "family": "g-cloud",
-    "id":6
+    "id":6,
+    "isESignatureSupported":false
   }
 }

--- a/tests/app/main/views/test_agreements.py
+++ b/tests/app/main/views/test_agreements.py
@@ -63,6 +63,7 @@ class TestListAgreements(LoggedInApplicationTest):
                 "name": "G-Cloud 7",
                 "slug": "g-cloud-7",
                 "framework": "g-cloud",
+                "isESignatureSupported": False
             }
         }
 
@@ -222,7 +223,8 @@ class TestListAgreements(LoggedInApplicationTest):
         self.data_api_client.get_framework.return_value = {
             "frameworks": {
                 "slug": "g-cloud-12",
-                "frameworkAgreementVersion": "RM.12"
+                "frameworkAgreementVersion": "RM.12",
+                "isESignatureSupported": True
             }
         }
         self.data_api_client.find_framework_suppliers.return_value = {
@@ -255,7 +257,8 @@ class TestListAgreements(LoggedInApplicationTest):
         self.data_api_client.get_framework.return_value = {
             "frameworks": {
                 "slug": "g-cloud-12",
-                "frameworkAgreementVersion": "RM.12"
+                "frameworkAgreementVersion": "RM.12",
+                "isESignatureSupported": True
             }
         }
         self.data_api_client.find_framework_suppliers.return_value = {

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -2752,6 +2752,7 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
             assert len(document.xpath('//span[contains(text(), "uploader@email.com")]')) == 1
 
     def test_signed_agreement_details_visible_for_esignature_flow(self, s3):
+        self.data_api_client.get_framework.return_value['frameworks'].update({'isESignatureSupported': True})
         self.data_api_client.find_services_iter.return_value = iter(self.services_response)
 
         response = self.client.get('/admin/suppliers/1234/agreements/g-cloud-12')
@@ -2773,6 +2774,7 @@ class TestViewingSignedAgreement(LoggedInApplicationTest):
         assert len(document.xpath('//p[contains(text(), "Waiting for automatic countersigning")]')) == 1
 
     def test_countersigned_agreement_details_visible_for_esignature_flow(self, s3):
+        self.data_api_client.get_framework.return_value['frameworks'].update({'isESignatureSupported': True})
         self.data_api_client.find_services_iter.return_value = iter(self.services_response)
         supplier_framework_info = self.load_example_listing(
             'supplier_framework_response'
@@ -3073,6 +3075,7 @@ class TestCorrectButtonsAreShownDependingOnContext(LoggedInApplicationTest):
                 'frameworkAgreementVersion': 'v1.0',
                 'slug': 'g-cloud-8',
                 'status': 'live',
+                'isESignatureSupported': False
             },
         }
         self.data_api_client.find_services_iter.return_value = []


### PR DESCRIPTION
https://trello.com/c/qmUdpw9u/656-1-e-signature-cleanup-use-api-boolean-to-check-frameworks

Use e-signature boolean in API response to determine e-signature frameworks rather than hardcoded heuristic.