### PR TITLE
Show last two expired G-Cloud frameworks

### DIFF
--- a/app/main/helpers/service.py
+++ b/app/main/helpers/service.py
@@ -2,6 +2,29 @@ import datetime
 import re
 
 
+def filter_relevant_frameworks(frameworks):
+    """
+    Show admins only the frameworks that they're likely to be interested in.
+
+    Include all live frameworks. Include all expired DOS frameworks, but only the last 2 expired G-Cloud frameworks.
+    """
+    frameworks.sort(key=lambda x: x['id'], reverse=True)
+
+    expired_gcloud_frameworks = 0
+
+    for framework in frameworks:
+        if framework['status'] == 'coming':
+            continue
+
+        if framework["family"] == 'digital-outcomes-and-specialists':
+            yield framework
+        elif framework['status'] != 'expired':
+            yield framework
+        elif framework['status'] == 'expired' and expired_gcloud_frameworks < 2:
+            expired_gcloud_frameworks += 1
+            yield framework
+
+
 def parse_document_upload_time(data):
     match = re.search(r"(\d{4}-\d{2}-\d{2}-\d{2}\d{2})\..{2,3}$", data)
     if match:

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -15,6 +15,7 @@ from .. import main
 from ..auth import role_required
 from ..helpers.diff_tools import html_diff_tables_from_sections_iter
 from ..helpers.frameworks import get_framework_or_404
+from ..helpers.service import filter_relevant_frameworks
 from ... import content_loader
 from ... import data_api_client
 
@@ -40,14 +41,7 @@ ALL_ADMIN_ROLES = [
 @role_required(*ALL_ADMIN_ROLES)
 def index():
     frameworks = data_api_client.find_frameworks()['frameworks']
-    # TODO replace this temporary fix for DOS2 when a better solution has been created.
-    frameworks = [
-        fw for fw in frameworks if not (fw['status'] == 'coming' or (
-            fw['status'] == 'expired' and fw["family"] != 'digital-outcomes-and-specialists'
-        ))
-    ]
-    frameworks = sorted(frameworks, key=lambda x: x['id'], reverse=True)
-    return render_template("index.html", frameworks=frameworks)
+    return render_template("index.html", frameworks=filter_relevant_frameworks(frameworks))
 
 
 @main.route('/services', methods=['GET'])


### PR DESCRIPTION
https://trello.com/c/wTPrDiEp/1565-admin-framework-manager-bug

Admins still need to handle requests for old G-Cloud frameworks. Make this easier for them by including links for the last two expired G-Cloud frameworks on the homepage.

There was [a deliberate decision to exclude old G-Cloud frameworks made in 2017](https://trello.com/c/wxCSXbeH/159-update-homepage-group-framework-tasks-by-framework-and-add-headings). However, I can find nothing that says why the change was made. So I think we're probably safe enough to reverse that decision.

With this change, the homepage now looks like:

![image](https://user-images.githubusercontent.com/15256121/115437237-d8c01280-a203-11eb-88f2-06565104cf5b.png)
