### PR TITLE
Remove pip-tools from requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,5 @@
 -c requirements.txt
 
-pip-tools>=5.4.0
-
 cssselect
 flake8
 freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,10 +14,6 @@ chardet==3.0.4
     # via
     #   -c requirements.txt
     #   requests
-click==7.0
-    # via
-    #   -c requirements.txt
-    #   pip-tools
 cssselect==1.1.0
     # via -r requirements-dev.in
 digitalmarketplace-test-utils==2.8.2
@@ -42,8 +38,6 @@ packaging==20.1
     # via pytest
 pathtools==0.1.2
     # via watchdog
-pip-tools==5.5.0
-    # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 py==1.10.0
@@ -84,6 +78,3 @@ watchdog==0.10.2
     # via -r requirements-dev.in
 wcwidth==0.1.8
     # via pytest
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip


### PR DESCRIPTION
https://trello.com/c/2dP0Dfmr/2357-fix-pip-tools-catch-22

As instructed, I have removed `pip-tools` and then updated the requirements files