### PR TITLE
add npm to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
   open-pull-requests-limit: 10
   allow:
   - dependency-type: production
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"


### PR DESCRIPTION
https://trello.com/c/iAQbojbf/842-3-keep-npm-dependencies-up-to-date
Add NPM dependencies to Dependabot. I have validated this using their schema validator: https://dependabot.com/docs/config-file-beta/validator/
