### PR TITLE
Fix breadcrumbs for edit service section page

### DIFF
--- a/app/templates/edit_section.html
+++ b/app/templates/edit_section.html
@@ -17,7 +17,11 @@
         "href": url_for('.index')
       },
       {
-        "text": service_data['serviceName'],
+        "text": service_data.supplierName,
+        "href": url_for(".find_supplier_services", supplier_id=service_data.supplierId)
+      },
+      {
+        "text": service_data.serviceName | default(service_data.frameworkName ~ " - " ~ service_data.lotName),
         "href": url_for(".view_service", service_id=service_data.id)
       },
       {

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -813,6 +813,8 @@ class TestServiceEdit(LoggedInApplicationTest):
     def test_service_edit_documents_get_response(self):
         service = {
             "id": 321,
+            "supplierId": 100,
+            "supplierName": "Boylan",
             'frameworkSlug': 'g-cloud-8',
             "serviceName": "Boylan the billsticker",
             "lot": "scs",
@@ -837,6 +839,7 @@ class TestServiceEdit(LoggedInApplicationTest):
 
     def test_service_edit_with_no_features_or_benefits(self):
         self.data_api_client.get_service.return_value = {'services': {
+            "supplierId": 100,
             'lot': 'saas',
             'frameworkSlug': 'g-cloud-8',
         }}
@@ -875,6 +878,9 @@ class TestServiceEdit(LoggedInApplicationTest):
 
     def test_service_edit_assurance_questions(self):
         service = {
+            "supplierId": 100,
+            "supplierName": "My supplier",
+
             'frameworkSlug': 'g-cloud-8',
             'lot': 'saas',
             'serviceAvailabilityPercentage': {


### PR DESCRIPTION
Ticket: https://trello.com/c/5U1S0Y0H/841-1-breadcrumbs-are-broken-on-admin-edit-a-service-page