### PR TITLE
Let admins change user's names themselves

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -289,3 +289,17 @@ class EditFrameworkStatusForm(FlaskForm):
             {"value": value, "text": label, "checked": checked}
             for value, label, checked in self.status.iter_choices()
         ]
+
+
+class EditUserNameForm(FlaskForm):
+    """
+    This is a copy of the `name` form in `CreateUserForm` in user-frontend.
+    """
+    name = DMStripWhitespaceStringField('User name', validators=[
+        DataRequired(message="Enter the user's name"),
+        Length(
+            min=1,
+            max=255,
+            message="The user's name must be between 1 and 255 characters"
+        )
+    ])

--- a/app/templates/change_user_name.html
+++ b/app/templates/change_user_name.html
@@ -1,0 +1,57 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}
+  Change user name – {{ user.name }} – Digital Marketplace admin
+{% endblock %}
+
+{% block breadcrumbs %}
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Admin home",
+        "href": url_for('.index')
+      },
+      {
+        "text": "Change user name"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" action="{{ url_for('.change_user_name', user_id=user.id) }}" novalidate>
+        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+
+        {% set label %}
+          Update user name for ‘{{user.name}}’
+        {% endset %}
+
+        {% set hint %}
+          For the {{user.role}} with email address ‘{{user.emailAddress}}’.
+        {% endset %}
+
+        {{ govukInput({
+          "label": {
+            "text": label,
+            "classes": "govuk-label--xl",
+            "attributes": {"id": form.name.name},
+            "isPageHeading": true
+          },
+          "hint": {
+            "text": hint
+          },
+          "id": "input-" + form.name.name,
+          "name": form.name.name,
+          "errorMessage": errors.name.errorMessage if errors.name.errorMessage,
+          "value": form.name.data if form.name.data
+        })}}
+
+        {{ govukButton({
+          "text": "Save"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/view_buyers.html
+++ b/app/templates/view_buyers.html
@@ -53,7 +53,13 @@
 
       {% call summary.row() %}
 
-        {{ summary.field_name(item.name) }}
+        {% call summary.field() %}
+          {% if current_user.has_any_role('admin') %}
+            <a class="govuk-link" href="{{ url_for('.change_user_name', user_id=item.id) }}">{{ item.name }}</a>
+          {% else %}
+            {{ item.name }}
+          {% endif %}
+        {% endcall %}
 
         {% call summary.field() %}
           {{ item.emailAddress }}

--- a/app/templates/view_supplier_users.html
+++ b/app/templates/view_supplier_users.html
@@ -44,7 +44,13 @@
     %}
       {% call summary.row() %}
 
-        {{ summary.field_name(item.name) }}
+        {% call summary.field() %}
+          {% if current_user.has_any_role('admin') %}
+            <a class="govuk-link" href="{{ url_for('.change_user_name', user_id=item.id) }}">{{ item.name }}</a>
+          {% else %}
+            {{ item.name }}
+          {% endif %}
+        {% endcall %}
 
         {{ summary.text(item.emailAddress) }}
 

--- a/app/templates/view_users.html
+++ b/app/templates/view_users.html
@@ -40,6 +40,15 @@
   {% if users %}
     {% set ns = namespace(rows = []) %}
     {% for user in users %}
+
+      {% set name %}
+        {% if current_user.has_any_role('admin') %}
+          <a class="govuk-link" href="{{ url_for('.change_user_name', user_id=user.id) }}">{{ user.name }}</a>
+        {% else %}
+          {{ user.name }}
+        {% endif %}
+      {% endset %}
+
       {% set supplier %}
         {% if user.role == 'supplier' %}
           <a class="govuk-link" href="{{ url_for('.find_suppliers', supplier_id=user.supplier.supplierId) }}">{{ user.supplier.name }}</a>
@@ -113,7 +122,7 @@
 
       {% set row = ns.rows.append(
         [
-          {"text": user.name},
+          {"html": name},
           {"text": user.role},
           {"html": supplier},
           {"html": logged_in_at},

--- a/tests/app/main/views/test_buyers.py
+++ b/tests/app/main/views/test_buyers.py
@@ -100,9 +100,10 @@ class TestBuyersView(LoggedInApplicationTest):
         response = self.client.get('/admin/buyers?brief_id=1')
 
         document = html.fromstring(response.get_data(as_text=True))
-        name = document.xpath('//td[@class="summary-item-field-first"]//text()')[1].strip()
-        email = document.xpath('//td[@class="summary-item-field"]//text()')[1].strip()
-        phone = document.xpath('//td[@class="summary-item-field"]//text()')[4].strip()
+        [name, email, phone] = [
+            field.xpath("normalize-space(string())")
+            for field in document.xpath('//td[@class="summary-item-field"]/span')
+        ]
 
         assert name == "Test Buyer"
         assert email == "test_buyer@example.com"

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -203,6 +203,52 @@ class TestUsersView(LoggedInApplicationTest):
         assert document.xpath('//button[contains(text(), "Activate")]')
 
 
+class TestChangeUserName(LoggedInApplicationTest):
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.users.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.get_user.return_value = self.load_example_listing("user_response")
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
+    @pytest.mark.parametrize("role,expected_code", [
+        ("admin", 200),
+        ("admin-ccs-category", 403),
+        ("admin-ccs-sourcing", 403),
+        ("admin-manager", 403),
+        ("admin-framework-manager", 403),
+        ("admin-ccs-data-controller", 403),
+    ])
+    def test_page_is_only_accessible_to_specific_user_role(self, role, expected_code):
+        self.user_role = role
+        response = self.client.get('/admin/users/12345/name')
+        actual_code = response.status_code
+        assert actual_code == expected_code, f"Unexpected response {actual_code} for role {role}"
+
+    def test_shows_current_name(self):
+        response = self.client.get('/admin/users/12345/name')
+        document = html.fromstring(response.get_data(as_text=True))
+
+        assert document.xpath('//input[@name="name"][@value="Test User"]')
+
+    def test_changes_name(self):
+        response = self.client.post('/admin/users/12345/name', data={"name": "New name"})
+
+        assert response.status_code == 200
+        assert self.data_api_client.update_user.call_args_list == [
+            mock.call(12345, name='New name', updater='test@example.com')
+        ]
+
+    @pytest.mark.parametrize('name', ["", "a" * 1000])
+    def test_reject_invalid_names(self, name):
+        response = self.client.post('/admin/users/12345/name', data={"name": name})
+
+        assert response.status_code == 400
+
+
 @mock.patch('app.main.views.users.s3')
 class TestUserListPage(LoggedInApplicationTest):
     user_role = 'admin-framework-manager'

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -82,36 +82,16 @@ class TestUsersView(LoggedInApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
 
-        name = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[0].strip()
+        [name, role, supplier, last_login, last_password_changed, locked, _button_text] = [
+            field.xpath("normalize-space(string())")
+            for field in document.xpath('//tr[@class="govuk-table__row"]//td')
+        ]
+
         assert name == "Test User"
-
-        role = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[1].strip()
         assert role == "buyer"
-
-        supplier = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[2].strip()
         assert supplier == ''
-
-        last_login = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[3].strip()
-        assert last_login == '09:33:53'
-
-        last_login_day = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[4].strip()
-        assert last_login_day == 'Thursday 23 July 2015'
-
-        last_password_changed = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[5].strip()
-        assert last_password_changed == '12:46:01'
-
-        last_password_changed_day = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[6].strip()
-        assert last_password_changed_day == 'Monday 29 June 2015'
-
-        locked = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[7].strip()
+        assert last_login == '09:33:53 Thursday 23 July 2015'
+        assert last_password_changed == '12:46:01 Monday 29 June 2015'
         assert locked == 'No'
 
         button = document.xpath(
@@ -124,16 +104,11 @@ class TestUsersView(LoggedInApplicationTest):
 
         document = html.fromstring(response.get_data(as_text=True))
 
-        role = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/text()')[1].strip()
-        assert role == "supplier"
+        role = document.xpath('//tr[@class="govuk-table__row"]//td')[1]
+        assert role.xpath("normalize-space(string())") == "supplier"
 
-        supplier = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/a/text()')[0].strip()
-        assert supplier == 'SME Corp UK Limited'
-
-        supplier_link = document.xpath(
-            '//tr[@class="govuk-table__row"]//td/a')[0]
+        supplier_link = document.xpath('//tr[@class="govuk-table__row"]//td/a')[1]
+        assert supplier_link.xpath("normalize-space(string())") == 'SME Corp UK Limited'
         assert supplier_link.attrib['href'] == '/admin/suppliers?supplier_id=1000'
 
     def test_should_show_unlock_button(self):


### PR DESCRIPTION
We occasionally get requests from users to change their name. CCS support forward these requests on to us. We change the name via the API. We don't actually provide any value - if an admin asks us to change a user's name, we do it.

So it is safe to cut out the developer in the middle and give admins the ability to change user's names themselves. This should save both sides time.

This action is already audited via the API, so we will have a record of any changes admins make.

Once this is merged, we should tell CCS about the change, and also update the manual (https://alphagov.github.io/digitalmarketplace-manual/2nd-line-runbook/support-tasks.html?highlight=admin#changing-a-user-s-name).

Example of the new link:

![image](https://user-images.githubusercontent.com/15256121/125279799-444de380-e30c-11eb-92c4-ec14aba66c52.png)


And the page:

![image](https://user-images.githubusercontent.com/15256121/125279693-25e7e800-e30c-11eb-8817-2b17a583166a.png)


