### PR TITLE
Show page with status of all frameworks

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,3 +1,4 @@
+import os
 from collections import OrderedDict
 from itertools import chain, dropwhile, islice
 
@@ -47,6 +48,21 @@ def index():
     ]
     frameworks = sorted(frameworks, key=lambda x: x['id'], reverse=True)
     return render_template("index.html", frameworks=frameworks)
+
+
+@main.route('/frameworks', methods=['GET'])
+@role_required(*ALL_ADMIN_ROLES)
+def view_frameworks():
+    if os.getenv("DM_ENVIRONMENT") == 'production':
+        abort(404)  # This endpoint isn't safe in production.
+
+    frameworks = data_api_client.find_frameworks()['frameworks']
+    frameworks.sort(key=lambda x: (x['family'], x['id']), reverse=True)
+
+    return render_template(
+        "view_frameworks.html",
+        frameworks=frameworks,
+    )
 
 
 @main.route('/services', methods=['GET'])

--- a/app/templates/view_frameworks.html
+++ b/app/templates/view_frameworks.html
@@ -1,0 +1,40 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% block pageTitle %}
+  View frameworks - Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumbs %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": "View frameworks"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <h1 class="govuk-heading-xl">Frameworks</h1>
+
+  {% call(framework) summary.list_table(
+    frameworks,
+    caption="Frameworks",
+    empty_message="No frameworks to show",
+    field_headings=[
+        'Name',
+        'Status',
+    ],
+    field_headings_visible=True)
+  %}
+    {% call summary.row() %}
+      {{ summary.text(framework.name) }}
+      {{ summary.text(framework.status) }}
+    {% endcall %}
+  {% endcall %}
+{% endblock %}

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from io import BytesIO
 from itertools import chain
@@ -14,6 +15,26 @@ from lxml import html
 from dmtestutils.fixtures import valid_pdf_bytes
 
 from ...helpers import LoggedInApplicationTest
+
+
+class TestViewFrameworks(LoggedInApplicationTest):
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.services.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
+    @mock.patch.dict(os.environ, {"DM_ENVIRONMENT": "production"})
+    def test_hidden_in_production(self):
+        response = self.client.get('/admin/frameworks')
+        assert response.status_code == 404
+
+    def test_visible_in_non_production_environments(self):
+        response = self.client.get('/admin/frameworks')
+        assert response.status_code == 200
 
 
 class TestServiceFind(LoggedInApplicationTest):


### PR DESCRIPTION
https://trello.com/c/DXsXHeZo/96-let-admins-change-the-non-prod-framework-state

This is the first part of a firebreak project to give admins in non-prod environments the ability to view and change framework states. admin-frontend doens't use the design system yet, so I have to use the toolkit instead.

Since this is a firebreak experiment, I'm hiding this in production.

![image](https://user-images.githubusercontent.com/15256121/124626907-ff8efc00-de76-11eb-8e2e-8ae6949ffa04.png)
