### PR TITLE
re-write modern slavery urls to go to public assets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ digitalmarketplace-apiclient==22.0.0
     # via -r requirements.in
 digitalmarketplace-content-loader==8.1.0
     # via -r requirements.in
-digitalmarketplace-utils==59.0.0
+digitalmarketplace-utils==59.1.0
     # via
     #   -r requirements.in
     #   digitalmarketplace-content-loader


### PR DESCRIPTION
https://trello.com/c/5E22SHaQ/988-ccs-sourcing-admins-cant-view-suppliers-modern-slavery-statements

previously these were going through an authenticated route on supplier-frontend causing them to fail on admin-frontend
See also description in https://github.com/alphagov/digitalmarketplace-utils/pull/659