### PR TITLE
Use govukTable for viewing users

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,10 +1,11 @@
 {% extends "govuk/template.njk" %}
 
-{# Import GOV.UK Frontend components for globale usage#}
+{# Import GOV.UK Frontend components for global usage #}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {# Import DM Components #}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -3,6 +3,7 @@
 {# Import GOV.UK Frontend components for global usage #}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -88,7 +88,7 @@
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
               {{ govukButton({
-                "classes": "govuk-button--warning",
+                "classes": "govuk-button--warning govuk-!-margin-bottom-0",
                 "text": "Deactivate"
               }) }}
             </form>
@@ -101,7 +101,7 @@
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
               {{ govukButton({
-                "classes": "govuk-button--secondary",
+                "classes": "govuk-button--secondary govuk-!-margin-bottom-0",
                 "text": "Activate"
               }) }}
             </form>

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -1,5 +1,3 @@
-{% import "toolkit/summary-table.html" as summary %}
-
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
@@ -38,54 +36,36 @@
 
   </form>
 
-  {% call(item) summary.list_table(
-    users,
-    caption="Users",
-    empty_message="No users to show",
-    field_headings=[
-        'Name',
-        'Role',
-        'Supplier',
-        'Last login',
-        'Last password change',
-        'Locked',
-        summary.hidden_field_heading("Change status")
-    ],
-    field_headings_visible=True)
-  %}
-    {% call summary.row() %}
-
-      {{ summary.field_name(item.name) }}
-
-      {{ summary.text(item.role) }}
-
-      {% call summary.field() %}
-        {% if item.role == 'supplier' %}
-          <a class="govuk-link" href="{{ url_for('.find_suppliers', supplier_id=item.supplier.supplierId) }}">{{ item.supplier.name }}</a>
+  {% if users %}
+    {% set ns = namespace(rows = []) %}
+    {% for user in users %}
+      {% set supplier %}
+        {% if user.role == 'supplier' %}
+          <a class="govuk-link" href="{{ url_for('.find_suppliers', supplier_id=user.supplier.supplierId) }}">{{ user.supplier.name }}</a>
         {% endif %}
-      {% endcall %}
+      {% endset %}
 
-      {% call summary.field() %}
-        {% if item.loggedInAt %}
-          {{ item.loggedInAt|timeformat }}<br/>
-          {{ item.loggedInAt|dateformat }}
+      {% set logged_in_at %}
+        {% if user.loggedInAt %}
+          {{ user.loggedInAt|timeformat }}<br/>
+          {{ user.loggedInAt|dateformat }}
         {% else %}
           Never
         {% endif %}
-      {% endcall %}
+      {% endset %}
 
-      {% call summary.field() %}
-        {% if item.passwordChangedAt %}
-          {{ item.passwordChangedAt|timeformat }}<br/>
-          {{ item.passwordChangedAt|dateformat }}
+      {% set password_changed_at %}
+        {% if user.passwordChangedAt %}
+          {{ user.passwordChangedAt|timeformat }}<br/>
+          {{ user.passwordChangedAt|dateformat }}
         {% else %}
           Never
         {% endif %}
-      {% endcall %}
+      {% endset %}
 
-      {% call summary.field() %}
-        {% if item.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
-          <form action="{{ url_for('.unlock_user', user_id=item.id) }}" method="post">
+      {% set locked %}
+        {% if user.locked and current_user.has_any_role('admin', 'admin-ccs-category') and not user.personalDataRemoved %}
+          <form action="{{ url_for('.unlock_user', user_id=user.id) }}" method="post">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
             {{ govukButton({
@@ -93,17 +73,17 @@
               "text": "Unlock"
             }) }}
           </form>
-        {% elif item.locked %}
+        {% elif user.locked %}
           Yes
         {% else %}
           No
         {% endif %}
-      {% endcall %}
+      {% endset %}
 
-      {% call summary.field() %}
-        {% if item.active %}
+      {% set change_status %}
+        {% if user.active %}
           {% if current_user.has_any_role('admin', 'admin-ccs-category') %}
-            <form action="{{ url_for('.deactivate_user', user_id=item.id) }}" method="post">
+            <form action="{{ url_for('.deactivate_user', user_id=user.id) }}" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
               {{ govukButton({
@@ -115,8 +95,8 @@
             Active
           {% endif %}
         {% else %}
-          {% if current_user.has_any_role('admin', 'admin-ccs-category') and not item.personalDataRemoved %}
-            <form action="{{ url_for('.activate_user', user_id=item.id) }}" method="post">
+          {% if current_user.has_any_role('admin', 'admin-ccs-category') and not user.personalDataRemoved %}
+            <form action="{{ url_for('.activate_user', user_id=user.id) }}" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <input type="hidden" name="source" value="{{ url_for('.find_user_by_email_address', email_address=email_address) }}"/>
               {{ govukButton({
@@ -128,8 +108,35 @@
             Deactivated
           {% endif %}
         {% endif %}
-      {% endcall %}
+      {% endset %}
 
-    {% endcall %}
-  {% endcall %}
+      {% set row = ns.rows.append(
+        [
+          {"text": user.name},
+          {"text": user.role},
+          {"html": supplier},
+          {"html": logged_in_at},
+          {"html": password_changed_at},
+          {"html": locked},
+          {"html": change_status},
+        ]
+      ) %}
+    {% endfor %}
+
+    {{ govukTable({
+      'head': [
+        {'text': 'Name'},
+        {'text': 'Role'},
+        {'text': 'Supplier'},
+        {'text': 'Last login'},
+        {'text': 'Last password change'},
+        {'text': 'Locked'},
+        {'text': 'Change status'},
+      ],
+      'rows': ns.rows,
+      "classes": "dm-table govuk-!-margin-bottom-6",
+    }) }}
+  {% else %}
+    <p class="govuk-body">No users to show</p>
+  {% endif %}
 {% endblock %}

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -135,7 +135,6 @@
         {'text': 'Change status'},
       ],
       'rows': ns.rows,
-      "classes": "dm-table govuk-!-margin-bottom-6",
     }) }}
   {% else %}
     <p class="govuk-body">No users to show</p>

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -21,14 +21,15 @@
 {% block mainContent %}
   <h1 class="govuk-heading-xl">Find a user</h1>
 
-  <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question">
-    {%
-      with
-      question = "Find a user by email",
-      name = "email_address"
-    %}
-      {% include "toolkit/forms/textbox.html" %}
-    {% endwith %}
+  <form action="{{ url_for('.find_user_by_email_address') }}" method="get" class="question" novalidate>
+    {{ govukInput({
+      "label": {
+        "text": "Find a user by email",
+        "classes": "govuk-label--m",
+      },
+      "id": "input-email_address",
+      "name": "email_address",
+    })}}
 
     {{ govukButton({
       "text": "Search"

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -57,7 +57,7 @@ class TestUsersView(LoggedInApplicationTest):
         assert len(document.cssselect(f'.banner-message:contains("{flash_message}")')) == 1
 
         summary_result = "No users to show"
-        assert len(document.cssselect(f'.summary-item-no-content:contains("{summary_result}")')) == 1
+        assert len(document.cssselect(f'.govuk-body:contains("{summary_result}")')) == 1
 
     def test_should_be_a_404_if_no_email_provided(self):
         self.data_api_client.get_user.return_value = None
@@ -69,9 +69,8 @@ class TestUsersView(LoggedInApplicationTest):
         flash_message = "Sorry, we couldn't find an account with that email address"
         assert len(document.cssselect(f'.banner-message:contains("{flash_message}")')) == 1
 
-        page_title = document.xpath(
-            '//p[@class="summary-item-no-content"]//text()')[0].strip()
-        assert page_title == "No users to show"
+        summary_result = "No users to show"
+        assert len(document.cssselect(f'.govuk-body:contains("{summary_result}")')) == 1
 
     def test_should_show_buyer_user(self):
         buyer = self.load_example_listing("user_response")
@@ -84,35 +83,35 @@ class TestUsersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         name = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[0].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[0].strip()
         assert name == "Test User"
 
         role = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[1].strip()
         assert role == "buyer"
 
         supplier = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[2].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[2].strip()
         assert supplier == ''
 
         last_login = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[3].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[3].strip()
         assert last_login == '09:33:53'
 
         last_login_day = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[4].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[4].strip()
         assert last_login_day == 'Thursday 23 July 2015'
 
         last_password_changed = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[5].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[5].strip()
         assert last_password_changed == '12:46:01'
 
         last_password_changed_day = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[6].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[6].strip()
         assert last_password_changed_day == 'Monday 29 June 2015'
 
         locked = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[7].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[7].strip()
         assert locked == 'No'
 
         button = document.xpath(
@@ -126,15 +125,15 @@ class TestUsersView(LoggedInApplicationTest):
         document = html.fromstring(response.get_data(as_text=True))
 
         role = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/text()')[1].strip()
+            '//tr[@class="govuk-table__row"]//td/text()')[1].strip()
         assert role == "supplier"
 
         supplier = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/a/text()')[0].strip()
+            '//tr[@class="govuk-table__row"]//td/a/text()')[0].strip()
         assert supplier == 'SME Corp UK Limited'
 
         supplier_link = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/a')[0]
+            '//tr[@class="govuk-table__row"]//td/a')[0]
         assert supplier_link.attrib['href'] == '/admin/suppliers?supplier_id=1000'
 
     def test_should_show_unlock_button(self):
@@ -150,9 +149,9 @@ class TestUsersView(LoggedInApplicationTest):
         unlock_button = document.xpath(
             '//button[contains(@class, "govuk-button--secondary")]')[0].text.strip()
         unlock_link = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/form')[0]
+            '//tr[@class="govuk-table__row"]//td/form')[0]
         return_link = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/form/input')[1]
+            '//tr[@class="govuk-table__row"]//td/form/input')[1]
         assert unlock_link.attrib['action'] == '/admin/suppliers/users/999/unlock'
         assert unlock_button == 'Unlock'
         assert return_link.attrib['value'] == '/admin/users?email_address=test.user%40sme.com'
@@ -176,9 +175,9 @@ class TestUsersView(LoggedInApplicationTest):
         deactivate_button = document.xpath(
             '//button[contains(@class, "govuk-button--warning")]')[0].text.strip()
         deactivate_link = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/form')[0]
+            '//tr[@class="govuk-table__row"]//td/form')[0]
         return_link = document.xpath(
-            '//tr[@class="summary-item-row"]//td/span/form/input')[1]
+            '//tr[@class="govuk-table__row"]//td/form/input')[1]
         assert deactivate_link.attrib['action'] == '/admin/suppliers/users/999/deactivate'
         assert deactivate_button == 'Deactivate'
         assert return_link.attrib['value'] == '/admin/users?email_address=test.user%40sme.com'


### PR DESCRIPTION
We were previously using toolkit/summary-table.html. We want to replace all uses of the toolkit with design system components. This is part of our migration to Design System 3 to improve accessibility. Admin-frontend is not a priority app, but I was working in the area for my firebreak project, so did this in passing.

No obvious changes in behaviour - just minor formattting differences.

Old:

![image](https://user-images.githubusercontent.com/15256121/125101382-11201000-e0d2-11eb-8de5-b381fff45afb.png)


New:

![image](https://user-images.githubusercontent.com/15256121/125101255-ee8df700-e0d1-11eb-9070-12507a760cfa.png)
