### PR TITLE
Add support for localstack S3 subdomains

### DIFF
--- a/app/main/views/communications.py
+++ b/app/main/views/communications.py
@@ -23,7 +23,9 @@ _comm_types = ("communication", "clarification",)
 @main.route('/communications/<framework_slug>', methods=['GET'])
 @role_required('admin-framework-manager')
 def manage_communications(framework_slug):
-    communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
+    communications_bucket = s3.S3(
+        current_app.config['DM_COMMUNICATIONS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     framework = get_framework_or_404(data_api_client, framework_slug)
 
     # generate a dict of comm_type: seq of s3 object dicts
@@ -56,7 +58,9 @@ def download_communication(framework_slug, comm_type, filepath):
     # ensure this is a real framework
     get_framework_or_404(data_api_client, framework_slug)
 
-    bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
+    bucket = s3.S3(
+        current_app.config['DM_COMMUNICATIONS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     full_path = _get_comm_type_root(framework_slug, comm_type) / filepath
     url = get_signed_url(bucket, str(full_path), current_app.config["DM_ASSETS_URL"])
     if not url:
@@ -68,7 +72,9 @@ def download_communication(framework_slug, comm_type, filepath):
 @main.route('/communications/<framework_slug>', methods=['POST'])
 @role_required('admin-framework-manager')
 def upload_communication(framework_slug):
-    communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
+    communications_bucket = s3.S3(
+        current_app.config['DM_COMMUNICATIONS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     errors = {}
 
     if request.files.get('communication'):
@@ -115,7 +121,9 @@ def delete_communication(framework_slug, comm_type, filepath):
         if "confirm" not in request.form:
             abort(400, "Expected 'confirm' parameter in POST request")
 
-        communications_bucket = s3.S3(current_app.config['DM_COMMUNICATIONS_BUCKET'])
+        communications_bucket = s3.S3(
+            current_app.config['DM_COMMUNICATIONS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+        )
         full_path = _get_comm_type_root(framework_slug, comm_type) / filepath
 
         # do this check ourselves - deleting an object in S3 silently has no effect, forwarding this behaviour to the

--- a/app/main/views/outcomes.py
+++ b/app/main/views/outcomes.py
@@ -94,7 +94,9 @@ def download_dos_outcomes():
         )[0]["slug"]
     )
 
-    reports_bucket = s3.S3(current_app.config["DM_REPORTS_BUCKET"])
+    reports_bucket = s3.S3(
+        current_app.config["DM_REPORTS_BUCKET"], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     url = get_signed_url(
         reports_bucket,
         f"{framework_slug}/reports/opportunity-data.csv",

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -213,7 +213,7 @@ def update_service(service_id, section_id, question_slug=None):
     posted_data = section.get_data(request.form)
 
     uploaded_documents, document_errors = upload_service_documents(
-        s3.S3(current_app.config['DM_S3_DOCUMENT_BUCKET']),
+        s3.S3(current_app.config['DM_S3_DOCUMENT_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")),
         'documents',
         current_app.config['DM_ASSETS_URL'],
         service, request.files, section)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -390,7 +390,9 @@ def view_signed_agreement(supplier_id, framework_slug):
             if service["status"] == "submitted" and service['lotName'] not in lot_names:
                 lot_names.append(service['lotName'])
 
-    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    agreements_bucket = s3.S3(
+        current_app.config['DM_AGREEMENTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
 
     is_e_signature_flow = framework['isESignatureSupported']
     if not is_e_signature_flow:
@@ -501,7 +503,9 @@ def download_agreement_file(supplier_id, framework_slug, document_name):
     if supplier_framework is None or not supplier_framework.get("declaration"):
         abort(404)
 
-    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    agreements_bucket = s3.S3(
+        current_app.config['DM_AGREEMENTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     path = get_document_path(framework_slug, supplier_id, 'agreements', document_name)
     url = get_signed_url(agreements_bucket, path, current_app.config['DM_ASSETS_URL'])
     if not url:
@@ -518,7 +522,9 @@ def list_countersigned_agreement_file(supplier_id, framework_slug):
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
     if not supplier_framework['onFramework'] or supplier_framework['agreementStatus'] in (None, 'draft'):
         abort(404)
-    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    agreements_bucket = s3.S3(
+        current_app.config['DM_AGREEMENTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     countersigned_agreement_document = agreements_bucket.get_key(supplier_framework.get('countersignedPath'))
 
     remove_countersigned_agreement_confirm = convert_to_boolean(request.args.get('remove_countersigned_agreement'))
@@ -545,7 +551,9 @@ def upload_countersigned_agreement_file(supplier_id, framework_slug):
     if not supplier_framework['onFramework'] or supplier_framework['agreementStatus'] in (None, 'draft'):
         abort(404)
     agreement_id = supplier_framework['agreementId']
-    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    agreements_bucket = s3.S3(
+        current_app.config['DM_AGREEMENTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     errors = {}
 
     if request.files.get('countersigned_agreement'):
@@ -601,7 +609,9 @@ def upload_countersigned_agreement_file(supplier_id, framework_slug):
 def remove_countersigned_agreement_file(supplier_id, framework_slug):
     supplier_framework = data_api_client.get_supplier_framework_info(supplier_id, framework_slug)['frameworkInterest']
     document = supplier_framework.get('countersignedPath')
-    agreements_bucket = s3.S3(current_app.config['DM_AGREEMENTS_BUCKET'])
+    agreements_bucket = s3.S3(
+        current_app.config['DM_AGREEMENTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
 
     if request.method == 'GET':
         return redirect(url_for(

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -62,7 +62,9 @@ def user_list_page_for_framework(framework_slug):
 @main.route('/frameworks/<framework_slug>/users/<report_type>/download', methods=['GET'])
 @role_required('admin-framework-manager', 'admin-ccs-category', 'admin-ccs-data-controller')
 def download_supplier_user_list_report(framework_slug, report_type):
-    reports_bucket = s3.S3(current_app.config['DM_REPORTS_BUCKET'])
+    reports_bucket = s3.S3(
+        current_app.config['DM_REPORTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
 
     if report_type == 'official':
         path = f"{framework_slug}/reports/official-details-for-suppliers-{framework_slug}.csv"
@@ -107,7 +109,9 @@ def supplier_user_research_participants_by_framework():
 @role_required('admin-framework-manager')
 def download_supplier_user_research_report(framework_slug):
 
-    reports_bucket = s3.S3(current_app.config['DM_REPORTS_BUCKET'])
+    reports_bucket = s3.S3(
+        current_app.config['DM_REPORTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
+    )
     path = "{framework_slug}/reports/user-research-suppliers-on-{framework_slug}.csv"
     url = get_signed_url(
         reports_bucket, path.format(framework_slug=framework_slug), current_app.config['DM_ASSETS_URL']

--- a/config.py
+++ b/config.py
@@ -106,7 +106,7 @@ class Development(Config):
     AUTHENTICATION = True
 
     DM_S3_ENDPOINT_URL = (  # use envars to set this, defaults to using AWS
-        f"http://localhost:{os.environ['DM_S3_ENDPOINT_PORT']}"
+        f"http://s3.localhost.localstack.cloud:{os.environ['DM_S3_ENDPOINT_PORT']}"
         if os.getenv("DM_S3_ENDPOINT_PORT") else None
     )
 
@@ -115,7 +115,8 @@ class Development(Config):
     DM_S3_DOCUMENT_BUCKET = "digitalmarketplace-dev-uploads"
     DM_REPORTS_BUCKET = "digitalmarketplace-dev-uploads"
     DM_ASSETS_URL = (
-        DM_S3_ENDPOINT_URL if DM_S3_ENDPOINT_URL else
+        f"http://{DM_S3_DOCUMENT_BUCKET}.s3.localhost.localstack.cloud:{os.environ['DM_S3_ENDPOINT_PORT']}"
+        if os.getenv("DM_S3_ENDPOINT_PORT") else
         f"https://{DM_S3_DOCUMENT_BUCKET}.s3-eu-west-1.amazonaws.com"
     )
 

--- a/tests/app/main/views/test_communications.py
+++ b/tests/app/main/views/test_communications.py
@@ -65,7 +65,7 @@ class TestManageCommunicationsView(_BaseTestCommunicationsView):
             mock.call.get_framework(self.framework_slug)
         ]
         assert self.s3.mock_calls == [
-            mock.call("flop-slop-slap"),
+            mock.call("flop-slop-slap", endpoint_url=None),
             mock.call().list('g-things-23/communications/updates/communications', load_timestamps=True),
             mock.call().list('g-things-23/communications/updates/clarifications', load_timestamps=True),
         ]
@@ -181,7 +181,7 @@ class TestManageCommunicationsView(_BaseTestCommunicationsView):
             mock.call.get_framework(self.framework_slug)
         ]
         assert self.s3.mock_calls == [
-            mock.call("flop-slop-slap"),
+            mock.call("flop-slop-slap", endpoint_url=None),
             mock.call().list('g-things-23/communications/updates/communications', load_timestamps=True),
             mock.call().list('g-things-23/communications/updates/clarifications', load_timestamps=True),
         ]
@@ -199,7 +199,7 @@ class TestUploadCommunicationsView(_BaseTestCommunicationsView):
 
         # check that we did actually mock-send two files
         assert self.s3.mock_calls == [
-            mock.call('flop-slop-slap'),
+            mock.call('flop-slop-slap', endpoint_url=None),
             mock.call().save(
                 f'{self.framework_slug}/communications/updates/communications/test-comm.pdf',
                 RestrictedAny(lambda other: other.filename == "test-comm.pdf"),
@@ -261,7 +261,7 @@ class TestUploadCommunicationsView(_BaseTestCommunicationsView):
         ) == f"http://localhost/admin/communications/{self.framework_slug}"
 
         # nothing was uploaded
-        assert self.s3.mock_calls == [mock.call('flop-slop-slap')]
+        assert self.s3.mock_calls == [mock.call('flop-slop-slap', endpoint_url=None)]
 
 
 class TestDownloadCommunicationsView(_BaseTestCommunicationsView):
@@ -291,7 +291,7 @@ class TestDownloadCommunicationsView(_BaseTestCommunicationsView):
         assert response.location == "https://basket.market.net/green/goldenly/lagoons.pdf"
 
         assert self.s3.mock_calls == [
-            mock.call('flop-slop-slap'),
+            mock.call('flop-slop-slap', endpoint_url=None),
             mock.call().get_signed_url(
                 f'{self.framework_slug}/communications/updates/{comm_type}s/floating/foampool.pdf'
             ),
@@ -323,7 +323,7 @@ class TestDownloadCommunicationsView(_BaseTestCommunicationsView):
         assert response.status_code == 404
 
         assert self.s3.mock_calls == [
-            mock.call('flop-slop-slap'),
+            mock.call('flop-slop-slap', endpoint_url=None),
             mock.call().get_signed_url(
                 f'{self.framework_slug}/communications/updates/{comm_type}s/floating/foampool.pdf'
             ),
@@ -478,7 +478,7 @@ class TestDeleteCommunicationsPost(_BaseTestCommunicationsView):
         ]
 
         assert self.s3.mock_calls == [
-            mock.call('flop-slop-slap'),
+            mock.call('flop-slop-slap', endpoint_url=None),
             mock.call().path_exists(
                 f'{self.framework_slug}/communications/updates/{comm_type}s/{file_path}'
             ),
@@ -504,7 +504,7 @@ class TestDeleteCommunicationsPost(_BaseTestCommunicationsView):
         ]
 
         assert self.s3.mock_calls == [
-            mock.call('flop-slop-slap'),
+            mock.call('flop-slop-slap', endpoint_url=None),
             mock.call().path_exists(f'{self.framework_slug}/communications/updates/{comm_type}s/floating/foampool.pdf'),
             # no deletion call
         ]


### PR DESCRIPTION
Trello: https://trello.com/c/XoWXM8lC/85-run-dmrunner-without-credentials

This matches what we use for the real S3 - the old way of doing it in the path is deprecated.

By using localstack S3 subdomains, we now get file upload working correctly. This is because we no longer lose the bucket name when we add the document path, which was the previous behaviour.

This affects supplier-frontend only when run locally in developer mode. It depends on having a recent version of localstack - see alphagov/digitalmarketplace-runner#194. This change means that the functional tests tagged as '@file-upload' now succeed when run locally.

Copied from alphagov/digitalmarketplace-supplier-frontend#1409