### PR TITLE
Fix indentation in Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
-    ignored_updates:
+  ignored_updates:
     - match:
         dependency_name: "govuk-frontend"
         version_requirement: "3.x"


### PR DESCRIPTION
I made a mistake in https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/743: 

`The property '#/updates/1/schedule' contains additional properties ["ignored_updates"] outside of the schema when none are allowed`