### PR TITLE
Bump digitalmarketplace-frontend-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1244,8 +1244,8 @@
       "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.1"
     },
     "digitalmarketplace-frontend-toolkit": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#56cf86e68c5af4df0cacf7710461e8e96619ee8a",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.1",
       "requires": {
         "govuk-elements-sass": "3.0.3",
         "govuk_frontend_toolkit": "5.0.3"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "colors": "1.1.2",
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v18.0.1",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.1",
     "digitalmarketplace-govuk-frontend": "^2.1.0",
     "govuk-country-and-territory-autocomplete": "0.5.1",
     "govuk-elements-sass": "3.0.3",


### PR DESCRIPTION
Pick up bug fix from https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/494 which allows admins to update DOS5 specialist services.

https://trello.com/c/XGAEqKRu/2165-ccs-category-admins-cant-add-new-specialist-types-to-digital-specialists-services-on-dos5