### PR TITLE
Add form to change framework status

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -267,3 +267,17 @@ class EditSupplierCompanyRegistrationNumberForm(FlaskForm):
             valid = False
 
         return valid
+
+
+class EditFrameworkStatusForm(FlaskForm):
+
+    status = DMRadioField(
+        "Framework status",
+        validators=[
+            validators.InputRequired(message='You must choose a framework status')
+        ],
+        options=[
+            {"value": status, "label": status.capitalize()}
+            for status in ('coming', 'open', 'pending', 'standstill', 'live', 'expired')
+        ],
+    )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -77,6 +77,9 @@ def change_framework_status(framework_slug):
     if not framework:
         abort(404, "Framework not found")
 
+    if request.method == "POST":
+        return redirect(url_for('.view_frameworks'))
+
     form = EditFrameworkStatusForm()
     form.status.data = framework['status']
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -14,6 +14,7 @@ from flask_login import current_user
 
 from .. import main
 from ..auth import role_required
+from ..forms import EditFrameworkStatusForm
 from ..helpers.diff_tools import html_diff_tables_from_sections_iter
 from ..helpers.frameworks import get_framework_or_404
 from ... import content_loader
@@ -62,6 +63,27 @@ def view_frameworks():
     return render_template(
         "view_frameworks.html",
         frameworks=frameworks,
+    )
+
+
+@main.route('/frameworks/<framework_slug>/status', methods=['GET', 'POST'])
+@role_required(*ALL_ADMIN_ROLES)
+def change_framework_status(framework_slug):
+    if os.getenv("DM_ENVIRONMENT") == 'production':
+        abort(404)  # This endpoint isn't safe in production.
+
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+
+    if not framework:
+        abort(404, "Framework not found")
+
+    form = EditFrameworkStatusForm()
+    form.status.data = framework['status']
+
+    return render_template(
+        "change_framework_status.html",
+        form=form,
+        framework=framework,
     )
 
 

--- a/app/templates/change_framework_status.html
+++ b/app/templates/change_framework_status.html
@@ -34,7 +34,7 @@
         {{ form.status }}
         {% block save_button %}
           {{ govukButton({
-            "text": "Save"
+            "text": "Save and return"
           }) }}
         {% endblock %}
       </form>

--- a/app/templates/change_framework_status.html
+++ b/app/templates/change_framework_status.html
@@ -1,0 +1,43 @@
+{% extends "_base_page.html" %}
+{% import "toolkit/summary-table.html" as summary %}
+
+{% set page_title = 'Change ' + framework['name'] + ' status' %}
+{% block pageTitle %}
+  {{ page_title }} – Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumbs %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index'),
+      },
+      {
+        "text": "View frameworks",
+        "href": url_for('.view_frameworks'),
+      },
+      {
+        "text": page_title,
+      },
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ page_title }}</h1>
+
+      <form method="POST" action="{{ url_for('.change_framework_status', framework_slug=framework['slug']) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {{ form.status }}
+        {% block save_button %}
+          {{ govukButton({
+            "text": "Save"
+          }) }}
+        {% endblock %}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/view_frameworks.html
+++ b/app/templates/view_frameworks.html
@@ -29,12 +29,14 @@
     field_headings=[
         'Name',
         'Status',
+        summary.hidden_field_heading("Change status"),
     ],
     field_headings_visible=True)
   %}
     {% call summary.row() %}
       {{ summary.text(framework.name) }}
       {{ summary.text(framework.status) }}
+      {{ summary.edit_link(label="Change", link=url_for(".change_framework_status", framework_slug=framework.slug), hidden_text=framework.name) }}
     {% endcall %}
   {% endcall %}
 {% endblock %}


### PR DESCRIPTION
This is the second part of a firebreak project to give admins in non-prod environments the ability to view and change the framework state. Follows on from https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/767.

Create the form that admins will use to change the state. Wire it up so that it shows the current state. The form doesn't yet do anything on POST other than redirect back to the previous page.

Admin frontend has not been modernised, so I'm following the existing patterns for radios in this app.

Since this is a firebreak experiment, I'm hiding this in production.

![image](https://user-images.githubusercontent.com/15256121/124753093-7e8c3f00-df20-11eb-831f-4154e1609653.png)

![image](https://user-images.githubusercontent.com/15256121/124753155-8f3cb500-df20-11eb-8d37-860b8fa32d45.png)
