### PR TITLE
Strip whitespace from user email search entry

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -24,7 +24,7 @@ def find_user_by_email_address():
     response_code = 200
 
     if "email_address" in request.args:
-        email_address = request.args.get("email_address")
+        email_address = request.args["email_address"].strip()
         if email_address:
             users = data_api_client.get_user(email_address=email_address)
         if not users:

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -111,6 +111,12 @@ class TestUsersView(LoggedInApplicationTest):
         assert supplier_link.xpath("normalize-space(string())") == 'SME Corp UK Limited'
         assert supplier_link.attrib['href'] == '/admin/suppliers?supplier_id=1000'
 
+    def test_should_strip_whitespace(self):
+        response_with_whitespace = self.client.get('/admin/users?email_address=+test.user@sme.com+')
+        assert response_with_whitespace.status_code == 200
+        response_without_whitespace = self.client.get('/admin/users?email_address=test.user@sme.com')
+        assert response_with_whitespace.get_data(as_text=True) == response_without_whitespace.get_data(as_text=True)
+
     def test_should_show_unlock_button(self):
         buyer = self.load_example_listing("user_response")
         buyer['users']['locked'] = True


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4678005

This matches the behaviour of all our forms, which strip leading and trailing whitespace. The previous behaviour caused problems for a real admin user recently, so this should prevent a repeat of that.