### PR TITLE
add permission check for button availability on GET route

### DIFF
--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1543,7 +1543,7 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
         get_response = self.client.get('/admin/suppliers/users?supplier_id=1234')
         document = html.fromstring(get_response.get_data(as_text=True))
         send_invitation_button = document.xpath('.//button[contains(text(), "Send invitation")]')
-        assert len(send_invitation_button) == (1 if see_invite_button else 0)
+        assert bool(send_invitation_button) is see_invite_button
 
         response = self.client.post(
             '/admin/suppliers/1234/invite-user',

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -1528,17 +1528,22 @@ class TestSupplierInviteUserView(LoggedInApplicationTest):
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
-    @pytest.mark.parametrize("role, expected_code", [
-        ("admin", 302),
-        ("admin-ccs-category", 302),
-        ("admin-ccs-sourcing", 403),
-        ("admin-ccs-data-controller", 403),
-        ("admin-framework-manager", 403),
-        ("admin-manager", 403),
+    @pytest.mark.parametrize("role, expected_code, see_invite_button", [
+        ("admin", 302, True),
+        ("admin-ccs-category", 302, True),
+        ("admin-ccs-sourcing", 403, False),
+        ("admin-ccs-data-controller", 403, False),
+        ("admin-framework-manager", 403, False),
+        ("admin-manager", 403, False),
     ])
     @mock.patch('app.main.views.suppliers.send_user_account_email')
-    def test_correct_roles_can_invite_user(self, send_user_account_email, role, expected_code):
+    def test_correct_roles_can_invite_user(self, _send_user_account_email, role, expected_code, see_invite_button):
         self.user_role = role
+
+        get_response = self.client.get('/admin/suppliers/users?supplier_id=1234')
+        document = html.fromstring(get_response.get_data(as_text=True))
+        send_invitation_button = document.xpath('.//button[contains(text(), "Send invitation")]')
+        assert len(send_invitation_button) == (1 if see_invite_button else 0)
 
         response = self.client.post(
             '/admin/suppliers/1234/invite-user',


### PR DESCRIPTION
https://trello.com/c/asIcsC2D/584-3-convert-all-tests-that-test-admin-frontend-user-permissions-into-unit-tests

Previously we checked the POST but did not check the form visibility on the GET

This replicates the feature test in: https://github.com/alphagov/digitalmarketplace-functional-tests/blob/b8fa5302f8ac8de6c0b53e76965c8626b085989b/features/admin/invite_supplier_contributor.feature#L35