### PR TITLE
Change framework status radio

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -7,7 +7,7 @@ from dmutils.forms.fields import DMRadioField, DMStripWhitespaceStringField
 
 from flask import current_app
 from flask_wtf import FlaskForm
-from wtforms import validators
+from wtforms import validators, RadioField
 from wtforms.validators import DataRequired, AnyOf, InputRequired, Length, Optional, Regexp, ValidationError
 
 from .. import data_api_client
@@ -271,14 +271,21 @@ class EditSupplierCompanyRegistrationNumberForm(FlaskForm):
 
 class EditFrameworkStatusForm(FlaskForm):
 
-    status = DMRadioField(
-        "Framework status",
-        hint="Tell the rest of the team before making a change",
+    status = RadioField(
+        id="input-status-1",  # TODO: change to input-copy_service when on govuk-frontend~3
+        label="Framework status",
+        description="Tell the rest of the team before making a change",
         validators=[
             validators.InputRequired(message='You must choose a framework status')
         ],
-        options=[
-            {"value": status, "label": status.capitalize()}
+        choices=[
+            (status, status.capitalize())
             for status in ('coming', 'open', 'pending', 'standstill', 'live', 'expired')
         ],
     )
+
+    def items(self):
+        return [
+            {"value": value, "text": label, "checked": checked}
+            for value, label, checked in self.status.iter_choices()
+        ]

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -276,7 +276,7 @@ class EditFrameworkStatusForm(FlaskForm):
         label="Framework status",
         description="Tell the rest of the team before making a change",
         validators=[
-            validators.InputRequired(message='You must choose a framework status')
+            validators.InputRequired(message='Select a framework status')
         ],
         choices=[
             (status, status.capitalize())

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -5,6 +5,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}

--- a/app/templates/change_framework_status.html
+++ b/app/templates/change_framework_status.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% set page_title = 'Change ' + framework['name'] + ' status' %}
 {% block pageTitle %}
@@ -27,11 +26,28 @@
 {% block mainContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">{{ page_title }}</h1>
-
-      <form method="POST" action="{{ url_for('.change_framework_status', framework_slug=framework['slug']) }}">
+      <form method="POST" action="{{ url_for('.change_framework_status', framework_slug=framework['slug']) }}" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        {{ form.status }}
+
+        {{ govukRadios({
+          "idPrefix": "input-" + form.status.name,
+          "name": form.status.name,
+          "hint": {
+            "text": form.status.description,
+          },
+          "items": form.items(),
+          "fieldset": {
+            "legend": {
+              "text": page_title,
+              "classes": "govuk-fieldset__legend--l",
+              "isPageHeading": true,
+            }
+          },
+          "errorMessage": {
+              "text": errors.get(form.status.name, {}).get('message', None)
+            } if errors,
+        }) }}
+        
         {% block save_button %}
           {{ govukButton({
             "text": "Save and return"

--- a/app/templates/view_frameworks.html
+++ b/app/templates/view_frameworks.html
@@ -1,5 +1,4 @@
 {% extends "_base_page.html" %}
-{% import "toolkit/summary-table.html" as summary %}
 
 {% block pageTitle %}
   View frameworks - Digital Marketplace admin
@@ -22,21 +21,27 @@
 {% block mainContent %}
   <h1 class="govuk-heading-xl">Frameworks</h1>
 
-  {% call(framework) summary.list_table(
-    frameworks,
-    caption="Frameworks",
-    empty_message="No frameworks to show",
-    field_headings=[
-        'Name',
-        'Status',
-        summary.hidden_field_heading("Change status"),
-    ],
-    field_headings_visible=True)
-  %}
-    {% call summary.row() %}
-      {{ summary.text(framework.name) }}
-      {{ summary.text(framework.status) }}
-      {{ summary.edit_link(label="Change", link=url_for(".change_framework_status", framework_slug=framework.slug), hidden_text=framework.name) }}
-    {% endcall %}
-  {% endcall %}
+    {% set ns = namespace(rows = []) %}
+    {% for framework in frameworks %}
+      {% set change_link %}
+        <a class="govuk-link" href="{{ url_for('.change_framework_status', framework_slug=framework.slug) }}">Change<span class="govuk-visually-hidden"> status of {{ framework.name }}</span></a>
+      {% endset %}
+
+      {% set row = ns.rows.append(
+        [
+          {"text": framework.name},
+          {"text": framework.status},
+          {"html": change_link},
+        ]
+      ) %}
+    {% endfor %}
+
+    {{ govukTable({
+      'head': [
+        {'text': 'Name'},
+        {'text': 'Status'},
+        {'html': '<span class="govuk-visually-hidden">Change status</span>'},
+      ],
+      'rows': ns.rows,
+    }) }}
 {% endblock %}


### PR DESCRIPTION
I introduced two new pages in https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/770. They used toolkit components, so were not very accessible.

Replace the toolkit components with the more accessible design system equivalents. Also add some visually hidden text to help screen reader users understand the table.

Minor formatting changes - no difference in functionality.