### PR TITLE
Ignore GOV.UK Frontend v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
+    ignored_updates:
+    - match:
+        dependency_name: "govuk-frontend"
+        version_requirement: "3.x"
+    - match:
+        dependency_name: "digitalmarketplace-govuk-frontend"
+        version_requirement: "3.x"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
This app has not yet been upgraded to GOV.UK Frontend 3.