### PR TITLE
remove coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Digital Marketplace Admin Frontend
 
-[![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-admin-frontend/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-admin-frontend?branch=master)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 Frontend application for the Digital Marketplace.


### PR DESCRIPTION
We are no longer using this since switching to Github Actions