### PR TITLE
test admin page title

### DIFF
--- a/tests/app/main/views/test_search.py
+++ b/tests/app/main/views/test_search.py
@@ -19,9 +19,11 @@ class TestSearchSuppliersAndServices(LoggedInApplicationTest):
         document = html.fromstring(page_html)
         header = document.xpath(
             '///h1/text()')[0].strip()
+        title = document.xpath('//title/text()')[0].strip()
 
         assert response.status_code == 200
         assert header == expected_header
+        assert title.startswith(expected_header)
 
     @pytest.mark.parametrize("role,expected_code", [
         ("admin", 200),


### PR DESCRIPTION
https://trello.com/c/asIcsC2D/967-3-convert-all-tests-that-test-admin-frontend-user-permissions-into-unit-tests

this is to acheive parity with the feature test in https://github.com/alphagov/digitalmarketplace-functional-tests/blob/d86d6bac41947c32ab4cb8c70afd3133c37f5f35/features/admin/company_details.feature#L22 so this can be subsequently safely deleted