### PR TITLE
Let non-prod admins change framework statuses

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -273,6 +273,7 @@ class EditFrameworkStatusForm(FlaskForm):
 
     status = DMRadioField(
         "Framework status",
+        hint="Tell the rest of the team before making a change",
         validators=[
             validators.InputRequired(message='You must choose a framework status')
         ],

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -77,11 +77,16 @@ def change_framework_status(framework_slug):
     if not framework:
         abort(404, "Framework not found")
 
-    if request.method == "POST":
-        return redirect(url_for('.view_frameworks'))
-
     form = EditFrameworkStatusForm()
-    form.status.data = framework['status']
+
+    if request.method == "POST":
+        status = form.data.get('status')
+
+        data_api_client.update_framework(framework_slug, {"status": status}, user=current_user.email_address)
+
+        return redirect(url_for('.view_frameworks'))
+    else:
+        form.status.data = framework['status']
 
     return render_template(
         "change_framework_status.html",

--- a/tests/app/main/views/test_services.py
+++ b/tests/app/main/views/test_services.py
@@ -73,6 +73,16 @@ class TestChangeFrameworkStatus(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
         assert document.xpath('//input[@value="live"][@checked="checked"]')
 
+    def test_changes_status(self):
+        self.data_api_client.get_framework.return_value = {'frameworks': {'slug': 'foo', 'status': 'live'}}
+
+        response = self.client.post('/admin/frameworks/foo/status', data={"status": "expired"})
+
+        assert response.status_code == 302
+        assert self.data_api_client.update_framework.call_args_list == [
+            mock.call('foo', {'status': 'expired'}, user='test@example.com')
+        ]
+
 
 class TestServiceFind(LoggedInApplicationTest):
 


### PR DESCRIPTION
https://trello.com/c/DXsXHeZo/96-let-admins-change-the-non-prod-framework-state

This is the third part of a firebreak project to give admins in non-prod environments the ability to view and change the framework state. It follows on from https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/768.

Update the 'change framework status' page to actually change the framework status. The full user journey now works.

I've tested that this works locally. This page is hidden in production, so should be low-risk if broken.

Note that this doesn't handle clarification questions - that's for future work.