### PR TITLE
Use v2 syntax for dependency ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,11 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
-  ignored_updates:
-    - match:
-        dependency_name: "govuk-frontend"
-        version_requirement: "3.x"
-    - match:
-        dependency_name: "digitalmarketplace-govuk-frontend"
-        version_requirement: "3.x"
+  ignore:
+  - dependency-name: "govuk-frontend"
+    versions: "3.x"
+  - dependency-name: "digitalmarketplace-govuk-frontend"
+    versions: "3.x"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
I was using v1 syntax, which was why Dependabot didn't like it, since the file uses v2 syntax.

I've now checked the updated version using the validator (https://dependabot.com/docs/config-file/validator/), so I am more confident this is finally correct.

Ignore docs: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#ignore